### PR TITLE
Add Span Status support to Python processor 

### DIFF
--- a/contrib/processor/tests/read_and_write_spans_test.py
+++ b/contrib/processor/tests/read_and_write_spans_test.py
@@ -1,0 +1,27 @@
+from rotel_python_processor_sdk import PyStatus, PyStatusCode
+
+
+def process(resource_spans):
+    span = resource_spans.scope_spans[0].spans[0]
+    span.trace_id = b"5555555555"
+    span.span_id = b"6666666666"
+    span.trace_state = "test=1234567890"
+    span.parent_span_id = b"7777777777"
+    span.flags = 1
+    span.name = "py_processed_span"
+    span.kind = 4  # producer
+    span.start_time_unix_nano = 1234567890
+    span.end_time_unix_nano = 1234567890
+    # TODO add attributes
+    # span.attributes
+    span.dropped_attributes_count = 100
+    # TODO add events
+    # span.events
+    span.dropped_events_count = 200
+    # TODO add links
+    # span.links
+    span.dropped_links_count = 300
+    status = PyStatus()
+    status.code = PyStatusCode.Error
+    status.message = "error message"
+    span.status = status

--- a/src/processor/model/mod.rs
+++ b/src/processor/model/mod.rs
@@ -109,46 +109,16 @@ pub struct Status {
     pub code: i32,
 }
 
-/// Nested message and enum types in `Status`.
-pub mod status {
-    /// For the semantics of status codes see
-    /// <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status>
-    #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
-    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-    #[repr(i32)]
-    pub enum StatusCode {
-        /// The default status.
-        Unset = 0,
-        /// The Span has been validated by an Application developer or Operator to
-        /// have completed successfully.
-        Ok = 1,
-        /// The Span contains an error.
-        Error = 2,
-    }
-    impl StatusCode {
-        /// String value of the enum field names used in the ProtoBuf definition.
-        ///
-        /// The values are not transformed in any way and thus are considered stable
-        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn as_str_name(&self) -> &'static str {
-            match self {
-                Self::Unset => "STATUS_CODE_UNSET",
-                Self::Ok => "STATUS_CODE_OK",
-                Self::Error => "STATUS_CODE_ERROR",
-            }
-        }
-        /// Creates an enum from field names used in the ProtoBuf definition.
-        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-            match value {
-                "STATUS_CODE_UNSET" => Some(Self::Unset),
-                "STATUS_CODE_OK" => Some(Self::Ok),
-                "STATUS_CODE_ERROR" => Some(Self::Error),
-                _ => None,
-            }
-        }
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[allow(dead_code)]
+pub enum StatusCode {
+    /// The default status.
+    Unset = 0,
+    /// The Span has been validated by an Application developer or Operator to
+    /// have completed successfully.
+    Ok = 1,
+    /// The Span contains an error.
+    Error = 2,
 }
 
 pub fn register_processor(code: String, script: String, module: String) -> Result<(), BoxError> {

--- a/src/processor/model/mod.rs
+++ b/src/processor/model/mod.rs
@@ -103,10 +103,52 @@ pub struct Span {
     pub dropped_links_count: u32,
     pub status: Arc<Mutex<Option<Status>>>,
 }
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Status {
     pub message: String,
     pub code: i32,
+}
+
+/// Nested message and enum types in `Status`.
+pub mod status {
+    /// For the semantics of status codes see
+    /// <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status>
+    #[cfg_attr(feature = "with-schemars", derive(schemars::JsonSchema))]
+    #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "with-serde", serde(rename_all = "camelCase"))]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    #[repr(i32)]
+    pub enum StatusCode {
+        /// The default status.
+        Unset = 0,
+        /// The Span has been validated by an Application developer or Operator to
+        /// have completed successfully.
+        Ok = 1,
+        /// The Span contains an error.
+        Error = 2,
+    }
+    impl StatusCode {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Unset => "STATUS_CODE_UNSET",
+                Self::Ok => "STATUS_CODE_OK",
+                Self::Error => "STATUS_CODE_ERROR",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STATUS_CODE_UNSET" => Some(Self::Unset),
+                "STATUS_CODE_OK" => Some(Self::Ok),
+                "STATUS_CODE_ERROR" => Some(Self::Error),
+                _ => None,
+            }
+        }
+    }
 }
 
 pub fn register_processor(code: String, script: String, module: String) -> Result<(), BoxError> {

--- a/src/processor/model/otel_transform.rs
+++ b/src/processor/model/otel_transform.rs
@@ -1,7 +1,9 @@
 use crate::processor::model::Value::{
     ArrayValue, BoolValue, BytesValue, DoubleValue, IntValue, StringValue,
 };
-use crate::processor::model::{AnyValue, InstrumentationScope, KeyValue, ResourceSpans, Span};
+use crate::processor::model::{
+    AnyValue, InstrumentationScope, KeyValue, ResourceSpans, Span, Status,
+};
 use std::sync::{Arc, Mutex};
 
 pub fn transform(rs: opentelemetry_proto::tonic::trace::v1::ResourceSpans) -> ResourceSpans {
@@ -53,8 +55,10 @@ pub fn transform(rs: opentelemetry_proto::tonic::trace::v1::ResourceSpans) -> Re
                 dropped_attributes_count: s.dropped_attributes_count,
                 dropped_events_count: s.dropped_events_count,
                 dropped_links_count: s.dropped_links_count,
-                // TODO add status copy
-                status: Arc::new(Mutex::new(None)),
+                status: Arc::new(Mutex::new(s.status.map(|status| Status {
+                    message: status.message,
+                    code: status.code,
+                }))),
             };
             scope_span
                 .spans

--- a/utilities/src/otlp.rs
+++ b/utilities/src/otlp.rs
@@ -13,7 +13,7 @@ use opentelemetry_proto::tonic::metrics::v1::{
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
-use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Status};
 
 pub struct FakeOTLP;
 
@@ -224,7 +224,7 @@ impl FakeOTLP {
                 dropped_events_count: 0,
                 links: vec![],
                 dropped_links_count: 0,
-                status: None,
+                status: Some(Status::default()),
             };
             spans.push(span);
         }


### PR DESCRIPTION
Completes: STR-3256

Adds support for setting Span status and associated status code. Added transformers for converting back and forth between Rust and python and added new unit tests for working with and mutating Spans.

