### PR TITLE
Support an envfile to ease config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -278,7 +278,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.0",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -294,7 +294,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -934,6 +934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,7 +1219,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-targets",
 ]
 
@@ -1959,6 +1965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +2378,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2741,6 +2753,7 @@ dependencies = [
  "clap",
  "criterion",
  "daemonize",
+ "dotenvy",
  "flate2",
  "flume",
  "futures",
@@ -2771,6 +2784,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -2809,7 +2823,20 @@ dependencies = [
  "bitflags 2.8.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -3150,15 +3177,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -3814,7 +3840,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ pin-project = "1.1.10"
 futures-util = "0.3.31"
 lambda-extension = "0.11.0"
 serde = { version = "1.0.217", features = ["derive"] }
+dotenvy = "0.15.7"
 
 [dev-dependencies]
 tokio-test = "0.4.4"
@@ -58,6 +59,7 @@ utilities = { path = "utilities" }
 httpmock = "0.7.0"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 tracing-test = "0.2.5"
+tempfile = "3.19.1"
 
 [build-dependencies]
 prost-build = "0.13.4"

--- a/src/bin/rotel-lambda-extension/main.rs
+++ b/src/bin/rotel-lambda-extension/main.rs
@@ -132,7 +132,7 @@ fn load_env_file(env_file: &String) -> Result<(), BoxError> {
     let subs = load_env_file_updates(env_file)?;
 
     for (key, val) in subs {
-        unsafe{env::set_var(key, val)}
+        unsafe { env::set_var(key, val) }
     }
 
     Ok(())
@@ -348,10 +348,7 @@ mod test {
                     "ROTEL_DOUBLE_SUB".to_string(),
                     "frontend-123abc".to_string()
                 ),
-                (
-                    "ROTEL_ESCAPED".to_string(),
-                    "NotMe${TEAM}".to_string()
-                )
+                ("ROTEL_ESCAPED".to_string(), "NotMe${TEAM}".to_string())
             ],
             updates
         );


### PR DESCRIPTION
This supports an envfile for the lambda extension to make it easier to load complex config. This library will expand environment variables in the env file, so you can do:
```
ROTEL_EXPORTER_ENDPOINT=https://foo.example.com
ROTEL_EXPORTER_CUSTOM_HEADERS="Bearer ${API_TOKEN}"
```
And set `API_TOKEN` in your lambda runtime config.

We may need to handle the substitution to allow for ARN's in the future.

Completes: STR-3244