### PR TITLE
Include DD Exporter by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ prost-build = "0.13.4"
 
 [features]
 pprof = ["dep:pprof"]
-datadog = []
 
 [[bench]]
 name = "flume_bench"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -31,6 +31,3 @@ When you have rebuilt with pprof support, the following options are available. Y
 * `--pprof-flame-graph`
 * `--pprof-call-graph`
 
-## Other features
-
-* Datadog trace support: `datadog`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ rotel start --help
 
 All CLI arguments can also be passed as environment variable by prefixing with `ROTEL_` and switching hyphens to underscores. For example, `--log-level info` can also be specified by setting the environment variable `ROTEL_LOG_LEVEL=info`.
 
-
 | Option                                 | Default              | Options                  |
 |----------------------------------------|----------------------|--------------------------|
 | --daemon                               |                      |                          |
@@ -75,7 +74,14 @@ All CLI arguments can also be passed as environment variable by prefixing with `
 | --otlp-grpc-endpoint                   | localhost:4317       |                          |
 | --otlp-http-endpoint                   | localhost:4318       |                          |
 | --otlp-grpc-max-recv-msg-size-mib      | 4                    |                          |
-| --exporter                             | otlp                 | otlp, blackhole          |
+| --exporter                             | otlp                 | otlp, blackhole, datadog |
+
+### OTLP exporter configuration
+
+The OTLP exporter is the default, or can be explicitly selected with `--exporter otlp`.
+
+| Option                                 | Default              | Options                  |
+|----------------------------------------|----------------------|--------------------------|
 | --otlp-receiver-traces-disabled        |                      |                          |
 | --otlp-receiver-metrics-disabled       |                      |                          |
 | --otlp-receiver-logs-disabled          |                      |                          |
@@ -100,6 +106,18 @@ All CLI arguments can also be passed as environment variable by prefixing with `
 | --otlp-exporter-batch-max-size         | 8192                 |                          |
 | --otlp-exporter-batch-timeout          | 200ms                |                          |
 
+### Datadog exporter configuration
+
+The Datadog exporter can be selected by passing `--exporter datadog`. The Datadog exporter only supports traces at the
+moment. For more information, see the [Datadog Exporter](src/exporters/datadog/README.md) docs.
+
+| Option                             | Default | Options                |
+|------------------------------------|---------|------------------------|
+| --datadog-exporter-region          | us1     | us1, us3, us5, eu, ap1 |
+| --datadog-exporter-custom-endpoint |         |                        |
+| --datadog-exporter-api-key         |         |                        |
+
+Specifying a custom endpoint will override the region selection.
 
 **Notes**:
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    #[cfg(feature = "datadog")]
+    println!("cargo::rerun-if-changed=proto/datadog");
     prost_build::compile_protos(&["proto/datadog/agent_payload.proto"], &["proto/datadog"])?;
     Ok(())
 }

--- a/src/bin/rotel/main.rs
+++ b/src/bin/rotel/main.rs
@@ -33,13 +33,11 @@ use tracing_log::LogTracer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
-#[cfg(feature = "datadog")]
 use gethostname::gethostname;
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
-#[cfg(feature = "datadog")]
-use rotel::exporters::datadog::DatadogTraceExporter;
+use rotel::exporters::datadog::{DatadogTraceExporter, Region};
 use rotel::exporters::otlp;
 use rotel::topology::batch::BatchConfig;
 
@@ -398,20 +396,31 @@ pub struct AgentRun {
     #[clap(flatten)]
     profile_group: ProfileGroup,
 
-    /// Datadog Endpoint
-    /// todo: switch this to a region selector
-    #[cfg(feature = "datadog")]
+    /// Datadog Exporter Region
     #[arg(
+        value_enum,
         long,
-        env = "ROTEL_DATADOG_EXPORTER_ENDPOINT",
-        default_value = "https://trace.agent.datadoghq.com"
+        env = "ROTEL_DATADOG_EXPORTER_REGION",
+        default_value = "us1"
     )]
-    datadog_exporter_endpoint: String,
+    datadog_exporter_region: DatadogRegion,
 
-    #[cfg(feature = "datadog")]
-    /// Datadog Exporter API KEY
+    /// Datadog Exporter custom endpoint override
+    #[arg(long, env = "ROTEL_DATADOG_EXPORTER_CUSTOM_ENDPOINT")]
+    datadog_exporter_custom_endpoint: Option<String>,
+
+    /// Datadog Exporter API key
     #[arg(long, env = "ROTEL_DATADOG_EXPORTER_API_KEY")]
     datadog_exporter_api_key: Option<String>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
+pub enum DatadogRegion {
+    US1,
+    US3,
+    US5,
+    EU,
+    AP1,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
@@ -565,7 +574,6 @@ pub enum Exporter {
 
     Blackhole,
 
-    #[cfg(feature = "datadog")]
     Datadog,
 }
 
@@ -677,12 +685,7 @@ fn main() -> ExitCode {
 
             let _logger = setup_logging(&opt.log_level, &opt.log_format);
 
-            match run_agent(
-                agent,
-                port_map,
-                #[cfg(feature = "datadog")]
-                &opt.environment,
-            ) {
+            match run_agent(agent, port_map, &opt.environment) {
                 Ok(_) => {}
                 Err(e) => {
                     error!(error = ?e, "Failed to run agent.");
@@ -705,7 +708,7 @@ fn main() -> ExitCode {
 async fn run_agent(
     agent: Box<AgentRun>,
     mut port_map: HashMap<SocketAddr, Listener>,
-    #[cfg(feature = "datadog")] environment: &String,
+    environment: &String,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     info!(
         grpc_endpoint = agent.otlp_grpc_endpoint.to_string(),
@@ -728,28 +731,28 @@ async fn run_agent(
     let pipeline_cancel = CancellationToken::new();
     let exporters_cancel = CancellationToken::new();
 
-    let has_global_endpoint = agent.otlp_exporter_endpoint.is_some();
-    let has_traces_endpoint = has_global_endpoint || agent.otlp_exporter_traces_endpoint.is_some();
-    let has_metrics_endpoint =
-        has_global_endpoint || agent.otlp_exporter_metrics_endpoint.is_some();
-    let has_logs_endpoint = has_global_endpoint || agent.otlp_exporter_logs_endpoint.is_some();
+    let activation = TelemetryActivation::from_config(&agent);
 
-    if !has_global_endpoint
-        && !has_traces_endpoint
-        && !has_metrics_endpoint
-        && !has_logs_endpoint
-        && agent.exporter == Exporter::Otlp
+    // If there are no listeners, suggest the blackhole exporter
+    if activation.traces == TelemetryState::NoListeners
+        && activation.metrics == TelemetryState::NoListeners
+        && activation.logs == TelemetryState::NoListeners
     {
         return Err(
-            "no OTLP endpoints specified, perhaps you meant to use --exporter blackhole instead"
+            "no exporter endpoints specified, perhaps you meant to use --exporter blackhole instead"
                 .into(),
         );
     }
-    //
-    // OTLP GRPC server
-    //
-    // let mut enable_traces_svc = false;
-    // let mut enable_metrics_svc = false;
+
+    // If no active type exists, nothing to do. Exit here before errors later
+    if !(activation.traces == TelemetryState::Active
+        || activation.metrics == TelemetryState::Active
+        || activation.logs == TelemetryState::Active)
+    {
+        return Err(
+            "there are no active telemetry types, exiting because there is nothing to do".into(),
+        );
+    }
 
     let (trace_pipeline_in_tx, trace_pipeline_in_rx) =
         bounded::<Vec<ResourceSpans>>(max(4, num_cpus));
@@ -772,33 +775,39 @@ async fn run_agent(
     let mut metrics_output = None;
     let mut logs_output = None;
 
-    if agent.otlp_receiver_traces_disabled {
-        info!("OTLP Receiver for traces disabled, OTLP receiver will be configured to not accept traces");
-    } else if agent.exporter == Exporter::Otlp && !has_traces_endpoint {
-        // User has not explicitly disabled traces, see if we need to do it implicitly
-        info!("No global or explicit OTLP trace exporter endpoint specified, OTLP receiver will be configured to not accept traces");
-    } else {
-        traces_output = Some(trace_otlp_output);
+    match activation.traces {
+        TelemetryState::Active => traces_output = Some(trace_otlp_output),
+        TelemetryState::Disabled => {
+            info!("OTLP Receiver for traces disabled, OTLP receiver will be configured to not accept traces");
+        }
+        TelemetryState::NoListeners => {
+            info!("No exporters are configured for traces, OTLP receiver will be configured to not accept traces");
+        }
     }
 
-    if agent.otlp_receiver_metrics_disabled {
-        info!("OTLP Receiver for metrics disabled, OTLP receiver will be configured to not accept traces");
-    } else if agent.exporter == Exporter::Otlp && !has_metrics_endpoint {
-        // User has not explicitly disabled traces, see if we need to do it implicitly
-        info!("No global or explicit OTLP metrics exporter endpoint specified, OTLP receiver will be configured to not accept metrics");
-    } else {
-        metrics_output = Some(metrics_otlp_output);
+    match activation.metrics {
+        TelemetryState::Active => metrics_output = Some(metrics_otlp_output),
+        TelemetryState::Disabled => {
+            info!("OTLP Receiver for metrics disabled, OTLP receiver will be configured to not accept metrics");
+        }
+        TelemetryState::NoListeners => {
+            info!("No exporters are configured for metrics, OTLP receiver will be configured to not accept metrics");
+        }
     }
 
-    if agent.otlp_receiver_logs_disabled {
-        info!("OTLP Receiver for logs disabled, OTLP receiver will be configured to not accept traces");
-    } else if agent.exporter == Exporter::Otlp && !has_logs_endpoint {
-        // User has not explicitly disabled traces, see if we need to do it implicitly
-        info!("No global or explicit OTLP logs exporter endpoint specified, OTLP receiver will be configured to not accept logs");
-    } else {
-        logs_output = Some(logs_otlp_output);
+    match activation.logs {
+        TelemetryState::Active => logs_output = Some(logs_otlp_output),
+        TelemetryState::Disabled => {
+            info!("OTLP Receiver for logs disabled, OTLP receiver will be configured to not accept logs");
+        }
+        TelemetryState::NoListeners => {
+            info!("No exporters are configured for logs, OTLP receiver will be configured to not accept logs");
+        }
     }
 
+    //
+    // OTLP GRPC server
+    //
     let grpc_srv = OTLPGrpcServer::builder()
         .with_max_recv_msg_size_mib(agent.otlp_grpc_max_recv_msg_size_mib as usize)
         .with_traces_output(traces_output.clone())
@@ -865,7 +874,7 @@ async fn run_agent(
         }
         Exporter::Otlp => {
             let endpoint = agent.otlp_exporter_endpoint.as_ref();
-            if has_traces_endpoint {
+            if activation.traces == TelemetryState::Active {
                 let traces_config = build_traces_config(agent.clone(), endpoint);
                 let mut traces = otlp::exporter::build_traces_exporter(
                     traces_config,
@@ -885,7 +894,7 @@ async fn run_agent(
                     Ok(())
                 });
             }
-            if has_metrics_endpoint {
+            if activation.metrics == TelemetryState::Active {
                 let metrics_config = build_metrics_config(agent.clone(), endpoint);
                 let mut metrics = otlp::exporter::build_metrics_exporter(
                     metrics_config,
@@ -905,7 +914,7 @@ async fn run_agent(
                     Ok(())
                 });
             }
-            if has_logs_endpoint {
+            if activation.logs == TelemetryState::Active {
                 let logs_config = build_logs_config(agent.clone(), endpoint);
                 let mut logs =
                     otlp::exporter::build_logs_exporter(logs_config, logs_pipeline_out_rx.clone())?;
@@ -925,7 +934,6 @@ async fn run_agent(
             }
         }
 
-        #[cfg(feature = "datadog")]
         Exporter::Datadog => {
             if agent.datadog_exporter_api_key.is_none() {
                 // todo: is there a way to make this config required with the exporter mode?
@@ -935,9 +943,12 @@ async fn run_agent(
 
             let hostname = get_hostname();
 
-            let mut builder =
-                DatadogTraceExporter::builder(agent.datadog_exporter_endpoint, api_key)
-                    .with_environment(environment.clone());
+            let mut builder = DatadogTraceExporter::builder(
+                agent.datadog_exporter_region.into(),
+                agent.datadog_exporter_custom_endpoint.clone(),
+                api_key,
+            )
+            .with_environment(environment.clone());
 
             if let Some(hostname) = hostname {
                 builder = builder.with_hostname(hostname);
@@ -1561,7 +1572,6 @@ fn daemonize(pid_file: &String, log_file: &String) -> Result<Option<ExitCode>, B
     }
 }
 
-#[cfg(feature = "datadog")]
 fn get_hostname() -> Option<String> {
     match gethostname().into_string() {
         Ok(s) => Some(s),
@@ -1597,6 +1607,75 @@ impl From<OTLPExporterProtocol> for Protocol {
             OTLPExporterProtocol::Grpc => Protocol::Grpc,
             OTLPExporterProtocol::Http => Protocol::Http,
         }
+    }
+}
+
+impl From<DatadogRegion> for Region {
+    fn from(value: DatadogRegion) -> Self {
+        match value {
+            DatadogRegion::US1 => Region::US1,
+            DatadogRegion::US3 => Region::US3,
+            DatadogRegion::US5 => Region::US5,
+            DatadogRegion::EU => Region::EU,
+            DatadogRegion::AP1 => Region::AP1,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct TelemetryActivation {
+    traces: TelemetryState,
+    metrics: TelemetryState,
+    logs: TelemetryState,
+}
+
+#[derive(Default, PartialEq)]
+pub enum TelemetryState {
+    #[default]
+    Active,
+    Disabled,
+    NoListeners,
+}
+
+impl TelemetryActivation {
+    fn from_config(config: &AgentRun) -> Self {
+        let mut activation = match config.exporter {
+            Exporter::Otlp => {
+                let has_global_endpoint = config.otlp_exporter_endpoint.is_some();
+                let mut activation = TelemetryActivation::default();
+                if !has_global_endpoint && config.otlp_exporter_traces_endpoint.is_none() {
+                    activation.traces = TelemetryState::NoListeners
+                }
+                if !has_global_endpoint && config.otlp_exporter_metrics_endpoint.is_none() {
+                    activation.metrics = TelemetryState::NoListeners
+                }
+                if !has_global_endpoint && config.otlp_exporter_logs_endpoint.is_none() {
+                    activation.logs = TelemetryState::NoListeners
+                }
+                activation
+            }
+            Exporter::Blackhole => TelemetryActivation::default(),
+            Exporter::Datadog => {
+                // Only supports traces for now
+                TelemetryActivation {
+                    traces: TelemetryState::Active,
+                    metrics: TelemetryState::NoListeners,
+                    logs: TelemetryState::NoListeners,
+                }
+            }
+        };
+
+        if config.otlp_receiver_traces_disabled {
+            activation.traces = TelemetryState::Disabled
+        }
+        if config.otlp_receiver_metrics_disabled {
+            activation.metrics = TelemetryState::Disabled
+        }
+        if config.otlp_receiver_logs_disabled {
+            activation.logs = TelemetryState::Disabled
+        }
+
+        activation
     }
 }
 

--- a/src/exporters/datadog/README.md
+++ b/src/exporters/datadog/README.md
@@ -1,0 +1,22 @@
+# Datadog Exporter
+
+The Datadog exporter is an experimental exporter that supports exporting OTLP trace span data to Datadog, without having to
+run the Datadog agent. It is a port of the Go implementation contained across the following repos:
+
+* [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+* [datadog-agent](https://github.com/DataDog/datadog-agent)
+* [opentelemetry-mapping-go](https://github.com/DataDog/opentelemetry-mapping-go)
+
+At the moment this exporter only supports **traces**, so enabling it will disable receiving of metrics and logs at the
+OTLP receiver. In the future it will be possible to split exporting of telemetry across multiple exporters.
+
+## Remaining support
+
+The trace export support is early, but should produce working traces. This is a list of the known remaining large pieces
+to support, in no particular order. If you find issues with the current support, please open an issue!
+
+* Trace stats/metrics
+* Normalizing tag names and values
+* Support for sampling at the exporter
+* GCP and Azure attributes, it supports AWS today
+* Span events and links

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -56,11 +56,10 @@ impl Region {
             Region::US3 => "us3.datadoghq.com",
             Region::US5 => "us5.datadoghq.com",
             Region::EU => "datadoghq.eu",
-            Region::AP1 => "ap1.datadoghq.com"
+            Region::AP1 => "ap1.datadoghq.com",
         };
         format!("https://trace.agent.{}", base)
     }
-
 }
 
 pub struct DatadogTraceExporter {
@@ -120,8 +119,12 @@ impl DatadogTraceExporterBuilder {
 
         let transformer = Transformer::new(self.environment.clone(), self.hostname.clone());
 
-        let req_builder =
-            RequestBuilder::new(transformer, self.region, self.custom_endpoint.clone(), self.api_token.clone())?;
+        let req_builder = RequestBuilder::new(
+            transformer,
+            self.region,
+            self.custom_endpoint.clone(),
+            self.api_token.clone(),
+        )?;
 
         let retry_layer = RetryPolicy::new(self.retry_config, None);
 
@@ -141,7 +144,11 @@ impl DatadogTraceExporterBuilder {
 }
 
 impl DatadogTraceExporter {
-    pub fn builder(region: Region, custom_endpoint: Option<String>, api_key: String) -> DatadogTraceExporterBuilder {
+    pub fn builder(
+        region: Region,
+        custom_endpoint: Option<String>,
+        api_key: String,
+    ) -> DatadogTraceExporterBuilder {
         DatadogTraceExporterBuilder {
             region,
             custom_endpoint,

--- a/src/exporters/datadog/request_builder.rs
+++ b/src/exporters/datadog/request_builder.rs
@@ -6,6 +6,7 @@ use crate::exporters::datadog::types::pb::AgentPayload;
 use crate::exporters::http::types::Request;
 use std::marker::PhantomData;
 use tower::BoxError;
+use crate::exporters::datadog::Region;
 
 pub trait TransformPayload<T> {
     fn transform(&self, input: Vec<T>) -> AgentPayload;
@@ -28,9 +29,15 @@ where
 {
     pub fn new(
         transformer: Transform,
-        endpoint: String,
+        region: Region,
+        custom_endpoint: Option<String>,
         api_key: String,
     ) -> Result<Self, BoxError> {
+        let endpoint = if let Some(custom) = custom_endpoint {
+            custom
+        } else {
+            region.trace_endpoint()
+        };
         let api_req_builder = ApiRequestBuilder::new(endpoint, api_key)?;
 
         Ok(Self {

--- a/src/exporters/datadog/request_builder.rs
+++ b/src/exporters/datadog/request_builder.rs
@@ -3,10 +3,10 @@
 use crate::exporters::datadog::api_request::ApiRequestBuilder;
 use crate::exporters::datadog::request_builder_mapper::BuildRequest;
 use crate::exporters::datadog::types::pb::AgentPayload;
+use crate::exporters::datadog::Region;
 use crate::exporters::http::types::Request;
 use std::marker::PhantomData;
 use tower::BoxError;
-use crate::exporters::datadog::Region;
 
 pub trait TransformPayload<T> {
     fn transform(&self, input: Vec<T>) -> AgentPayload;

--- a/src/exporters/http/mod.rs
+++ b/src/exporters/http/mod.rs
@@ -1,19 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "datadog")]
 pub mod client;
-#[cfg(feature = "datadog")]
 pub mod grpc_client;
-#[cfg(feature = "datadog")]
 pub mod http_client;
-#[cfg(feature = "datadog")]
 pub mod request;
-#[cfg(feature = "datadog")]
 pub mod response;
-#[cfg(feature = "datadog")]
 pub mod retry;
-#[cfg(feature = "datadog")]
-pub mod types;
-
-// currently shared
 pub mod tls;
+pub mod types;

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod blackhole;
+pub mod datadog;
 pub mod otlp;
 
-mod retry;
-
-#[cfg(feature = "datadog")]
-pub mod datadog;
 mod http;
+mod retry;


### PR DESCRIPTION
This enables the Datadog exporter for traces by default. Adds some documentation to mention this is experimental and the known remaining issues to support.

We add a DD region selection for picking the endpoint by default, but it can be overridden if needed.

This required some cleanup of how we are identifying which telemetry types are active and have listening exporters.

Completes: STR-3225