### PR TITLE
Generic batch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ The OTLP exporter is the default, or can be explicitly selected with `--exporter
 | --otlp-exporter-retry-initial-backoff  | 5s                   |                          |
 | --otlp-exporter-retry-max-backoff      | 30s                  |                          |
 | --otlp-exporter-retry-max-elapsed-time | 300s                 |                          |
-| --otlp-exporter-batch-max-size         | 8192                 |                          |
-| --otlp-exporter-batch-timeout          | 200ms                |                          |
 
 ### Datadog exporter configuration
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ schema used in the OpenTelemetry
 
 _The Clickhouse exporter is built using code from the official Rust [clickhouse-rs](https://crates.io/crates/clickhouse) crate._
 
+### Batch configuration
+
+You can configure the properties of the batch processor, controlling both the size limit of the batch and how long the batch
+is kept before flushing. The batch properties behave the same regardless of which exporter you use. You can override the
+batch settings specifically for a telemetry type by prefixing any of the options below with the telemetry type (metrics, logs,
+or traces). For example, `--traces-batch-max-size` will override the batch max size for traces only.
+
+| Option           | Default | Options     |
+|------------------|---------|-------------|
+| --batch-max-size | 8192    |             |
+| --batch-timeout  | 200ms   |             |
+
+
 ---
 
 **Notes**:

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -8,8 +8,8 @@ use crate::init::activation::{TelemetryActivation, TelemetryState};
 use crate::init::args::{AgentRun, DebugLogParam, Exporter, parse_bool_value};
 use crate::init::datadog_exporter::DatadogRegion;
 use crate::init::otlp_exporter::{
-    build_logs_batch_config, build_logs_config, build_metrics_batch_config, build_metrics_config,
-    build_traces_batch_config, build_traces_config,
+    build_logs_config, build_metrics_config,
+    build_traces_config,
 };
 #[cfg(feature = "pprof")]
 use crate::init::pprof;
@@ -39,6 +39,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::log::warn;
 use tracing::{debug, error, info};
+use crate::init::batch::{build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config};
 
 pub struct Agent {
     config: Box<AgentRun>,
@@ -212,7 +213,7 @@ impl Agent {
             trace_pipeline_in_rx.clone(),
             trace_pipeline_out_tx,
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_traces_batch_config(config.otlp_exporter.clone()),
+            build_traces_batch_config(config.batch.clone()),
             config.otlp_with_trace_processor.clone(),
         );
 
@@ -220,7 +221,7 @@ impl Agent {
             metrics_pipeline_in_rx.clone(),
             metrics_pipeline_out_tx,
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_metrics_batch_config(config.otlp_exporter.clone()),
+            build_metrics_batch_config(config.batch.clone()),
             vec![],
         );
 
@@ -228,7 +229,7 @@ impl Agent {
             logs_pipeline_in_rx.clone(),
             logs_pipeline_out_tx,
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_logs_batch_config(config.otlp_exporter.clone()),
+            build_logs_batch_config(config.batch.clone()),
             vec![],
         );
 
@@ -242,7 +243,7 @@ impl Agent {
             internal_metrics_pipeline_in_rx.clone(),
             internal_metrics_pipeline_out_tx,
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_metrics_batch_config(config.otlp_exporter.clone()),
+            build_metrics_batch_config(config.batch.clone()),
             vec![],
         );
 

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -6,11 +6,11 @@ use crate::exporters::datadog::{DatadogTraceExporter, Region};
 use crate::exporters::otlp;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
 use crate::init::args::{AgentRun, DebugLogParam, Exporter, parse_bool_value};
-use crate::init::datadog_exporter::DatadogRegion;
-use crate::init::otlp_exporter::{
-    build_logs_config, build_metrics_config,
-    build_traces_config,
+use crate::init::batch::{
+    build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config,
 };
+use crate::init::datadog_exporter::DatadogRegion;
+use crate::init::otlp_exporter::{build_logs_config, build_metrics_config, build_traces_config};
 #[cfg(feature = "pprof")]
 use crate::init::pprof;
 use crate::init::wait;
@@ -39,7 +39,6 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::log::warn;
 use tracing::{debug, error, info};
-use crate::init::batch::{build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config};
 
 pub struct Agent {
     config: Box<AgentRun>,

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -5,6 +5,7 @@ use clap::{Args, ValueEnum};
 use std::error::Error;
 use std::net::SocketAddr;
 use tower::BoxError;
+use crate::init::batch::BatchArgs;
 
 #[derive(Debug, Args, Clone)]
 pub struct AgentRun {
@@ -86,7 +87,10 @@ pub struct AgentRun {
 
     #[arg(long, env = "ROTEL_OTLP_WITH_TRACE_PROCESSOR", action = clap::ArgAction::Append)]
     pub otlp_with_trace_processor: Vec<String>,
-
+    
+    #[command(flatten)]
+    pub batch: BatchArgs,
+    
     /// Exporter
     #[arg(value_enum, long, env = "ROTEL_EXPORTER", default_value = "otlp")]
     pub exporter: Exporter,

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -1,3 +1,4 @@
+use crate::init::batch::BatchArgs;
 use crate::init::clickhouse_exporter::ClickhouseExporterArgs;
 use crate::init::datadog_exporter::DatadogExporterArgs;
 use crate::init::otlp_exporter::OTLPExporterArgs;
@@ -5,7 +6,6 @@ use clap::{Args, ValueEnum};
 use std::error::Error;
 use std::net::SocketAddr;
 use tower::BoxError;
-use crate::init::batch::BatchArgs;
 
 #[derive(Debug, Args, Clone)]
 pub struct AgentRun {
@@ -87,10 +87,10 @@ pub struct AgentRun {
 
     #[arg(long, env = "ROTEL_OTLP_WITH_TRACE_PROCESSOR", action = clap::ArgAction::Append)]
     pub otlp_with_trace_processor: Vec<String>,
-    
+
     #[command(flatten)]
     pub batch: BatchArgs,
-    
+
     /// Exporter
     #[arg(value_enum, long, env = "ROTEL_EXPORTER", default_value = "otlp")]
     pub exporter: Exporter,

--- a/src/init/batch.rs
+++ b/src/init/batch.rs
@@ -1,5 +1,5 @@
-use clap::Args;
 use crate::topology::batch::BatchConfig;
+use clap::Args;
 
 // Batch settings
 #[derive(Debug, Clone, Args)]
@@ -64,9 +64,7 @@ pub fn build_metrics_batch_config(config: BatchArgs) -> BatchConfig {
 
 pub fn build_logs_batch_config(config: BatchArgs) -> BatchConfig {
     BatchConfig {
-        max_size: config
-            .logs_batch_max_size
-            .unwrap_or(config.batch_max_size),
+        max_size: config.logs_batch_max_size.unwrap_or(config.batch_max_size),
         timeout: config
             .logs_batch_timeout
             .unwrap_or(config.batch_timeout)

--- a/src/init/batch.rs
+++ b/src/init/batch.rs
@@ -1,0 +1,75 @@
+use clap::Args;
+use crate::topology::batch::BatchConfig;
+
+// Batch settings
+#[derive(Debug, Clone, Args)]
+pub struct BatchArgs {
+    /// Batch size in number of spans/metrics - Used as default for all OTLP data types unless more specific flag specified.
+    #[arg(long, env = "ROTEL_BATCH_MAX_SIZE", default_value = "8192")]
+    pub batch_max_size: usize,
+
+    /// OTLP batch timeout - Used as default for all OTLP data types unless more specific flag specified.
+    #[arg(long, env = "ROTEL_BATCH_TIMEOUT", default_value = "200ms")]
+    pub batch_timeout: humantime::Duration,
+
+    /// OTLP traces max batch size in number of spans - Overrides batch_max_size for OTLP traces if specified.
+    #[arg(long, env = "ROTEL_TRACES_BATCH_MAX_SIZE")]
+    pub traces_batch_max_size: Option<usize>,
+
+    /// OTLP metrics max batch size in number of metrics - Overrides batch_max_size for OTLP metrics if specified.
+    #[arg(long, env = "ROTEL_METRICS_BATCH_MAX_SIZE")]
+    pub metrics_batch_max_size: Option<usize>,
+
+    /// OTLP logs max batch size in number of logs - Overrides batch_max_size for OTLP logs if specified.
+    #[arg(long, env = "ROTEL_LOGS_BATCH_MAX_SIZE")]
+    pub logs_batch_max_size: Option<usize>,
+
+    /// OTLP traces batch timeout - Overrides batch_timeout for OTLP traces if specified.
+    #[arg(long, env = "ROTEL_TRACES_BATCH_TIMEOUT")]
+    pub traces_batch_timeout: Option<humantime::Duration>,
+
+    /// OTLP metrics batch timeout - Overrides batch_timeout for OTLP metrics if specified.
+    #[arg(long, env = "ROTEL_METRICS_BATCH_TIMEOUT")]
+    pub metrics_batch_timeout: Option<humantime::Duration>,
+
+    /// OTLP logs batch timeout - Overrides batch_timeout for OTLP logs if specified.
+    #[arg(long, env = "ROTEL_LOGS_BATCH_TIMEOUT")]
+    pub logs_batch_timeout: Option<humantime::Duration>,
+}
+
+// todo: add these as impl functions of the exporter args?
+pub fn build_traces_batch_config(config: BatchArgs) -> BatchConfig {
+    BatchConfig {
+        max_size: config
+            .traces_batch_max_size
+            .unwrap_or(config.batch_max_size),
+        timeout: config
+            .traces_batch_timeout
+            .unwrap_or(config.batch_timeout)
+            .into(),
+    }
+}
+
+pub fn build_metrics_batch_config(config: BatchArgs) -> BatchConfig {
+    BatchConfig {
+        max_size: config
+            .metrics_batch_max_size
+            .unwrap_or(config.batch_max_size),
+        timeout: config
+            .metrics_batch_timeout
+            .unwrap_or(config.batch_timeout)
+            .into(),
+    }
+}
+
+pub fn build_logs_batch_config(config: BatchArgs) -> BatchConfig {
+    BatchConfig {
+        max_size: config
+            .logs_batch_max_size
+            .unwrap_or(config.batch_max_size),
+        timeout: config
+            .logs_batch_timeout
+            .unwrap_or(config.batch_timeout)
+            .into(),
+    }
+}

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -8,6 +8,6 @@ mod clickhouse_exporter;
 mod datadog_exporter;
 mod otlp_exporter;
 
+mod batch;
 #[cfg(feature = "pprof")]
 pub mod pprof;
-mod batch;

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -10,3 +10,4 @@ mod otlp_exporter;
 
 #[cfg(feature = "pprof")]
 pub mod pprof;
+mod batch;

--- a/src/init/otlp_exporter.rs
+++ b/src/init/otlp_exporter.rs
@@ -5,7 +5,6 @@ use crate::exporters::otlp::config::{
 use crate::exporters::otlp::{CompressionEncoding, Endpoint, Protocol};
 use crate::init::args;
 use crate::init::args::OTLPExporterProtocol;
-use crate::topology::batch::BatchConfig;
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct OTLPExporterArgs {
@@ -225,47 +224,6 @@ pub struct OTLPExporterArgs {
     /// OTLP Exporter logs Retry max elapsed time - Overrides otlp_exporter_retry_max_elapsed_time for OTLP logs if specified.
     #[arg(long, env = "ROTEL_OTLP_EXPORTER_LOGS_RETRY_MAX_ELAPSED_TIME")]
     pub otlp_exporter_logs_retry_max_elapsed_time: Option<humantime::Duration>,
-
-    // Batch settings
-    /// OTLP Exporter max batch size in number of spans/metrics - Used as default for all OTLP data types unless more specific flag specified.
-    #[arg(
-        long,
-        env = "ROTEL_OTLP_EXPORTER_BATCH_MAX_SIZE",
-        default_value = "8192"
-    )]
-    pub otlp_exporter_batch_max_size: usize,
-
-    /// OTLP Exporter traces max batch size in number of spans - Overrides otlp_exporter_batch_max_size for OTLP traces if specified.
-    #[arg(long, env = "ROTEL_OTLP_EXPORTER_TRACES_BATCH_MAX_SIZE")]
-    pub otlp_exporter_traces_batch_max_size: Option<usize>,
-
-    /// OTLP Exporter metrics max batch size in number of metrics - Overrides otlp_exporter_batch_max_size for OTLP metrics if specified.
-    #[arg(long, env = "ROTEL_OTLP_EXPORTER_METRICS_BATCH_MAX_SIZE")]
-    pub otlp_exporter_metrics_batch_max_size: Option<usize>,
-
-    /// OTLP Exporter logs max batch size in number of logs - Overrides otlp_exporter_batch_max_size for OTLP logs if specified.
-    #[arg(long, env = "ROTEL_OTLP_EXPORTER_LOGS_BATCH_MAX_SIZE")]
-    pub otlp_exporter_logs_batch_max_size: Option<usize>,
-
-    /// OTLP Exporter batch timeout - Used as default for all OTLP data types unless more specific flag specified.
-    #[arg(
-        long,
-        env = "ROTEL_OTLP_EXPORTER_BATCH_TIMEOUT",
-        default_value = "200ms"
-    )]
-    pub otlp_exporter_batch_timeout: humantime::Duration,
-
-    /// OTLP Exporter traces batch timeout - Overrides otlp_exporter_batch_timeout for OTLP traces if specified.
-    #[arg(long, env = "ROTEL_OTLP_EXPORTER_TRACES_BATCH_TIMEOUT")]
-    pub otlp_exporter_traces_batch_timeout: Option<humantime::Duration>,
-
-    /// OTLP Exporter metrics batch timeout - Overrides otlp_exporter_batch_timeout for OTLP metrics if specified.
-    #[arg(long, env = "ROTEL_OTLP_EXPORTER_METRICS_BATCH_TIMEOUT")]
-    pub otlp_exporter_metrics_batch_timeout: Option<humantime::Duration>,
-
-    /// OTLP Exporter logs batch timeout - Overrides otlp_exporter_batch_timeout for OTLP logs if specified.
-    #[arg(long, env = "ROTEL_OTLP_EXPORTER_LOGS_BATCH_TIMEOUT")]
-    pub otlp_exporter_logs_batch_timeout: Option<humantime::Duration>,
 }
 
 impl From<OTLPExporterProtocol> for Protocol {
@@ -395,43 +353,6 @@ pub struct LogsCaGroup {
 
     #[arg(long, env = "ROTEL_OTLP_EXPORTER_LOGS_TLS_CA_PEM", default_value = None)]
     otlp_exporter_logs_tls_ca_pem: Option<String>,
-}
-
-// todo: add these as impl functions of the exporter args?
-pub fn build_traces_batch_config(agent: OTLPExporterArgs) -> BatchConfig {
-    BatchConfig {
-        max_size: agent
-            .otlp_exporter_traces_batch_max_size
-            .unwrap_or(agent.otlp_exporter_batch_max_size),
-        timeout: agent
-            .otlp_exporter_traces_batch_timeout
-            .unwrap_or(agent.otlp_exporter_batch_timeout)
-            .into(),
-    }
-}
-
-pub fn build_metrics_batch_config(agent: OTLPExporterArgs) -> BatchConfig {
-    BatchConfig {
-        max_size: agent
-            .otlp_exporter_metrics_batch_max_size
-            .unwrap_or(agent.otlp_exporter_batch_max_size),
-        timeout: agent
-            .otlp_exporter_metrics_batch_timeout
-            .unwrap_or(agent.otlp_exporter_batch_timeout)
-            .into(),
-    }
-}
-
-pub fn build_logs_batch_config(agent: OTLPExporterArgs) -> BatchConfig {
-    BatchConfig {
-        max_size: agent
-            .otlp_exporter_logs_batch_max_size
-            .unwrap_or(agent.otlp_exporter_batch_max_size),
-        timeout: agent
-            .otlp_exporter_logs_batch_timeout
-            .unwrap_or(agent.otlp_exporter_batch_timeout)
-            .into(),
-    }
 }
 
 pub fn build_traces_config(


### PR DESCRIPTION
This pulls the batch config up from the OTLP exporter config, since we use the same batching config across exporters.

Completes: STR-3328