### PR TITLE
Add response body and fix retryable status codes

### DIFF
--- a/src/exporters/http/retry.rs
+++ b/src/exporters/http/retry.rs
@@ -74,7 +74,7 @@ impl<Resp> RetryPolicy<Resp> {
                 // No need to retry success
                 200..=202 => false,
                 408 | 429 => true,
-                500..=503 => true,
+                500..=504 => true,
                 _ => false,
             };
         }

--- a/src/exporters/otlp/errors.rs
+++ b/src/exporters/otlp/errors.rs
@@ -43,8 +43,12 @@ pub fn is_retryable_error(status: &ExporterError) -> bool {
         ExporterError::Generic(_) => false, // todo: further classify errors here
         ExporterError::Connect => true,
         ExporterError::Http(status, _) => {
-            let code = status.as_u16();
-            (500..505).contains(&code)
+            match status.as_u16() {
+                200..=202 => false,
+                408 | 429 => true,
+                500..=503 => true,
+                _ => false,
+            }
         }
         ExporterError::Grpc(status) => matches!(
             status.code(),

--- a/src/exporters/otlp/errors.rs
+++ b/src/exporters/otlp/errors.rs
@@ -46,7 +46,7 @@ pub fn is_retryable_error(status: &ExporterError) -> bool {
             match status.as_u16() {
                 200..=202 => false,
                 408 | 429 => true,
-                500..=503 => true,
+                500..=504 => true,
                 _ => false,
             }
         }

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -939,9 +939,8 @@ mod tests {
 
         let hello_mock = server.mock(|when, then| {
             when.method(POST).path("/v1/traces");
-            then.status(200)
+            then.status(429)
                 .header("content-type", "application/x-protobuf")
-                .status(429)
                 .body(resp_buf);
         });
 
@@ -964,8 +963,9 @@ mod tests {
         let res = send_test_traces_msgs_and_stop(otlp_exp, trace_btx, 2).await;
         assert_err!(res);
 
-        // There is randomness, so at a minimum we should try twice, at max 3
-        assert!((2..=3).contains(&(hello_mock.hits() as i32)));
+        // Each message will have 2-3 attempts, so double that range. There is randomness
+        // due to the jitter
+        assert!((4..=6).contains(&(hello_mock.hits() as i32)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This includes a response body in status code failures, which helps with debugging.

We expand the OTLP exporter retry codes to include 408 (client request timeout, uncommon) and 429 (too many requests, more common), and the Datadog exporter to support 504 (gateway timeout). These should be merged in the future.

Completes: STR-3308, STR-3307

