### PR TITLE
Add array value support

### DIFF
--- a/contrib/processor/tests/read_and_write_attributes_array_value_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_array_value_test.py
@@ -30,3 +30,6 @@ def process(resource):
     assert resource.attributes[0].key == "my_array"
     av = resource.attributes[0].value.value[0]
     assert av.value == "baz"
+
+    # Check len support
+    assert 1 == len(resource.attributes[0].value.value)

--- a/contrib/processor/tests/read_and_write_attributes_array_value_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_array_value_test.py
@@ -1,0 +1,32 @@
+from rotel_python_processor_sdk import PyAnyValue, PyArrayValue, PyAttributes, PyKeyValue
+
+
+def process(resource):
+    # Access the AnyValue by subscript
+    av = resource.attributes[0].value.value[0]
+    assert av.value == "foo"
+
+    # Change the value of
+    av.string_value = "bar"
+    # Now verify it's updated by fetching again
+    av = resource.attributes[0].value.value[0]
+    assert av.value == "bar"
+
+    # Iterate the ArrayValue
+    for av in resource.attributes[0].value.value:
+        assert av.value == "bar"
+
+    # Create a new ArrayValue and update resource.attributes
+    new_array_value = PyArrayValue()
+    new_any_value = PyAnyValue()
+    new_any_value.string_value = "baz"
+    new_array_value.append(new_any_value)
+
+    kv = PyKeyValue.new_array_value("my_array", new_array_value)
+    new_attributes = PyAttributes()
+    new_attributes.append(kv)
+    resource.attributes = new_attributes
+
+    assert resource.attributes[0].key == "my_array"
+    av = resource.attributes[0].value.value[0]
+    assert av.value == "baz"

--- a/src/processor/model/mod.rs
+++ b/src/processor/model/mod.rs
@@ -27,7 +27,17 @@ pub enum Value {
 
 #[derive(Debug, Clone)]
 pub struct ArrayValue {
-    pub values: Vec<AnyValue>,
+    pub values: Arc<Mutex<Vec<AnyValue>>>,
+}
+
+#[allow(deprecated)]
+impl ArrayValue {
+    pub(crate) fn convert_to_py(&self, py: Python) -> PyResult<PyObject> {
+        Ok(crate::processor::py::PyArrayValue {
+            inner: self.values.clone(),
+        }
+        .into_py(py))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/processor/model/mod.rs
+++ b/src/processor/model/mod.rs
@@ -27,16 +27,13 @@ pub enum Value {
 
 #[derive(Debug, Clone)]
 pub struct ArrayValue {
-    pub values: Arc<Mutex<Vec<AnyValue>>>,
+    pub values: Arc<Mutex<Vec<Arc<Mutex<Option<AnyValue>>>>>>,
 }
 
 #[allow(deprecated)]
 impl ArrayValue {
     pub(crate) fn convert_to_py(&self, py: Python) -> PyResult<PyObject> {
-        Ok(crate::processor::py::PyArrayValue {
-            inner: self.values.clone(),
-        }
-        .into_py(py))
+        Ok(crate::processor::py::PyArrayValue(self.values.clone()).into_py(py))
     }
 }
 

--- a/src/processor/py/mod.rs
+++ b/src/processor/py/mod.rs
@@ -129,7 +129,12 @@ impl PyArrayValue {
         // Convert to a Python-managed object
         Py::new(py, iter)
     }
-
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(inner.len())
+    }
     fn __getitem__(&self, index: usize) -> PyResult<PyAnyValue> {
         let inner = self.0.lock().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")

--- a/src/processor/py/mod.rs
+++ b/src/processor/py/mod.rs
@@ -113,10 +113,6 @@ impl PyAnyValue {
 #[derive(Clone)]
 pub struct PyArrayValue(pub Arc<Mutex<Vec<Arc<Mutex<Option<AnyValue>>>>>>);
 
-// pub struct PyArrayValue {
-//     pub inner: Arc<Mutex<Vec<Arc<Mutex<Option<AnyValue>>>>>>,
-// }
-
 #[pymethods]
 impl PyArrayValue {
     #[new]

--- a/src/processor/py/mod.rs
+++ b/src/processor/py/mod.rs
@@ -1,4 +1,4 @@
-use crate::processor::model::Value::{BoolValue, DoubleValue, IntValue, StringValue};
+use crate::processor::model::Value::{ArrayValue, BoolValue, DoubleValue, IntValue, StringValue};
 use crate::processor::model::{AnyValue, KeyValue, Resource, ScopeSpans, Span};
 use pyo3::prelude::*;
 use std::sync::{Arc, Mutex};
@@ -32,6 +32,7 @@ impl PyAnyValue {
             Some(BoolValue(b)) => Ok(b.into_py(py)),
             Some(IntValue(i)) => Ok(i.into_py(py)),
             Some(DoubleValue(d)) => Ok(d.into_py(py)),
+            Some(ArrayValue(a)) => Ok(a.convert_to_py(py)?),
             None => Ok(py.None()),
             // TODO add remaining types
             _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -94,6 +95,11 @@ impl PyAnyValue {
             .replace(DoubleValue(new_value));
         Ok(())
     }
+}
+
+#[pyclass]
+pub struct PyArrayValue {
+    pub inner: Arc<Mutex<Vec<AnyValue>>>,
 }
 
 #[pyclass]


### PR DESCRIPTION
Completes: STR-3250. 

Adds support for the OTEL ArrayValue type, used predominantly (maybe exclusively) in attributes. Support for subscript access, creating, appending and iterating included. Introduced new unit tests for coverage and also tested end-to-end. We needed to rework the conversion logic a bit to handle the recursive nature of the data structures as ArrayValues contain AnyValues and vise-versa.
  