### PR TITLE
Rename modules for parity with otel proto definitions

### DIFF
--- a/contrib/processor/tests/read_and_write_attributes_array_value_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_array_value_test.py
@@ -1,4 +1,4 @@
-from rotel_python_processor_sdk import PyAnyValue, PyArrayValue, PyAttributes, PyKeyValue
+from rotel.open_telemetry.common.v1 import AnyValue, ArrayValue, Attributes, KeyValue
 
 
 def process(resource):
@@ -17,13 +17,13 @@ def process(resource):
         assert av.value == "bar"
 
     # Create a new ArrayValue and update resource.attributes
-    new_array_value = PyArrayValue()
-    new_any_value = PyAnyValue()
+    new_array_value = ArrayValue()
+    new_any_value = AnyValue()
     new_any_value.string_value = "baz"
     new_array_value.append(new_any_value)
 
-    kv = PyKeyValue.new_array_value("my_array", new_array_value)
-    new_attributes = PyAttributes()
+    kv = KeyValue.new_array_value("my_array", new_array_value)
+    new_attributes = Attributes()
     new_attributes.append(kv)
     resource.attributes = new_attributes
 

--- a/contrib/processor/tests/read_and_write_attributes_array_value_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_array_value_test.py
@@ -1,4 +1,4 @@
-from rotel.open_telemetry.common.v1 import AnyValue, ArrayValue, Attributes, KeyValue
+from rotel_sdk.open_telemetry.common.v1 import AnyValue, ArrayValue, Attributes, KeyValue
 
 
 def process(resource):

--- a/contrib/processor/tests/read_and_write_attributes_key_value_list_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_key_value_list_test.py
@@ -1,4 +1,4 @@
-from rotel.open_telemetry.common.v1 import KeyValueList, KeyValue, Attributes
+from rotel_sdk.open_telemetry.common.v1 import KeyValueList, KeyValue, Attributes
 
 
 def process(resource):

--- a/contrib/processor/tests/read_and_write_attributes_key_value_list_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_key_value_list_test.py
@@ -1,4 +1,4 @@
-from rotel_python_processor_sdk import PyKeyValueList, PyKeyValue, PyAttributes
+from rotel.open_telemetry.common.v1 import KeyValueList, KeyValue, Attributes
 
 
 def process(resource):
@@ -18,12 +18,12 @@ def process(resource):
         assert kv.value.value == "bar"
 
     # Create a new KeyValueList and update resource.attributes
-    new_key_value_list = PyKeyValueList()
-    new_kv = PyKeyValue.new_string_value("new_key", "baz")
+    new_key_value_list = KeyValueList()
+    new_kv = KeyValue.new_string_value("new_key", "baz")
     new_key_value_list.append(new_kv)
 
-    kvl = PyKeyValue.new_kv_list("my_kv_list", new_key_value_list)
-    new_attributes = PyAttributes()
+    kvl = KeyValue.new_kv_list("my_kv_list", new_key_value_list)
+    new_attributes = Attributes()
     new_attributes.append(kvl)
     resource.attributes = new_attributes
 

--- a/contrib/processor/tests/read_and_write_instrumentation_scope_test.py
+++ b/contrib/processor/tests/read_and_write_instrumentation_scope_test.py
@@ -1,4 +1,4 @@
-from rotel.open_telemetry.common.v1 import KeyValue
+from rotel_sdk.open_telemetry.common.v1 import KeyValue
 
 
 def process(resource_spans):

--- a/contrib/processor/tests/read_and_write_instrumentation_scope_test.py
+++ b/contrib/processor/tests/read_and_write_instrumentation_scope_test.py
@@ -1,4 +1,4 @@
-from rotel_python_processor_sdk import PyKeyValue
+from rotel.open_telemetry.common.v1 import KeyValue
 
 
 def process(resource_spans):
@@ -34,7 +34,7 @@ def process(resource_spans):
         assert 200 == attr.value.value
 
     # Append a new attribute
-    kv = PyKeyValue.new_string_value("severity", "WARN")
+    kv = KeyValue.new_string_value("severity", "WARN")
     resource_spans.scope_spans[0].scope.attributes.append(kv)
 
     assert len(resource_spans.scope_spans[0].scope.attributes) == 2

--- a/contrib/processor/tests/read_and_write_spans_test.py
+++ b/contrib/processor/tests/read_and_write_spans_test.py
@@ -1,4 +1,5 @@
-from rotel_python_processor_sdk import PyStatus, PyStatusCode, PyKeyValue, PyLink
+from rotel.open_telemetry.common.v1 import KeyValue
+from rotel.open_telemetry.trace.v1 import Status, StatusCode, Link
 
 
 def process(resource_spans):
@@ -51,29 +52,29 @@ def process(resource_spans):
     span.start_time_unix_nano = 1234567890
     span.end_time_unix_nano = 1234567890
 
-    span.attributes.append(PyKeyValue.new_string_value("span_attr_key", "span_attr_value"))
+    span.attributes.append(KeyValue.new_string_value("span_attr_key", "span_attr_value"))
     span.dropped_attributes_count = 100
     # TODO add events
     # span.events
     span.dropped_links_count = 300
     span.dropped_events_count = 200
     # Append a new link
-    new_link = PyLink()
+    new_link = Link()
     new_link.trace_id = b"88888888"
     new_link.span_id = b"99999999"
     new_link.trace_state = "test=1234567890"
-    new_link.attributes.append(PyKeyValue.new_string_value("link_attr_key", "link_attr_value"))
+    new_link.attributes.append(KeyValue.new_string_value("link_attr_key", "link_attr_value"))
     new_link.dropped_attributes_count = 300
     new_link.flags = 1
     span.links.append(new_link)
 
-    status = PyStatus()
-    status.code = PyStatusCode.Error
+    status = Status()
+    status.code = StatusCode.Error
     status.message = "error message"
     span.status = status
 
     event = span.events[0]
     event.time_unix_nano = 1234567890
     event.name = "py_processed_event"
-    event.attributes.append(PyKeyValue.new_string_value("event_attr_key", "event_attr_value"))
+    event.attributes.append(KeyValue.new_string_value("event_attr_key", "event_attr_value"))
     event.dropped_attributes_count = 400

--- a/contrib/processor/tests/read_and_write_spans_test.py
+++ b/contrib/processor/tests/read_and_write_spans_test.py
@@ -1,5 +1,5 @@
-from rotel.open_telemetry.common.v1 import KeyValue
-from rotel.open_telemetry.trace.v1 import Status, StatusCode, Link
+from rotel_sdk.open_telemetry.common.v1 import KeyValue
+from rotel_sdk.open_telemetry.trace.v1 import Status, StatusCode, Link
 
 
 def process(resource_spans):

--- a/contrib/processor/tests/read_key_value_key_test.py
+++ b/contrib/processor/tests/read_key_value_key_test.py
@@ -1,4 +1,2 @@
-from rotel_python_processor_sdk import PyKeyValue
-
 def process(key_value):
     print(f"key_value.key: {key_value.key}")

--- a/contrib/processor/tests/read_key_value_value_test.py
+++ b/contrib/processor/tests/read_key_value_value_test.py
@@ -1,4 +1,2 @@
-from rotel_python_processor_sdk import PyKeyValue
-
 def process(key_value):
     print(f"key_value.value: {key_value.value}")

--- a/contrib/processor/tests/read_resource_attributes_test.py
+++ b/contrib/processor/tests/read_resource_attributes_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyAnyValue
-
 def process(resource):
     attributes = resource.attributes
     print(f"resource.attributes: {attributes}")

--- a/contrib/processor/tests/read_value_test.py
+++ b/contrib/processor/tests/read_value_test.py
@@ -1,4 +1,2 @@
-from rotel_python_processor_sdk import PyAnyValue
-
 def process(any_value):
     print(f"any_value: {any_value.value}")

--- a/contrib/processor/tests/resource_attributes_append_attribute.py
+++ b/contrib/processor/tests/resource_attributes_append_attribute.py
@@ -1,6 +1,6 @@
 import platform
 from datetime import datetime
-from rotel.open_telemetry.common.v1 import KeyValue
+from rotel_sdk.open_telemetry.common.v1 import KeyValue
 
 
 def process(resource):

--- a/contrib/processor/tests/resource_attributes_append_attribute.py
+++ b/contrib/processor/tests/resource_attributes_append_attribute.py
@@ -1,7 +1,7 @@
-from rotel_python_processor_sdk import PyAnyValue, PyKeyValue
 import platform
-import os
 from datetime import datetime
+from rotel.open_telemetry.common.v1 import KeyValue
+
 
 def process(resource):
     print("Hello from python attributes before mutating")
@@ -22,21 +22,21 @@ def process(resource):
     os_name = platform.system()
     os_version = platform.release()
     # Add individual attributes
-    resource.attributes.append(PyKeyValue.new_string_value("os.name", os_name))
-    resource.attributes.append(PyKeyValue.new_string_value("os.version", os_version))
+    resource.attributes.append(KeyValue.new_string_value("os.name", os_name))
+    resource.attributes.append(KeyValue.new_string_value("os.version", os_version))
     resource.attributes.append_attributes(get_attrs_list())
 
     print("Goodbye from Python, here's the final attributes")
     for kv in resource.attributes:
-       print(f"{kv.key}")
-       print(f"{kv.value.value}")
+        print(f"{kv.key}")
+        print(f"{kv.value.value}")
+
 
 def get_attrs_list():
     new_attrs = []
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    new_attrs.append(PyKeyValue.new_string_value("observed_time", current_time))
-    new_attrs.append(PyKeyValue.new_string_value("service.name", "rotel"))
-    new_attrs.append(PyKeyValue.new_bool_value("observed", True))
-
+    new_attrs.append(KeyValue.new_string_value("observed_time", current_time))
+    new_attrs.append(KeyValue.new_string_value("service.name", "rotel"))
+    new_attrs.append(KeyValue.new_bool_value("observed", True))
 
     return new_attrs

--- a/contrib/processor/tests/resource_attributes_set_attributes.py
+++ b/contrib/processor/tests/resource_attributes_set_attributes.py
@@ -1,13 +1,13 @@
 import platform
 
-from rotel_python_processor_sdk import PyKeyValue, PyAttributes
+from rotel.open_telemetry.common.v1 import KeyValue, Attributes
 
 
 def process(resource):
-    new_attributes = PyAttributes()
+    new_attributes = Attributes()
     os_name = platform.system()
     os_version = platform.release()
     # Add individual attributes
-    new_attributes.append(PyKeyValue.new_string_value("os.name", os_name))
-    new_attributes.append(PyKeyValue.new_string_value("os.version", os_version))
+    new_attributes.append(KeyValue.new_string_value("os.name", os_name))
+    new_attributes.append(KeyValue.new_string_value("os.version", os_version))
     resource.attributes = new_attributes

--- a/contrib/processor/tests/resource_attributes_set_attributes.py
+++ b/contrib/processor/tests/resource_attributes_set_attributes.py
@@ -1,6 +1,6 @@
 import platform
 
-from rotel.open_telemetry.common.v1 import KeyValue, Attributes
+from rotel_sdk.open_telemetry.common.v1 import KeyValue, Attributes
 
 
 def process(resource):

--- a/contrib/processor/tests/resource_spans_append_attribute.py
+++ b/contrib/processor/tests/resource_spans_append_attribute.py
@@ -1,22 +1,22 @@
 import platform
 from datetime import datetime
-from rotel_python_processor_sdk import PyKeyValue
+from rotel.open_telemetry.common.v1 import KeyValue
 
 
 def process(resource_spans):
     os_name = platform.system()
     os_version = platform.release()
     # Add individual attributes
-    resource_spans.resource.attributes.append(PyKeyValue.new_string_value("os.name", os_name))
-    resource_spans.resource.attributes.append(PyKeyValue.new_string_value("os.version", os_version))
+    resource_spans.resource.attributes.append(KeyValue.new_string_value("os.name", os_name))
+    resource_spans.resource.attributes.append(KeyValue.new_string_value("os.version", os_version))
     resource_spans.resource.attributes.append_attributes(get_attrs_list())
 
 
 def get_attrs_list():
     new_attrs = []
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    new_attrs.append(PyKeyValue.new_string_value("observed_time", current_time))
-    new_attrs.append(PyKeyValue.new_string_value("service.name", "rotel"))
-    new_attrs.append(PyKeyValue.new_bool_value("observed", True))
+    new_attrs.append(KeyValue.new_string_value("observed_time", current_time))
+    new_attrs.append(KeyValue.new_string_value("service.name", "rotel"))
+    new_attrs.append(KeyValue.new_bool_value("observed", True))
 
     return new_attrs

--- a/contrib/processor/tests/resource_spans_append_attribute.py
+++ b/contrib/processor/tests/resource_spans_append_attribute.py
@@ -1,6 +1,6 @@
 import platform
 from datetime import datetime
-from rotel.open_telemetry.common.v1 import KeyValue
+from rotel_sdk.open_telemetry.common.v1 import KeyValue
 
 
 def process(resource_spans):

--- a/contrib/processor/tests/resource_spans_iterate_spans.py
+++ b/contrib/processor/tests/resource_spans_iterate_spans.py
@@ -1,8 +1,3 @@
-from rotel_python_processor_sdk import PyAnyValue, PyKeyValue, PySpan
-import platform
-import os
-from datetime import datetime
-
 def process(resource_spans):
     print("Hello from python attributes before mutating")
     for scope_spans in resource_spans.scope_spans:
@@ -17,4 +12,3 @@ def process(resource_spans):
             print(f"trace_id:  {span.trace_id}")
             print(f"span_id:  {span.span_id}")
             print(f"name_id:  {span.name}")
-

--- a/contrib/processor/tests/set_instrumentation_scope_test.py
+++ b/contrib/processor/tests/set_instrumentation_scope_test.py
@@ -1,4 +1,4 @@
-from rotel.open_telemetry.common.v1 import InstrumentationScope, KeyValue
+from rotel_sdk.open_telemetry.common.v1 import InstrumentationScope, KeyValue
 
 
 def process(resource_spans):

--- a/contrib/processor/tests/set_instrumentation_scope_test.py
+++ b/contrib/processor/tests/set_instrumentation_scope_test.py
@@ -1,4 +1,4 @@
-from rotel_python_processor_sdk import PyInstrumentationScope, PyKeyValue
+from rotel.open_telemetry.common.v1 import InstrumentationScope, KeyValue
 
 
 def process(resource_spans):
@@ -9,7 +9,7 @@ def process(resource_spans):
     # assert 0 == scope.dropped_attributes_count
 
     # Now create a new InstrumentationScope
-    scope = PyInstrumentationScope()
+    scope = InstrumentationScope()
     scope.name = "name_changed"
     scope.version = "0.0.2"
     scope.dropped_attributes_count = 100
@@ -23,7 +23,7 @@ def process(resource_spans):
     assert 100 == scope_spans.scope.dropped_attributes_count
 
     # Append a new attribute
-    kv = PyKeyValue.new_string_value("severity", "WARN")
+    kv = KeyValue.new_string_value("severity", "WARN")
     resource_spans.scope_spans[0].scope.attributes.append(kv)
 
     assert len(resource_spans.scope_spans[0].scope.attributes) == 1

--- a/contrib/processor/tests/write_bool_value_test.py
+++ b/contrib/processor/tests/write_bool_value_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyAnyValue
-
 def process(any_value):
     print(f"any_value.value: {any_value.value}")
     any_value.bool_value = True

--- a/contrib/processor/tests/write_key_value_key_test.py
+++ b/contrib/processor/tests/write_key_value_key_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyKeyValue
-
 def process(key_value):
     print(f"key_value.key: {key_value.key}")
     key_value.key = "new_key"

--- a/contrib/processor/tests/write_key_value_value_test.py
+++ b/contrib/processor/tests/write_key_value_value_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyKeyValue
-
 def process(key_value):
     print(f"key_value.value: {key_value.value}")
     key_value.value.string_value = "changed"

--- a/contrib/processor/tests/write_resource_attributes_key_value_key_test.py
+++ b/contrib/processor/tests/write_resource_attributes_key_value_key_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyAnyValue
-
 def process(resource):
     attributes = resource.attributes
     attributes[0].key = "new_key"

--- a/contrib/processor/tests/write_resource_attributes_key_value_value_test.py
+++ b/contrib/processor/tests/write_resource_attributes_key_value_value_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyAnyValue
-
 def process(resource):
     attributes = resource.attributes
     attributes[0].value.string_value = "changed"
@@ -7,4 +5,3 @@ def process(resource):
     for kv in resource.attributes:
         print(f"{kv.key}")
         print(f"{kv.value.value}")
-

--- a/contrib/processor/tests/write_string_value_test.py
+++ b/contrib/processor/tests/write_string_value_test.py
@@ -1,5 +1,3 @@
-from rotel_python_processor_sdk import PyAnyValue
-
 def process(any_value):
     print(f"any_value.value: {any_value.value}")
     any_value.string_value = "changed"

--- a/rotel_python_processor_sdk/Cargo.toml
+++ b/rotel_python_processor_sdk/Cargo.toml
@@ -17,7 +17,7 @@ pyo3-stub-gen-derive = "0.7.0"
 # The name of the native library. This is the name which will be used in Python to import the
 # library (i.e. `import string_sum`). If you change this, you must also change the name of the
 # `#[pymodule]` in `src/lib.rs`.
-name = "rotel_python_processor_sdk"
+name = "rotel"
 # "cdylib" is necessary to produce a shared library for Python to import from.
 #
 # Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able

--- a/rotel_python_processor_sdk/Cargo.toml
+++ b/rotel_python_processor_sdk/Cargo.toml
@@ -17,7 +17,7 @@ pyo3-stub-gen-derive = "0.7.0"
 # The name of the native library. This is the name which will be used in Python to import the
 # library (i.e. `import string_sum`). If you change this, you must also change the name of the
 # `#[pymodule]` in `src/lib.rs`.
-name = "rotel"
+name = "rotel_sdk"
 # "cdylib" is necessary to produce a shared library for Python to import from.
 #
 # Downstream Rust code (including code in `bin/`, `examples/`, and `tests/`) will not be able

--- a/rotel_python_processor_sdk/src/model/mod.rs
+++ b/rotel_python_processor_sdk/src/model/mod.rs
@@ -2,7 +2,7 @@ pub mod otel_transform;
 pub mod py_transform;
 
 use crate::py;
-use crate::py::{rotel, ResourceSpans};
+use crate::py::{rotel_sdk, ResourceSpans};
 use pyo3::prelude::*;
 use std::ffi::CString;
 use std::sync::{Arc, Mutex, Once};
@@ -144,7 +144,7 @@ pub struct RLink {
 
 pub fn register_processor(code: String, script: String, module: String) -> Result<(), BoxError> {
     PROCESSOR_INIT.call_once(|| {
-        pyo3::append_to_inittab!(rotel);
+        pyo3::append_to_inittab!(rotel_sdk);
         pyo3::prepare_freethreaded_python();
     });
 

--- a/rotel_python_processor_sdk/src/model/mod.rs
+++ b/rotel_python_processor_sdk/src/model/mod.rs
@@ -1,7 +1,8 @@
 pub mod otel_transform;
 pub mod py_transform;
 
-use crate::py::{rotel_python_processor_sdk, PyResourceSpans};
+use crate::py;
+use crate::py::{rotel, ResourceSpans};
 use pyo3::prelude::*;
 use std::ffi::CString;
 use std::sync::{Arc, Mutex, Once};
@@ -11,82 +12,82 @@ use tracing::error;
 static PROCESSOR_INIT: Once = Once::new();
 
 #[derive(Debug, Clone)]
-pub struct AnyValue {
-    pub value: Arc<Mutex<Option<Value>>>,
+pub struct RAnyValue {
+    pub value: Arc<Mutex<Option<RValue>>>,
 }
 
 #[derive(Debug, Clone)]
 #[allow(clippy::enum_variant_names)]
-pub enum Value {
+pub enum RValue {
     StringValue(String),
     BoolValue(bool),
     IntValue(i64),
     DoubleValue(f64),
-    ArrayValue(ArrayValue),
-    KvListValue(KeyValueList),
+    RVArrayValue(RArrayValue),
+    KvListValue(RKeyValueList),
     BytesValue(Vec<u8>),
 }
 
 #[derive(Debug, Clone)]
-pub struct ArrayValue {
-    pub values: Arc<Mutex<Vec<Arc<Mutex<Option<AnyValue>>>>>>,
+pub struct RArrayValue {
+    pub values: Arc<Mutex<Vec<Arc<Mutex<Option<RAnyValue>>>>>>,
 }
 
 #[allow(deprecated)]
-impl ArrayValue {
+impl RArrayValue {
     pub(crate) fn convert_to_py(&self, py: Python) -> PyResult<PyObject> {
-        Ok(crate::py::PyArrayValue(self.values.clone()).into_py(py))
+        Ok(py::ArrayValue(self.values.clone()).into_py(py))
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct KeyValueList {
-    pub values: Arc<Mutex<Vec<KeyValue>>>,
+pub struct RKeyValueList {
+    pub values: Arc<Mutex<Vec<RKeyValue>>>,
 }
 
 #[allow(deprecated)]
-impl KeyValueList {
+impl RKeyValueList {
     pub(crate) fn convert_to_py(&self, py: Python) -> PyResult<PyObject> {
-        Ok(crate::py::PyKeyValueList(self.values.clone()).into_py(py))
+        Ok(py::KeyValueList(self.values.clone()).into_py(py))
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct KeyValue {
+pub struct RKeyValue {
     pub key: Arc<Mutex<String>>,
-    pub value: Arc<Mutex<Option<AnyValue>>>,
+    pub value: Arc<Mutex<Option<RAnyValue>>>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Resource {
-    pub attributes: Arc<Mutex<Vec<Arc<Mutex<KeyValue>>>>>,
+pub struct RResource {
+    pub attributes: Arc<Mutex<Vec<Arc<Mutex<RKeyValue>>>>>,
     pub dropped_attributes_count: Arc<Mutex<u32>>,
 }
 
 #[derive(Debug, Clone)]
-pub struct ResourceSpans {
-    pub resource: Arc<Mutex<Option<Resource>>>,
-    pub scope_spans: Arc<Mutex<Vec<Arc<Mutex<ScopeSpans>>>>>,
+pub struct RResourceSpans {
+    pub resource: Arc<Mutex<Option<RResource>>>,
+    pub scope_spans: Arc<Mutex<Vec<Arc<Mutex<RScopeSpans>>>>>,
     pub schema_url: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct ScopeSpans {
-    pub scope: Arc<Mutex<Option<InstrumentationScope>>>,
-    pub spans: Arc<Mutex<Vec<Arc<Mutex<Span>>>>>,
+pub struct RScopeSpans {
+    pub scope: Arc<Mutex<Option<RInstrumentationScope>>>,
+    pub spans: Arc<Mutex<Vec<Arc<Mutex<RSpan>>>>>,
     pub schema_url: String,
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct InstrumentationScope {
+pub struct RInstrumentationScope {
     pub name: String,
     pub version: String,
-    pub attributes: Arc<Mutex<Vec<KeyValue>>>,
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
     pub dropped_attributes_count: u32,
 }
 
 #[derive(Debug, Clone)]
-pub struct Span {
+pub struct RSpan {
     pub trace_id: Vec<u8>,
     pub span_id: Vec<u8>,
     pub trace_state: String,
@@ -96,32 +97,32 @@ pub struct Span {
     pub kind: i32,
     pub start_time_unix_nano: u64,
     pub end_time_unix_nano: u64,
-    pub attributes: Arc<Mutex<Vec<KeyValue>>>,
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
     pub dropped_attributes_count: u32,
-    pub events: Arc<Mutex<Vec<Arc<Mutex<Event>>>>>,
+    pub events: Arc<Mutex<Vec<Arc<Mutex<REvent>>>>>,
     pub dropped_events_count: u32,
-    pub links: Arc<Mutex<Vec<Arc<Mutex<Link>>>>>,
+    pub links: Arc<Mutex<Vec<Arc<Mutex<RLink>>>>>,
     pub dropped_links_count: u32,
-    pub status: Arc<Mutex<Option<Status>>>,
+    pub status: Arc<Mutex<Option<RStatus>>>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Event {
+pub struct REvent {
     pub time_unix_nano: u64,
     pub name: String,
-    pub attributes: Arc<Mutex<Vec<KeyValue>>>,
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
     pub dropped_attributes_count: u32,
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Status {
+pub struct RStatus {
     pub message: String,
     pub code: i32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[allow(dead_code)]
-pub enum StatusCode {
+pub enum RStatusCode {
     /// The default status.
     Unset = 0,
     /// The Span has been validated by an Application developer or Operator to
@@ -132,18 +133,18 @@ pub enum StatusCode {
 }
 
 #[derive(Debug, Clone)]
-pub struct Link {
+pub struct RLink {
     pub trace_id: Vec<u8>,
     pub span_id: Vec<u8>,
     pub trace_state: String,
-    pub attributes: Arc<Mutex<Vec<KeyValue>>>,
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
     pub dropped_attributes_count: u32,
     pub flags: u32,
 }
 
 pub fn register_processor(code: String, script: String, module: String) -> Result<(), BoxError> {
     PROCESSOR_INIT.call_once(|| {
-        pyo3::append_to_inittab!(rotel_python_processor_sdk);
+        pyo3::append_to_inittab!(rotel);
         pyo3::prepare_freethreaded_python();
     });
 
@@ -170,7 +171,7 @@ impl PythonProcessable for opentelemetry_proto::tonic::trace::v1::ResourceSpans 
     fn process(self, processor: &str) -> Self {
         let inner = otel_transform::transform(self);
         // Build the PyObject
-        let spans = PyResourceSpans {
+        let spans = ResourceSpans {
             resource: inner.resource.clone(),
             scope_spans: inner.scope_spans.clone(),
             schema_url: inner.schema_url.clone(),

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -1706,7 +1706,7 @@ impl LoggingStdout {
 
 // Python module definition
 #[pymodule]
-pub fn rotel(m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let open_telemetry_module = PyModule::new(m.py(), "open_telemetry")?;
     let trace_module = PyModule::new(open_telemetry_module.py(), "trace")?;
     let resource_module = PyModule::new(open_telemetry_module.py(), "resource")?;
@@ -1726,34 +1726,34 @@ pub fn rotel(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry", &open_telemetry_module)?;
+        .set_item("rotel_sdk.open_telemetry", &open_telemetry_module)?;
 
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry.trace", &trace_module)?;
+        .set_item("rotel_sdk.open_telemetry.trace", &trace_module)?;
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry.trace.v1", &trace_v1_module)?;
+        .set_item("rotel_sdk.open_telemetry.trace.v1", &trace_v1_module)?;
 
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry.resource", &resource_module)?;
+        .set_item("rotel_sdk.open_telemetry.resource", &resource_module)?;
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry.resource.v1", &resource_v1_module)?;
+        .set_item("rotel_sdk.open_telemetry.resource.v1", &resource_v1_module)?;
 
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry.common", &common_module)?;
+        .set_item("rotel_sdk.open_telemetry.common", &common_module)?;
     m.py()
         .import("sys")?
         .getattr("modules")?
-        .set_item("rotel.open_telemetry.common.v1", &common_v1_module)?;
+        .set_item("rotel_sdk.open_telemetry.common.v1", &common_v1_module)?;
 
     common_v1_module.add_class::<AnyValue>()?;
     common_v1_module.add_class::<ArrayValue>()?;
@@ -1787,7 +1787,7 @@ mod tests {
 
     pub fn initialize() {
         INIT.call_once(|| {
-            pyo3::append_to_inittab!(rotel);
+            pyo3::append_to_inittab!(rotel_sdk);
             pyo3::prepare_freethreaded_python();
         });
     }


### PR DESCRIPTION
Completes: STR-3259

This PR simplifies and clarifies the names on the Python SDK side, removing the `Py` prefix as well as organizes the python classes into a proper module hierarchy that has parity with the otel proto definitions. We now have...

```
rotel.open_telemetry.trace.v1
rotel.open_telemetry.common.v1
rotel.open_telemetry.resource.v1
```

On the Rust side we change our type names to add a `R` prefix.