### PR TITLE
Bump Rust to latest stable (1.85.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rotel"
 version = "0.0.1-alpha1"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/streamfold/rotel"
 readme = "README.md"
-rust-version = "1.83.0"
+rust-version = "1.85.1"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive", "env"] }

--- a/src/bin/rotel/main.rs
+++ b/src/bin/rotel/main.rs
@@ -234,15 +234,15 @@ unsafe fn check_rotel_active(pid_path: &String) -> bool {
         }
     };
 
-    let ret = unwrap_errno(libc::open(path_c.as_ptr(), libc::O_RDONLY, 0o666));
+    let ret = unwrap_errno(unsafe{libc::open(path_c.as_ptr(), libc::O_RDONLY, 0o666)});
     if ret.0 < 0 {
         return false;
     }
 
-    let ret = unwrap_errno(libc::flock(ret.0, libc::LOCK_EX | libc::LOCK_NB));
+    let ret = unwrap_errno(unsafe{libc::flock(ret.0, libc::LOCK_EX | libc::LOCK_NB)});
 
     // Close the original file descriptor
-    libc::close(ret.0);
+    unsafe{libc::close(ret.0)};
 
     if ret.0 != 0 {
         // Unknown error from flock


### PR DESCRIPTION
This should stop RustRover asking to update. Unsafe calls now require wrapping, even from an unsafe function.

To update: `rustup update`

