### PR TITLE
Attempt Linux ARM64 build on GH beta images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
             runner: ubuntu-latest
             os: ubuntu
             cross: false
-# Disabled for now because these take 4 mins to run, we can use arm GH images when repo is public
-#          - target: aarch64-unknown-linux-gnu
-#            runner: ubuntu-latest # ubuntu-24.04-arm is only available on public repos
-#            os: ubuntu
-#            cross: true
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            os: ubuntu
+            cross: false
           - target: aarch64-apple-darwin
             runner: macos-latest
             os: macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
             os: ubuntu
             cross: false
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-latest # ubuntu-24.04-arm is only available on public repos
+            runner: ubuntu-24.04-arm
             os: ubuntu
-            cross: true
+            cross: false
           - target: aarch64-apple-darwin
             runner: macos-latest
             os: macos


### PR DESCRIPTION
Test out the Github beta ARM64 images for Linux.

On initial test it runs about 30s longer, but much better than the 4-5mins with cross-rs.
![Selection_022](https://github.com/user-attachments/assets/4060ba8f-73a7-4dea-b95a-de20d20b2440)


Completes: STR-3226