### PR TITLE
Don't log metrics failure on shutdown with CH exporter

### DIFF
--- a/src/telemetry/internal_exporter.rs
+++ b/src/telemetry/internal_exporter.rs
@@ -32,9 +32,7 @@ impl PushMetricExporter for InternalOTLPMetricsExporter {
             // So here we're using the main metrics OTLPOutput and that has a dependency on whether metrics have been disabled
             // at the receiver. So that means if metrics receiving is disabled for this rotel instance, so is the metrics pipeline.
             // However, we may want to special case that an allow a metrics pipeline to run but only for internal metrics.
-            None => Err(OTelSdkError::InternalFailure(
-                "metrics have been disabled".to_string(),
-            )),
+            None => Ok(()),
             Some(mo) => {
                 let req = ExportMetricsServiceRequest::from(&*metrics);
                 let res = mo.send(req.resource_metrics).await;


### PR DESCRIPTION
As explained by the comment here, we currently have a weird dependency between a functioning metrics pipeline and the internal metrics. For an exporter like Clickhouse, which doesn't currently have metrics support, we won't setup an output pipeline for internal metrics. However, if we return failure here then the MeterProvider shutdown fails and logs an error on shutdown:
```
ERROR  name="MeterProvider.Drop.ShutdownFailed" Shutdown attempt failed during drop of MeterProvider. reason="Operation failed: [InternalFailure(\"Failed to shutdown\")]"
```
Elide the error message for now by just dropping these metrics with success.

Completes: STR-3329