### PR TITLE
Support forced flush operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ The following example demonstrates how to send OTLP data to [Axiom](https://axio
 ```shell
 ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS="Authorization=Bearer ${AXIOM_API_KEY},X-Axiom-Dataset=${AXIOM_DATASET}" \
  ./rotel start --otlp-exporter-endpoint https://api.axiom.co --otlp-exporter-protocol http
-
 ```
 
 In another window run the telemetry generator again:

--- a/src/bin/rotel/main.rs
+++ b/src/bin/rotel/main.rs
@@ -146,10 +146,8 @@ async fn run_agent(
         let token = cancel_token.clone();
         let env = env.clone();
         let agent_fut = async move {
-            let agent = Agent::default();
-            agent
-                .run(agent_args, port_map, SENDING_QUEUE_SIZE, env, token, None)
-                .await
+            let agent = Agent::new(agent_args, port_map, SENDING_QUEUE_SIZE, env);
+            agent.run(token).await
         };
 
         agent_join_set.spawn(agent_fut);

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -29,7 +29,7 @@ use tower::retry::Retry as TowerRetry;
 use tower::timeout::Timeout;
 use tower::{BoxError, Service, ServiceBuilder};
 use tracing::log::warn;
-use tracing::{Level, debug, error, event, info};
+use tracing::{Level, debug, error, event};
 
 mod api_request;
 mod request_builder;
@@ -210,7 +210,7 @@ impl DatadogTraceExporter {
                 Some(resp) = conditional_flush(&mut flush_receiver) => {
                     match resp {
                         (Some(req), listener) => {
-                            info!("received force flush in datadog exporter: {:?}", req);
+                            debug!("received force flush in datadog exporter: {:?}", req);
 
                             if let Err(res) = self.drain_futures(&mut enc_stream, &mut export_futures).await {
                                 warn!("unable to drain exporter: {}", res);

--- a/src/exporters/otlp/exporter.rs
+++ b/src/exporters/otlp/exporter.rs
@@ -395,7 +395,7 @@ where
                 Some(resp) = conditional_flush(&mut flush_receiver) => {
                     match resp {
                         (Some(req), listener) => {
-                            info!(exporter_type = type_name, "received force flush in OTLP exporter: {:?}", req);
+                            debug!(exporter_type = type_name, "received force flush in OTLP exporter: {:?}", req);
 
                             if let Err(res) = self.drain_futures().await {
                                 warn!(exporter_type = type_name, "unable to drain exporter: {}", res);

--- a/src/exporters/otlp/exporter.rs
+++ b/src/exporters/otlp/exporter.rs
@@ -46,7 +46,7 @@ use tokio_util::sync::CancellationToken;
 use tower::retry::{Retry, RetryLayer};
 use tower::timeout::{Timeout, TimeoutLayer};
 use tower::{BoxError, Service, ServiceBuilder};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 const MAX_CONCURRENT_REQUESTS: usize = 10;
 const MAX_CONCURRENT_ENCODERS: usize = 20;
@@ -141,7 +141,13 @@ pub fn build_metrics_exporter(
         .build();
     let sent = RotelCounter::OTELCounter(sent);
     let send_failed = RotelCounter::OTELCounter(send_failed);
-    _build_metrics_exporter(sent, send_failed, metrics_config, metrics_rx, flush_receiver)
+    _build_metrics_exporter(
+        sent,
+        send_failed,
+        metrics_config,
+        metrics_rx,
+        flush_receiver,
+    )
 }
 
 /// Creates a configured OTLP logs exporter
@@ -217,7 +223,13 @@ pub fn build_internal_metrics_exporter(
 > {
     let sent = RotelCounter::NoOpCounter;
     let send_failed = RotelCounter::NoOpCounter;
-    _build_metrics_exporter(sent, send_failed, metrics_config, metrics_rx, flush_receiver)
+    _build_metrics_exporter(
+        sent,
+        send_failed,
+        metrics_config,
+        metrics_rx,
+        flush_receiver,
+    )
 }
 
 fn _build_metrics_exporter(

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -529,7 +529,8 @@ mod tests {
         .with_ca_file(server_root_ca_cert_file)
         .with_header("authorization", "bar");
 
-        let mut traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
+        let mut traces =
+            otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();
@@ -720,7 +721,8 @@ mod tests {
         .with_initial_backoff(Duration::from_millis(5))
         .with_max_elapsed_time(Duration::from_millis(50));
 
-        let mut traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
+        let mut traces =
+            otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -529,7 +529,7 @@ mod tests {
         .with_ca_file(server_root_ca_cert_file)
         .with_header("authorization", "bar");
 
-        let mut traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx).unwrap();
+        let mut traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();
@@ -596,7 +596,7 @@ mod tests {
         .with_header("authorization", "bar");
 
         let mut metrics =
-            otlp::exporter::build_metrics_exporter(metrics_config, metrics_brx).unwrap();
+            otlp::exporter::build_metrics_exporter(metrics_config, metrics_brx, None).unwrap();
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();
@@ -662,7 +662,7 @@ mod tests {
         .with_ca_file(server_root_ca_cert_file)
         .with_header("authorization", "bar");
 
-        let mut logs = otlp::exporter::build_logs_exporter(logs_config, logs_brx).unwrap();
+        let mut logs = otlp::exporter::build_logs_exporter(logs_config, logs_brx, None).unwrap();
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();
@@ -720,7 +720,7 @@ mod tests {
         .with_initial_backoff(Duration::from_millis(5))
         .with_max_elapsed_time(Duration::from_millis(50));
 
-        let mut traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx).unwrap();
+        let mut traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();
@@ -785,7 +785,7 @@ mod tests {
         .with_key_file(key_file)
         .with_ca_file(server_root_ca_cert_file);
 
-        let traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx).unwrap();
+        let traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
 
         let res = send_test_msg(traces, trace_btx, &mut server_rx).await;
         assert!(res.is_some());
@@ -799,7 +799,7 @@ mod tests {
         .with_cert_file(cert_file)
         .with_key_file(key_file);
 
-        let traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx).unwrap();
+        let traces = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None).unwrap();
         let res = send_test_msg(traces, trace_btx.clone(), &mut server_rx).await;
         assert!(res.is_none());
         //
@@ -812,7 +812,7 @@ mod tests {
         .with_cert_file(cert_file)
         .with_ca_file(server_root_ca_cert_file);
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_err());
 
         // Fails because missing cert
@@ -824,7 +824,7 @@ mod tests {
         .with_key_file(key_file)
         .with_ca_file(server_root_ca_cert_file);
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_err());
 
         // Succeeds because no identity but provides a CA and a correct domain
@@ -835,7 +835,7 @@ mod tests {
         )
         .with_ca_file(server_root_ca_cert_file);
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_ok());
 
         // Fails because we have a CA but incorrect domain
@@ -846,7 +846,7 @@ mod tests {
         )
         .with_ca_file(server_root_ca_cert_file);
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_ok());
 
         let res = send_test_msg(otlp_res.unwrap(), trace_btx.clone(), &mut server_rx).await;
@@ -881,7 +881,7 @@ mod tests {
             Protocol::Http,
         );
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_ok());
 
         let res = send_test_traces_msgs_and_stop(otlp_res.unwrap(), trace_btx, 1).await;
@@ -913,7 +913,7 @@ mod tests {
         .with_initial_backoff(Duration::from_millis(5))
         .with_max_elapsed_time(Duration::from_millis(20));
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_ok());
 
         let res = send_test_traces_msgs_and_stop(otlp_res.unwrap(), trace_btx, 1).await;
@@ -953,7 +953,7 @@ mod tests {
         .with_max_elapsed_time(Duration::from_millis(20))
         .with_encode_drain_max_time(Duration::from_millis(10));
 
-        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx);
+        let otlp_res = otlp::exporter::build_traces_exporter(traces_config, trace_brx, None);
         assert!(otlp_res.is_ok());
 
         let otlp_exp = otlp_res.unwrap();
@@ -991,7 +991,7 @@ mod tests {
             Protocol::Http,
         );
 
-        let otlp_res = otlp::exporter::build_metrics_exporter(metrics_config, metrics_brx);
+        let otlp_res = otlp::exporter::build_metrics_exporter(metrics_config, metrics_brx, None);
         assert!(otlp_res.is_ok());
 
         let res = send_test_metrics_msg_and_stop(otlp_res.unwrap(), metrics_btx, 1).await;
@@ -1026,7 +1026,7 @@ mod tests {
             Protocol::Http,
         );
 
-        let otlp_res = otlp::exporter::build_logs_exporter(logs_config, logs_brx);
+        let otlp_res = otlp::exporter::build_logs_exporter(logs_config, logs_brx, None);
         assert!(otlp_res.is_ok());
 
         let res = send_test_logs_msg_and_stop(otlp_res.unwrap(), logs_btx, 1).await;

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -382,8 +382,8 @@ impl Agent {
                         .clone(),
                     api_key,
                 )
-                    .with_flush_receiver(self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()))
-                    .with_environment(self.environment.clone());
+                .with_flush_receiver(self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()))
+                .with_environment(self.environment.clone());
 
                 if let Some(hostname) = hostname {
                     builder = builder.with_hostname(hostname);

--- a/src/topology/flush_control.rs
+++ b/src/topology/flush_control.rs
@@ -87,6 +87,8 @@ pub struct FlushSender {
 }
 
 impl FlushSender {
+    // This should always be called with a timeout, since it is possible to
+    // loop in here if a receiver does not ack the broadcast message.
     pub async fn broadcast(&mut self) -> Result<(), BoxError> {
         let curr_listeners = self.inner.lock().unwrap().listeners;
 

--- a/src/topology/flush_control.rs
+++ b/src/topology/flush_control.rs
@@ -152,7 +152,12 @@ impl FlushReceiver {
 
     pub async fn ack(&mut self, req: FlushRequest) -> Result<(), BoxError> {
         let resp = FlushResponse { id: req.id };
-        match timeout(Duration::from_millis(FLUSH_ACK_TIMEOUT_MILLIS), self.tx.send(resp)).await {
+        match timeout(
+            Duration::from_millis(FLUSH_ACK_TIMEOUT_MILLIS),
+            self.tx.send(resp),
+        )
+        .await
+        {
             Ok(Err(e)) => Err(format!("Failed to send ack: {}", e).into()),
             Err(_) => Err("timeout while acking message".into()),
             _ => Ok(()),

--- a/src/topology/flush_control.rs
+++ b/src/topology/flush_control.rs
@@ -1,0 +1,154 @@
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::{Receiver, Sender};
+use tower::BoxError;
+use tracing::log::warn;
+use crate::bounded_channel::{bounded, BoundedReceiver, BoundedSender};
+
+const FLUSH_CHAN_SIZE:usize = 20;
+
+#[derive(Debug, Clone)]
+pub struct FlushRequest {
+    id: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FlushResponse {
+    id: u64,
+}
+
+pub struct FlushBroadcast {
+    inner: Arc<Mutex<Inner>>,
+
+    req_tx: Sender<FlushRequest>,
+    resp_rx: BoundedReceiver<FlushResponse>,
+    resp_tx: BoundedSender<FlushResponse>,
+}
+
+struct Inner {
+    listeners: usize,
+
+    _req_rx: Receiver<FlushRequest>, // must keep open, but we subscribe from tx to create listeners
+}
+
+impl Inner {
+    fn new(req_rx: Receiver<FlushRequest>) -> Self {
+        Self{
+            listeners: 0,
+            _req_rx: req_rx,
+        }
+    }
+
+    pub fn add_subscriber(&mut self) {
+        self.listeners += 1;
+    }
+}
+
+impl FlushBroadcast {
+    pub fn new() -> Self {
+        let (req_tx, req_rx) = broadcast::channel(FLUSH_CHAN_SIZE);
+        let (resp_tx, resp_rx) = bounded(FLUSH_CHAN_SIZE);
+
+        Self {
+            inner: Arc::new(Mutex::new(Inner::new(req_rx))),
+            req_tx,
+            resp_tx,
+            resp_rx,
+        }
+    }
+
+    pub fn into_parts(self) -> (FlushPublisher, FlushSubscriber) {
+        let publisher = FlushPublisher{
+            inner: self.inner.clone(),
+            next_req_id: 1,
+            req_tx: self.req_tx.clone(),
+            resp_rx: self.resp_rx,
+        };
+        let subscriber = FlushSubscriber {
+            inner: self.inner.clone(),
+            req_tx: self.req_tx.clone(),
+            resp_tx: self.resp_tx,
+        };
+
+        (publisher, subscriber)
+    }
+}
+
+pub struct FlushPublisher {
+    inner: Arc<Mutex<Inner>>,
+    next_req_id: u64,
+    req_tx: Sender<FlushRequest>,
+    resp_rx: BoundedReceiver<FlushResponse>,
+}
+
+impl FlushPublisher {
+    pub async fn broadcast(&mut self) -> Result<(), BoxError> {
+        let curr_listeners = self.inner.lock().unwrap().listeners;
+        let req_id = self.next_req_id;
+        self.next_req_id += 1;
+        let req = FlushRequest{id: req_id};
+
+        if let Err(e) = self.req_tx.send(req) {
+            return Err(format!("Unable to send broadcast message: {}", e).into());
+        }
+
+        let mut acked = 0u64;
+        loop {
+            if acked == curr_listeners as u64 {
+                break
+            }
+            match self.resp_rx.next().await {
+                None => {
+                    return Err("unexpected close received on flush response channel".into());
+                }
+                Some(resp) => {
+                    if resp.id != req_id {
+                        warn!("invalid response id received, expected {}, got {}", req_id, resp.id);
+                        continue
+                    }
+                    acked += 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+}
+
+pub struct FlushSubscriber {
+    inner: Arc<Mutex<Inner>>,
+    req_tx: Sender<FlushRequest>,
+    resp_tx: BoundedSender<FlushResponse>,
+}
+
+impl FlushSubscriber {
+    pub fn subscribe(&mut self) -> FlushListener {
+        self.inner.lock().unwrap().add_subscriber();
+
+        FlushListener {
+            rx: self.req_tx.subscribe(),
+            tx: self.resp_tx.clone(),
+        }
+
+    }
+}
+
+pub struct FlushListener {
+    rx: Receiver<FlushRequest>,
+    tx: BoundedSender<FlushResponse>
+}
+
+impl FlushListener {
+    pub async fn next(&mut self) -> Option<FlushRequest> {
+        match self.rx.recv().await {
+            Ok(item) => Some(item),
+            Err(_e) => None, // disconnected
+        }
+    }
+
+    pub async fn ack(&mut self, req: FlushRequest) -> Result<(), BoxError>{
+        let resp = FlushResponse{id: req.id};
+        self.tx.send(resp).await.map_err(|e| format!("failed to ack: {}", e).into())
+    }
+}
+

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -217,7 +217,7 @@ where
                 Some(resp) = conditional_flush(&mut flush_listener) => {
                     match resp {
                         (Some(req), listener) => {
-                            info!("received force flush in pipeline: {:?}", req);
+                            debug!("received force flush in pipeline: {:?}", req);
 
                             let to_send = batch.take_batch();
                             if !to_send.is_empty() {

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -6,7 +6,7 @@ use crate::processor::model::register_processor;
 #[cfg(feature = "pyo3")]
 use crate::processor::py::rotel_python_processor_sdk;
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
-use crate::topology::flush_control::{conditional_flush, FlushReceiver};
+use crate::topology::flush_control::{FlushReceiver, conditional_flush};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 #[cfg(feature = "pyo3")]
 use tower::BoxError;
 use tracing::log::warn;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 //#[derive(Clone)]
 #[allow(dead_code)] // for the sake of the pyo3 feature

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -6,6 +6,7 @@ use crate::processor::model::register_processor;
 #[cfg(feature = "pyo3")]
 use crate::processor::py::rotel_python_processor_sdk;
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
+use crate::topology::flush_control::{FlushListener, FlushRequest};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
@@ -20,15 +21,17 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "pyo3")]
 use tower::BoxError;
-use tracing::{debug, error};
+use tracing::log::warn;
+use tracing::{debug, error, info};
 
-#[derive(Clone)]
+//#[derive(Clone)]
 #[allow(dead_code)] // for the sake of the pyo3 feature
 pub struct Pipeline<T> {
     receiver: BoundedReceiver<Vec<T>>,
     sender: BoundedSender<Vec<T>>,
     batch_config: BatchConfig,
     processors: Vec<String>,
+    flush_listener: Option<FlushListener>,
 }
 
 pub trait Inspect<T> {
@@ -74,12 +77,14 @@ where
     pub fn new(
         receiver: BoundedReceiver<Vec<T>>,
         sender: BoundedSender<Vec<T>>,
+        flush_listener: Option<FlushListener>,
         batch_config: BatchConfig,
         processors: Vec<String>,
     ) -> Self {
         Self {
             receiver,
             sender,
+            flush_listener,
             batch_config,
             processors,
         }
@@ -131,6 +136,8 @@ where
         let processor_modules = self.initialize_processors()?;
         #[cfg(not(feature = "pyo3"))]
         let processor_modules: Vec<String> = vec![];
+
+        let mut flush_listener = self.flush_listener.take();
 
         loop {
             select! {
@@ -207,6 +214,35 @@ where
                     }
                 },
 
+                Some(resp) = conditional_flush(&mut flush_listener) => {
+                    match resp {
+                        (Some(req), listener) => {
+                            info!("received force flush in pipeline: {:?}", req);
+
+                            let to_send = batch.take_batch();
+                            if !to_send.is_empty() {
+                                debug!(batch_size = to_send.len(), "Flushing a batch on flush message");
+
+                                if let Err(e) = self.send_item(to_send, &pipeline_token).await {
+                                    match e {
+                                        SendItemError::Cancelled => {
+                                            debug!("Pipeline received shutdown signal.");
+                                        }
+                                        SendItemError::Error(e) => {
+                                            error!(error = ?e, "Unable to send item, exiting.");
+                                        }
+                                    }
+                                }
+                            }
+
+                            if let Err(e) = listener.ack(req).await {
+                                warn!("unable to ack flush request: {}", e);
+                            }
+                        },
+                        (None, _) => warn!("flush channel was closed")
+                    }
+                },
+
                 _ = pipeline_token.cancelled() => {
                     debug!("Pipeline received shutdown signal, exiting main pipeline loop");
 
@@ -233,6 +269,13 @@ where
                 Err(SendItemError::Cancelled)
             }
         }
+    }
+}
+
+async fn conditional_flush(flush_listener: &mut Option<FlushListener>) -> Option<(Option<FlushRequest>, &mut FlushListener)> {
+    match flush_listener {
+        None => None,
+        Some(fl) => Some((fl.next().await, fl))
     }
 }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -5,3 +5,4 @@ pub mod debug;
 pub mod generic_pipeline;
 pub mod payload;
 pub mod pipeline;
+pub mod flush_control;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod batch;
 pub mod debug;
+pub mod flush_control;
 pub mod generic_pipeline;
 pub mod payload;
 pub mod pipeline;
-pub mod flush_control;


### PR DESCRIPTION
This brings in the concept of a broadcast flush message that can be separately tied to pipelines and exporters. The goal is allow an external process, the lambda extension in this case, to control when the pipeline flushes a batch and the exporters flush any requests. The process is two step:

1. flush pipelines and wait for each pipeline to respond
2. flush exporters and wait for each exporter to response

Hence, the FlushBroadcast is split into two parts: an MPMC broadcast channel and an MPSC response channel. Request and responses use a request ID to avoid potential late responses corrupting the ack, but I'm not sure that'll be needed in general practice.

We position the recv call for the flush msg at the bottom of the select loops in the pipeline and exporters. Given the biased select, it should mean that messages written to the incoming pipe will be serviced first, thereby "draining" messages ahead of the component before the flush is processed. While it could also lead to starvation theoretically, in the case we are flushing now we know the incoming messages should have halted.


STR-3248