### PR TITLE
Add link support to spans

### DIFF
--- a/contrib/processor/tests/read_and_write_spans_test.py
+++ b/contrib/processor/tests/read_and_write_spans_test.py
@@ -1,8 +1,37 @@
-from rotel_python_processor_sdk import PyStatus, PyStatusCode, PyKeyValue
+from rotel_python_processor_sdk import PyStatus, PyStatusCode, PyKeyValue, PyLink
 
 
 def process(resource_spans):
+    # assert expected initial state
     span = resource_spans.scope_spans[0].spans[0]
+    assert span.trace_id == b'\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01'
+    assert span.span_id == b'\x02\x02\x02\x02\x02\x02\x02\x02'
+    assert span.trace_state == "rojo=00f067aa0ba902b7"
+    assert span.parent_span_id == b'\x01\x01\x01\x01\x01\x01\x01\x01'
+    assert span.flags == 0
+    assert span.name == "foo"
+    assert span.kind == 1
+    assert span.dropped_attributes_count == 0
+    for event in span.events:
+        assert event.name == "a test event"
+        assert len(event.attributes) == 0
+        assert event.dropped_attributes_count == 0
+    assert span.dropped_events_count == 0
+    assert len(span.links) == 1
+    link = span.links[0]
+    assert link.trace_id == b'\x03\x03\x03\x03\x03\x03\x03\x03'
+    assert link.span_id == b'\x04\x04\x04\x04\x04\x04\x04\x04'
+    assert link.trace_state == "mojo=00f067aa0ba902b7"
+    assert len(link.attributes) == 2
+    for attr in link.attributes:
+        if attr.key == "http.method":
+            assert attr.value.value == "GET"
+        elif attr.key == "http.request.path":
+            assert attr.value.value == "/item/0"
+    assert link.dropped_attributes_count == 10
+    assert link.flags == 0
+
+    # mutate span
     span.trace_id = b"5555555555"
     span.span_id = b"6666666666"
     span.trace_state = "test=1234567890"
@@ -17,10 +46,18 @@ def process(resource_spans):
     span.dropped_attributes_count = 100
     # TODO add events
     # span.events
-    span.dropped_events_count = 200
-    # TODO add links
-    # span.links
     span.dropped_links_count = 300
+    span.dropped_events_count = 200
+    # Append a new link
+    new_link = PyLink()
+    new_link.trace_id = b"88888888"
+    new_link.span_id = b"99999999"
+    new_link.trace_state = "test=1234567890"
+    new_link.attributes.append(PyKeyValue.new_string_value("link_attr_key", "link_attr_value"))
+    new_link.dropped_attributes_count = 300
+    new_link.flags = 1
+    span.links.append(new_link)
+
     status = PyStatus()
     status.code = PyStatusCode.Error
     status.message = "error message"

--- a/rotel_python_processor_sdk/src/model/mod.rs
+++ b/rotel_python_processor_sdk/src/model/mod.rs
@@ -100,7 +100,7 @@ pub struct Span {
     pub dropped_attributes_count: u32,
     pub events: Arc<Mutex<Vec<Arc<Mutex<Event>>>>>,
     pub dropped_events_count: u32,
-    //pub links: ::prost::alloc::vec::Vec<span::Link>,
+    pub links: Arc<Mutex<Vec<Arc<Mutex<Link>>>>>,
     pub dropped_links_count: u32,
     pub status: Arc<Mutex<Option<Status>>>,
 }
@@ -129,6 +129,16 @@ pub enum StatusCode {
     Ok = 1,
     /// The Span contains an error.
     Error = 2,
+}
+
+#[derive(Debug, Clone)]
+pub struct Link {
+    pub trace_id: Vec<u8>,
+    pub span_id: Vec<u8>,
+    pub trace_state: String,
+    pub attributes: Arc<Mutex<Vec<KeyValue>>>,
+    pub dropped_attributes_count: u32,
+    pub flags: u32,
 }
 
 pub fn register_processor(code: String, script: String, module: String) -> Result<(), BoxError> {

--- a/rotel_python_processor_sdk/src/model/otel_transform.rs
+++ b/rotel_python_processor_sdk/src/model/otel_transform.rs
@@ -1,5 +1,7 @@
 use crate::model::Value::{ArrayValue, BoolValue, BytesValue, DoubleValue, IntValue, StringValue};
-use crate::model::{AnyValue, Event, InstrumentationScope, KeyValue, ResourceSpans, Span, Status};
+use crate::model::{
+    AnyValue, Event, InstrumentationScope, KeyValue, Link, ResourceSpans, Span, Status,
+};
 use std::sync::{Arc, Mutex};
 
 pub fn transform(rs: opentelemetry_proto::tonic::trace::v1::ResourceSpans) -> ResourceSpans {
@@ -57,6 +59,23 @@ pub fn transform(rs: opentelemetry_proto::tonic::trace::v1::ResourceSpans) -> Re
                                     e.attributes.to_owned(),
                                 ))),
                                 dropped_attributes_count: 0,
+                            }))
+                        })
+                        .collect(),
+                )),
+                links: Arc::new(Mutex::new(
+                    s.links
+                        .iter()
+                        .map(|l| {
+                            Arc::new(Mutex::new(Link {
+                                trace_id: l.trace_id.to_owned(),
+                                span_id: l.span_id.to_owned(),
+                                trace_state: l.trace_state.to_owned(),
+                                attributes: Arc::new(Mutex::new(convert_attributes(
+                                    l.attributes.to_owned(),
+                                ))),
+                                dropped_attributes_count: l.dropped_attributes_count,
+                                flags: l.flags,
                             }))
                         })
                         .collect(),

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -2,7 +2,7 @@ use crate::model::Value::{
     ArrayValue, BoolValue, BytesValue, DoubleValue, IntValue, KvListValue, StringValue,
 };
 use crate::model::{
-    AnyValue, Event, InstrumentationScope, KeyValue, Resource, ScopeSpans, Span, Status,
+    AnyValue, Event, InstrumentationScope, KeyValue, Link, Resource, ScopeSpans, Span, Status,
 };
 use pyo3::prelude::*;
 use std::sync::{Arc, Mutex};
@@ -1145,8 +1145,11 @@ impl PySpan {
         v.dropped_events_count = new_value;
         Ok(())
     }
-    // TODO
-    // //pub links: ::prost::alloc::vec::Vec<span::Link>,
+    #[getter]
+    fn links(&self) -> PyResult<PyLinks> {
+        let v = self.inner.lock().unwrap();
+        Ok(PyLinks(v.links.clone()))
+    }
     #[getter]
     fn dropped_links_count(&self) -> PyResult<u32> {
         let v = self.inner.lock().map_err(|_| {
@@ -1328,6 +1331,191 @@ impl PyEvent {
 }
 
 #[pyclass]
+struct PyLinks(Arc<Mutex<Vec<Arc<Mutex<Link>>>>>);
+
+#[pymethods]
+impl PyLinks {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<PyLinksIter>> {
+        let inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        let iter = PyLinksIter {
+            inner: inner.clone().into_iter(),
+        };
+        // Convert to a Python-managed object
+        Py::new(py, iter)
+    }
+    fn __getitem__(&self, index: usize) -> PyResult<PyLink> {
+        let inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        match inner.get(index) {
+            Some(item) => Ok(PyLink {
+                inner: item.clone(),
+            }),
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn append<'py>(&self, item: &PyLink) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        k.push(item.inner.clone());
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+struct PyLinksIter {
+    inner: std::vec::IntoIter<Arc<Mutex<Link>>>,
+}
+
+#[pymethods]
+impl PyLinksIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<PyLink>> {
+        let kv = slf.inner.next();
+        if kv.is_none() {
+            return Ok(None);
+        }
+        let inner = kv.unwrap();
+        Ok(Some(PyLink {
+            inner: inner.clone(),
+        }))
+    }
+}
+
+#[pyclass]
+#[derive(Debug)]
+struct PyLink {
+    inner: Arc<Mutex<Link>>,
+}
+
+#[pymethods]
+impl PyLink {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(PyLink {
+            inner: Arc::new(Mutex::new(Link {
+                trace_id: vec![],
+                span_id: vec![],
+                trace_state: "".to_string(),
+                attributes: Arc::new(Mutex::new(vec![])),
+                dropped_attributes_count: 0,
+                flags: 0,
+            })),
+        })
+    }
+    #[getter]
+    fn trace_id(&self) -> PyResult<Vec<u8>> {
+        let v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(v.trace_id.clone())
+    }
+    #[setter]
+    fn set_trace_id(&mut self, trace_id: Vec<u8>) -> PyResult<()> {
+        let mut v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        v.trace_id = trace_id;
+        Ok(())
+    }
+    #[getter]
+    fn span_id(&self) -> PyResult<Vec<u8>> {
+        let v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(v.span_id.clone())
+    }
+    #[setter]
+    fn set_span_id(&mut self, span_id: Vec<u8>) -> PyResult<()> {
+        let mut v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        v.span_id = span_id;
+        Ok(())
+    }
+    #[getter]
+    fn trace_state(&self) -> PyResult<String> {
+        let v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(v.trace_state.clone())
+    }
+    #[setter]
+    fn set_trace_state(&mut self, trace_state: String) -> PyResult<()> {
+        let mut v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        v.trace_state = trace_state;
+        Ok(())
+    }
+    #[getter]
+    fn attributes(&self) -> PyResult<PyAttributesList> {
+        let binding = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(PyAttributesList(binding.attributes.clone()))
+    }
+    #[setter]
+    fn set_attributes(&mut self, attrs: &PyAttributesList) -> PyResult<()> {
+        let inner = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        let mut v = inner.attributes.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        v.clear();
+        for kv in attrs.0.lock().unwrap().iter() {
+            v.push(kv.clone())
+        }
+        Ok(())
+    }
+    #[getter]
+    fn dropped_attributes_count(&self) -> PyResult<u32> {
+        let v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(v.dropped_attributes_count)
+    }
+    #[setter]
+    fn set_dropped_attributes_count(&self, new_value: u32) -> PyResult<()> {
+        let mut v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        v.dropped_attributes_count = new_value;
+        Ok(())
+    }
+    #[getter]
+    fn flags(&self) -> PyResult<u32> {
+        let v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        Ok(v.flags)
+    }
+    #[setter]
+    fn set_flags(&self, new_value: u32) -> PyResult<()> {
+        let mut v = self.inner.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        v.flags = new_value;
+        Ok(())
+    }
+}
+
+#[pyclass]
 #[derive(Clone)]
 struct PyStatus(Arc<Mutex<Option<Status>>>);
 
@@ -1455,6 +1643,7 @@ pub fn rotel_python_processor_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyScopeSpans>()?;
     m.add_class::<PyInstrumentationScope>()?;
     m.add_class::<PySpan>()?;
+    m.add_class::<PyLink>()?;
     m.add_class::<PyStatus>()?;
     m.add_class::<PyStatusCode>()?;
     Ok(())
@@ -1464,7 +1653,6 @@ pub fn rotel_python_processor_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[allow(deprecated)]
 mod tests {
     use super::*;
-    use crate::model::Value::{BoolValue, StringValue};
     use opentelemetry_proto::tonic::common::v1::any_value::Value;
     use pyo3::ffi::c_str;
     use std::ffi::CString;
@@ -1495,6 +1683,7 @@ mod tests {
             let err = result_py_object.unwrap_err();
             return Err(err);
         }
+        // For debugging python stdout -- println!("{:?}", result_py_object.unwrap());
         Ok(())
     }
 
@@ -2126,7 +2315,7 @@ mod tests {
 
         let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
         let mut scope_spans = scope_spans.pop().unwrap();
-        let span = scope_spans.spans.pop().unwrap();
+        let mut span = scope_spans.spans.pop().unwrap();
         assert_eq!(b"5555555555".to_vec(), span.trace_id);
         assert_eq!(b"6666666666".to_vec(), span.span_id);
         assert_eq!("test=1234567890", span.trace_state);
@@ -2156,6 +2345,23 @@ mod tests {
         match value {
             Value::StringValue(s) => {
                 assert_eq!("event_attr_value", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert_eq!(2, span.links.len());
+        // get the newly added link
+        let new_link = span.links.remove(1);
+        assert_eq!(b"88888888".to_vec(), new_link.trace_id);
+        assert_eq!(b"99999999".to_vec(), new_link.span_id);
+        assert_eq!("test=1234567890", new_link.trace_state);
+        assert_eq!(300, new_link.dropped_attributes_count);
+        assert_eq!(1, new_link.flags);
+        assert_eq!(1, new_link.attributes.len());
+        let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("link_attr_value", s)
             }
             _ => panic!("unexpected type"),
         }

--- a/utilities/src/otlp.rs
+++ b/utilities/src/otlp.rs
@@ -227,7 +227,17 @@ impl FakeOTLP {
                     dropped_attributes_count: 0,
                 }],
                 dropped_events_count: 0,
-                links: vec![],
+                links: vec![v1::span::Link {
+                    trace_id: vec![3, 3, 3, 3, 3, 3, 3, 3],
+                    span_id: vec![4, 4, 4, 4, 4, 4, 4, 4],
+                    trace_state: "mojo=00f067aa0ba902b7".to_string(),
+                    attributes: vec![
+                        string_attr("http.method", "GET"),
+                        string_attr("http.request.path", "/item/0"),
+                    ],
+                    dropped_attributes_count: 10,
+                    flags: 0,
+                }],
                 dropped_links_count: 0,
                 status: Some(Status::default()),
             };


### PR DESCRIPTION
Completes: STR-3255

Spans now support the Link type. Each Span has a potentially non-empty Vec<Link> which allows for expressing a relationship between Spans. Links have associated IDs (trace, span, parent) as well as attributes and a few more pieces of metadata. In this PR we also add unit tests to verify behavior when working with Links in Python and assertion of anticipated changes made, back in Rust.