### PR TITLE
Pipelines are dropped

### DIFF
--- a/src/exporters/blackhole.rs
+++ b/src/exporters/blackhole.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use crate::bounded_channel::BoundedReceiver;
+use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use tokio::select;

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -566,8 +566,7 @@ impl Agent {
         drop(internal_metrics_output);
 
         // Construct a noop meter provider that will allow all pipelines to drop their input channels
-        let noop_meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-            .build();
+        let noop_meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
         global::set_meter_provider(noop_meter_provider);
 
         // Set a maximum duration for exporters to exit, this way if the pipelines exit quickly,

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -263,7 +263,7 @@ impl Agent {
             .with_resource(Resource::builder().with_service_name("rotel").build())
             .build();
 
-        global::set_meter_provider(meter_provider.clone());
+        global::set_meter_provider(meter_provider);
 
         let token = exporters_cancel.clone();
         match config.exporter {
@@ -562,6 +562,12 @@ impl Agent {
         drop(traces_output);
         drop(metrics_output);
         drop(logs_output);
+        drop(internal_metrics_output);
+
+        // Construct a noop meter provider that will allow all pipelines to drop their input channels
+        let noop_meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .build();
+        global::set_meter_provider(noop_meter_provider);
 
         // Set a maximum duration for exporters to exit, this way if the pipelines exit quickly,
         // the entire wall time is left for exporters to finish flushing (which may require longer if

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -269,8 +269,9 @@ impl Agent {
         match config.exporter {
             Exporter::Blackhole => {
                 let mut exp = BlackholeExporter::new(
-                    trace_pipeline_out_rx.clone(),
-                    metrics_pipeline_out_rx.clone(),
+                    trace_pipeline_out_rx,
+                    metrics_pipeline_out_rx,
+                    logs_pipeline_out_rx,
                 );
 
                 exporters_task_set.spawn(async move {

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -284,7 +284,7 @@ impl Agent {
                     let traces_config = build_traces_config(config.otlp_exporter.clone(), endpoint);
                     let mut traces = otlp::exporter::build_traces_exporter(
                         traces_config,
-                        trace_pipeline_out_rx.clone(),
+                        trace_pipeline_out_rx,
                         self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                     )?;
                     let token = exporters_cancel.clone();
@@ -306,7 +306,7 @@ impl Agent {
                         build_metrics_config(config.otlp_exporter.clone(), endpoint);
                     let mut metrics = otlp::exporter::build_metrics_exporter(
                         metrics_config.clone(),
-                        metrics_pipeline_out_rx.clone(),
+                        metrics_pipeline_out_rx,
                         self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                     )?;
                     let token = exporters_cancel.clone();
@@ -325,7 +325,7 @@ impl Agent {
 
                     let mut internal_metrics = otlp::exporter::build_internal_metrics_exporter(
                         metrics_config.clone(),
-                        internal_metrics_pipeline_out_rx.clone(),
+                        internal_metrics_pipeline_out_rx,
                         self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                     )?;
                     let token = exporters_cancel.clone();


### PR DESCRIPTION
This addresses some shutdown steps and ensures we cleanly close our pipelines and terminate exporters. Mostly ensures we drop all references when shutting down.

This also adds logs to the blackhole exporter which was missing.

Completes: STR-3235