### PR TITLE
Keep request body generic

### DIFF
--- a/src/exporters/datadog/api_request.rs
+++ b/src/exporters/datadog/api_request.rs
@@ -2,12 +2,12 @@
 
 use crate::exporters::datadog::types::pb::AgentPayload;
 use crate::exporters::http::request::{BaseRequestBuilder, RequestUri};
-use crate::exporters::http::types::Request;
 use bytes::Bytes;
 use flate2::Compression;
 use flate2::read::GzEncoder;
 use http::header::{CONTENT_ENCODING, CONTENT_TYPE};
-use http::{HeaderMap, HeaderValue};
+use http::{HeaderMap, HeaderValue, Request};
+use http_body_util::Full;
 use prost::Message;
 use std::error::Error;
 use std::io::Read;
@@ -21,7 +21,7 @@ fn build_url(endpoint: &url::Url, path: &str) -> url::Url {
 
 #[derive(Clone)]
 pub struct ApiRequestBuilder {
-    base: BaseRequestBuilder,
+    base: BaseRequestBuilder<Full<Bytes>>,
 }
 
 impl ApiRequestBuilder {
@@ -49,7 +49,7 @@ impl ApiRequestBuilder {
         Ok(s)
     }
 
-    pub fn build(&self, payload: AgentPayload) -> Result<Request, BoxError> {
+    pub fn build(&self, payload: AgentPayload) -> Result<Request<Full<Bytes>>, BoxError> {
         let mut buf = Vec::new();
         if let Err(e) = payload.encode(&mut buf) {
             // todo: We pass these on as errors which the final service immediately returns,

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -15,6 +15,7 @@ use crate::topology::flush_control::{FlushReceiver, conditional_flush};
 use bytes::Bytes;
 use flume::r#async::RecvStream;
 use futures::stream::FuturesUnordered;
+use http_body_util::Full;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use std::error::Error;
 use std::future::Future;
@@ -69,7 +70,7 @@ pub struct DatadogTraceExporter {
     encode_drain_max_time: Duration,
     export_drain_max_time: Duration,
     req_builder: RequestBuilder<ResourceSpans, Transformer>,
-    svc: TowerRetry<RetryPolicy<()>, Timeout<HttpClient<(), DatadogTraceDecoder>>>,
+    svc: TowerRetry<RetryPolicy<()>, Timeout<HttpClient<Full<Bytes>, (), DatadogTraceDecoder>>>,
     flush_receiver: Option<FlushReceiver>,
 }
 

--- a/src/exporters/datadog/request_builder.rs
+++ b/src/exporters/datadog/request_builder.rs
@@ -4,7 +4,9 @@ use crate::exporters::datadog::Region;
 use crate::exporters::datadog::api_request::ApiRequestBuilder;
 use crate::exporters::datadog::request_builder_mapper::BuildRequest;
 use crate::exporters::datadog::types::pb::AgentPayload;
-use crate::exporters::http::types::Request;
+use bytes::Bytes;
+use http::Request;
+use http_body_util::Full;
 use std::marker::PhantomData;
 use tower::BoxError;
 
@@ -52,7 +54,7 @@ impl<Resource, Transform> BuildRequest<Resource> for RequestBuilder<Resource, Tr
 where
     Transform: TransformPayload<Resource>,
 {
-    fn build(&self, input: Vec<Resource>) -> Result<Request, BoxError> {
+    fn build(&self, input: Vec<Resource>) -> Result<Request<Full<Bytes>>, BoxError> {
         let payload = self.transformer.transform(input);
 
         self.api_req_builder.build(payload)

--- a/src/exporters/http/grpc_client.rs
+++ b/src/exporters/http/grpc_client.rs
@@ -3,10 +3,11 @@
 use crate::exporters::http::client::{ConnectError, ResponseDecode, build_hyper_client};
 use crate::exporters::http::response::Response;
 use crate::exporters::http::tls::Config;
-use crate::exporters::http::types::{ContentEncoding, Request};
-use bytes::Bytes;
+use crate::exporters::http::types::ContentEncoding;
+use http::Request;
 use http::header::CONTENT_ENCODING;
-use http_body_util::{BodyExt, Full};
+use http_body_util::BodyExt;
+use hyper::body::Body;
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::client::legacy::connect::HttpConnector;
@@ -18,13 +19,17 @@ use tonic::Status;
 use tower::{BoxError, Service};
 
 #[derive(Clone)]
-pub struct GrpcClient<Resp, Dec> {
-    inner: HyperClient<HttpsConnector<HttpConnector>, Full<Bytes>>,
+pub struct GrpcClient<ReqBody, Resp, Dec> {
+    inner: HyperClient<HttpsConnector<HttpConnector>, ReqBody>,
     decoder: Dec,
     _phantom: PhantomData<Resp>,
 }
 
-impl<Resp, Dec> GrpcClient<Resp, Dec> {
+impl<ReqBody, Resp, Dec> GrpcClient<ReqBody, Resp, Dec>
+where
+    ReqBody: Body + Send,
+    <ReqBody as Body>::Data: Send,
+{
     #[allow(dead_code)]
     pub fn build(tls_config: Config, decoder: Dec) -> Result<Self, BoxError> {
         let inner = build_hyper_client(tls_config, false)?;
@@ -37,12 +42,15 @@ impl<Resp, Dec> GrpcClient<Resp, Dec> {
     }
 }
 
-impl<Resp, Dec> GrpcClient<Resp, Dec>
+impl<ReqBody, Resp, Dec> GrpcClient<ReqBody, Resp, Dec>
 where
+    ReqBody: Body + Send + 'static + Unpin,
+    <ReqBody as Body>::Data: Send,
+    <ReqBody as Body>::Error: Into<BoxError>,
     Dec: ResponseDecode<Resp> + Clone,
     Resp: Default,
 {
-    async fn perform_request(&self, req: Request) -> Result<Response<Resp>, BoxError> {
+    async fn perform_request(&self, req: Request<ReqBody>) -> Result<Response<Resp>, BoxError> {
         match self.inner.request(req).await {
             Err(e) => {
                 if e.is_connect() {
@@ -113,9 +121,12 @@ where
     }
 }
 
-impl<Resp, Dec> Service<Request> for GrpcClient<Resp, Dec>
+impl<ReqBody, Resp, Dec> Service<Request<ReqBody>> for GrpcClient<ReqBody, Resp, Dec>
 where
     Dec: ResponseDecode<Resp> + Send + Clone + Sync + 'static,
+    ReqBody: Body + Clone + Send + 'static + Unpin,
+    <ReqBody as Body>::Data: Send,
+    <ReqBody as Body>::Error: Into<BoxError>,
     Resp: Default + Send + Clone + Sync + 'static,
 {
     type Response = Response<Resp>;
@@ -126,7 +137,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: Request) -> Self::Future {
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         let this = self.clone();
 
         Box::pin(async move {

--- a/src/exporters/http/types.rs
+++ b/src/exporters/http/types.rs
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use bytes::Bytes;
 use http::HeaderValue;
-use http::request::Request as HttpRequest;
-use http_body_util::Full;
 use tower_http::BoxError;
-
-// Types for all http requests
-pub type Request = HttpRequest<Full<Bytes>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContentEncoding {


### PR DESCRIPTION
This refactors the (to be) shared http generic exporter to maintain a generic request body type. While the Datadog exporter just builds single chunk payload (`Full<Bytes>`), the Clickhouse protocol can use a chunked payload so we may implement the `Body` trait for a custom type.

Completes: STR-3316