### PR TITLE
Switch to aws-lc-rs

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,12 @@
+use rustls::crypto::CryptoProvider;
+use tower::BoxError;
+
+pub fn init_crypto_provider() -> Result<(), BoxError> {
+    if CryptoProvider::get_default().is_none() {
+        return match rustls::crypto::aws_lc_rs::default_provider().install_default() {
+            Ok(_) => Ok(()),
+            Err(e) => Err(format!("failed to initialize crypto library: {:?}", e).into()),
+        };
+    }
+    Ok(())
+}

--- a/src/exporters/crypto_init_tests.rs
+++ b/src/exporters/crypto_init_tests.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+use crate::crypto::init_crypto_provider;
+#[cfg(test)]
 use std::sync::Once;
 
 #[cfg(test)]
@@ -6,9 +8,5 @@ static INIT_CRYPTO: Once = Once::new();
 
 #[cfg(test)]
 pub fn init_crypto() {
-    INIT_CRYPTO.call_once(|| {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .unwrap()
-    });
+    INIT_CRYPTO.call_once(|| init_crypto_provider().unwrap());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod bounded_channel;
+pub mod crypto;
 pub mod exporters;
 pub mod init;
 pub mod listener;


### PR DESCRIPTION
This appears to be the default for rustls now and claims to be better supported, high performance, more stable.

It does expand build size about 1-2mb.

STR-3299

