### PR TITLE
Support a telemetry log pipe

### DIFF
--- a/src/bin/rotel/main.rs
+++ b/src/bin/rotel/main.rs
@@ -148,7 +148,7 @@ async fn run_agent(
         let agent_fut = async move {
             let agent = Agent::default();
             agent
-                .run(agent_args, port_map, SENDING_QUEUE_SIZE, env, token)
+                .run(agent_args, port_map, SENDING_QUEUE_SIZE, env, token, None)
                 .await
         };
 

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -1,4 +1,4 @@
-use crate::bounded_channel::{bounded, BoundedReceiver};
+use crate::bounded_channel::{BoundedReceiver, bounded};
 use crate::exporters::blackhole::BlackholeExporter;
 use crate::exporters::datadog::{DatadogTraceExporter, Region};
 use crate::exporters::otlp;


### PR DESCRIPTION
This accepts a bounded receiver channel that will receive log messages when built with the lambda extension code. We inject these into the existing receiver pipeline.

STR-3276