### PR TITLE
Default to async inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,18 +128,24 @@ Specifying a custom endpoint will override the region selection.
 The Clickhouse exporter can be selected by passing `--exporter clickhouse`. The Clickhouse exporter only supports traces at the
 moment.
 
-| Option                             | Default | Options   |
-|------------------------------------|---------|-----------|
-| --clickhouse-exporter-endpoint     |         |           |
-| --clickhouse-exporter-database     | otel    |           |
-| --clickhouse-exporter-table-prefix | otel    |           |
-| --clickhouse-exporter-compression  | lz4     | none, lz4 |
-| --clickhouse-exporter-user         |         |           |
-| --clickhouse-exporter-password     |         |           |
+| Option                             | Default | Options     |
+|------------------------------------|---------|-------------|
+| --clickhouse-exporter-endpoint     |         |             |
+| --clickhouse-exporter-database     | otel    |             |
+| --clickhouse-exporter-table-prefix | otel    |             |
+| --clickhouse-exporter-compression  | lz4     | none, lz4   |
+| --clickhouse-exporter-async-insert | true    | true, false |
+| --clickhouse-exporter-user         |         |             |
+| --clickhouse-exporter-password     |         |             |
 
 The Clickhouse endpoint must be specified while all other options can be left as defaults. The table prefix is prefixed onto
 the specific telemetry table name with underscore, so a table prefix of `otel` will be combined with `_traces` to generate
 the full table name of `otel_traces`.
+
+The Clickhouse exporter will enable [async inserts](https://clickhouse.com/docs/optimize/asynchronous-inserts) by default,
+although it can be disabled server-side. Async inserts are
+recommended for most workloads to avoid overloading Clickhouse with many small inserts. Async inserts can be disabled by specifying:
+`--clickhouse-exporter-async-insert false`.
 
 The exporter will not generate the table schema if it does not exist. The [schema-migrate.sh](/contrib/clickhouse/schema-migrate.sh)
 script which is provided in this repo will output a Clickhouse schema that is supported by the exporter. It matches the

--- a/src/exporters/clickhouse/api_request.rs
+++ b/src/exporters/clickhouse/api_request.rs
@@ -18,6 +18,7 @@ impl ApiRequestBuilder {
         compression: Compression,
         auth_user: Option<String>,
         auth_password: Option<String>,
+        async_insert: bool,
     ) -> Result<Self, BoxError> {
         let full_url = construct_full_url(endpoint);
         let mut uri = Url::parse(full_url.as_str())?;
@@ -30,6 +31,9 @@ impl ApiRequestBuilder {
             pairs.append_pair("query", query.as_str());
             if compression == Compression::Lz4 {
                 pairs.append_pair("decompress", "1");
+            }
+            if async_insert {
+                pairs.append_pair("async_insert", "1");
             }
         }
 

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -78,6 +78,7 @@ pub struct ClickhouseExporterBuilder {
     table_prefix: String,
     auth_user: Option<String>,
     auth_password: Option<String>,
+    async_insert: bool,
 }
 
 impl ClickhouseExporterBuilder {
@@ -88,6 +89,11 @@ impl ClickhouseExporterBuilder {
 
     pub fn with_compression(mut self, compression: impl Into<Compression>) -> Self {
         self.compression = compression.into();
+        self
+    }
+    
+    pub fn with_async_insert(mut self, async_insert: bool) -> Self {
+        self.async_insert = async_insert;
         self
     }
 
@@ -117,6 +123,7 @@ impl ClickhouseExporterBuilder {
             self.compression.clone(),
             self.auth_user,
             self.auth_password,
+            self.async_insert,
         )?;
 
         let req_builder = RequestBuilder::new(transformer, api_req_builder)?;

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -91,7 +91,7 @@ impl ClickhouseExporterBuilder {
         self.compression = compression.into();
         self
     }
-    
+
     pub fn with_async_insert(mut self, async_insert: bool) -> Self {
         self.async_insert = async_insert;
         self

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -5,7 +5,7 @@ use crate::exporters::clickhouse::ClickhouseExporter;
 use crate::exporters::datadog::{DatadogTraceExporter, Region};
 use crate::exporters::otlp;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
-use crate::init::args::{parse_bool_value, AgentRun, DebugLogParam, Exporter};
+use crate::init::args::{AgentRun, DebugLogParam, Exporter, parse_bool_value};
 use crate::init::datadog_exporter::DatadogRegion;
 use crate::init::otlp_exporter::{
     build_logs_batch_config, build_logs_config, build_metrics_batch_config, build_metrics_config,
@@ -412,7 +412,8 @@ impl Agent {
                     return Err("must specify a Clickhouse exporter endpoint".into());
                 }
 
-                let async_insert = parse_bool_value(config.clickhouse_exporter.clickhouse_exporter_async_insert)?;
+                let async_insert =
+                    parse_bool_value(config.clickhouse_exporter.clickhouse_exporter_async_insert)?;
 
                 let mut builder = ClickhouseExporter::builder(
                     config

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -5,7 +5,7 @@ use crate::exporters::clickhouse::ClickhouseExporter;
 use crate::exporters::datadog::{DatadogTraceExporter, Region};
 use crate::exporters::otlp;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
-use crate::init::args::{AgentRun, DebugLogParam, Exporter};
+use crate::init::args::{parse_bool_value, AgentRun, DebugLogParam, Exporter};
 use crate::init::datadog_exporter::DatadogRegion;
 use crate::init::otlp_exporter::{
     build_logs_batch_config, build_logs_config, build_metrics_batch_config, build_metrics_config,
@@ -412,6 +412,8 @@ impl Agent {
                     return Err("must specify a Clickhouse exporter endpoint".into());
                 }
 
+                let async_insert = parse_bool_value(config.clickhouse_exporter.clickhouse_exporter_async_insert)?;
+
                 let mut builder = ClickhouseExporter::builder(
                     config
                         .clickhouse_exporter
@@ -421,7 +423,8 @@ impl Agent {
                     config.clickhouse_exporter.clickhouse_exporter_table_prefix,
                 )
                 .with_flush_receiver(self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()))
-                .with_compression(config.clickhouse_exporter.clickhouse_exporter_compression);
+                .with_compression(config.clickhouse_exporter.clickhouse_exporter_compression)
+                .with_async_insert(async_insert);
 
                 if let Some(user) = config.clickhouse_exporter.clickhouse_exporter_user {
                     builder = builder.with_user(user);

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -198,6 +198,6 @@ pub(crate) fn parse_bool_value(val: String) -> Result<bool, BoxError> {
     match val.to_lowercase().as_str() {
         "0" | "false" => Ok(false),
         "1" | "true" => Ok(true),
-        _ => Err(format!("Unable to parse bool value: {}", val).into())
+        _ => Err(format!("Unable to parse bool value: {}", val).into()),
     }
 }

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -4,6 +4,7 @@ use crate::init::otlp_exporter::OTLPExporterArgs;
 use clap::{Args, ValueEnum};
 use std::error::Error;
 use std::net::SocketAddr;
+use tower::BoxError;
 
 #[derive(Debug, Args, Clone)]
 pub struct AgentRun {
@@ -190,5 +191,13 @@ mod test {
         assert_ok!(sa);
         let sa = sa.unwrap();
         assert_eq!("0.0.0.0", sa.ip().to_string());
+    }
+}
+
+pub(crate) fn parse_bool_value(val: String) -> Result<bool, BoxError> {
+    match val.to_lowercase().as_str() {
+        "0" | "false" => Ok(false),
+        "1" | "true" => Ok(true),
+        _ => Err(format!("Unable to parse bool value: {}", val).into())
     }
 }

--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -35,6 +35,10 @@ pub struct ClickhouseExporterArgs {
     /// Clickhouse Exporter password
     #[arg(long, env = "ROTEL_CLICKHOUSE_EXPORTER_PASSWORD")]
     pub clickhouse_exporter_password: Option<String>,
+
+    /// Clickhouse Exporter async insert
+    #[arg(long, env = "ROTEL_CLICKHOUSE_EXPORTER_ASYNC_INSERT", default_value = "true")]
+    pub clickhouse_exporter_async_insert: String,
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -37,7 +37,11 @@ pub struct ClickhouseExporterArgs {
     pub clickhouse_exporter_password: Option<String>,
 
     /// Clickhouse Exporter async insert
-    #[arg(long, env = "ROTEL_CLICKHOUSE_EXPORTER_ASYNC_INSERT", default_value = "true")]
+    #[arg(
+        long,
+        env = "ROTEL_CLICKHOUSE_EXPORTER_ASYNC_INSERT",
+        default_value = "true"
+    )]
     pub clickhouse_exporter_async_insert: String,
 }
 


### PR DESCRIPTION
Default to [async inserts](https://clickhouse.com/docs/optimize/asynchronous-inserts), since that is often recommended to avoid many small inserts.

Completes: STR-3326