### PR TITLE
Allow batch timer to be disabled

### DIFF
--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -18,12 +18,12 @@ use std::error::Error;
 use std::sync::Once;
 use std::time::Duration;
 use tokio::select;
-use tokio::time::{Instant, Interval};
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "pyo3")]
 use tower::BoxError;
 use tracing::log::warn;
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 //#[derive(Clone)]
 #[allow(dead_code)] // for the sake of the pyo3 feature


### PR DESCRIPTION
This allows the batch timer to be disabled when flushing is controlled manually. Just set a timer with a long interval and periodically reset it when we perform a manual flush.
