### PR TITLE
Match DB exceptions in response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.9",
+ "serde",
 ]
 
 [[package]]
@@ -2995,6 +2997,7 @@ dependencies = [
 name = "rotel"
 version = "0.0.1-alpha3"
 dependencies = [
+ "bstr",
  "bytes",
  "chrono",
  "cityhash-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.12"
 lz4_flex = "0.11.3"
 cityhash-rs = "1.0.1"
+bstr = "1.12.0"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/src/exporters/clickhouse/exception.rs
+++ b/src/exporters/clickhouse/exception.rs
@@ -1,0 +1,31 @@
+// From Clickhouse Rust lib
+
+use bstr::ByteSlice;
+use tower::BoxError;
+
+// Format:
+// ```
+//   <data>Code: <code>. DB::Exception: <desc> (version <version> (official build))\n
+// ```
+pub fn extract_exception(chunk: &[u8]) -> Option<BoxError> {
+    // `))\n` is very rare in real data, so it's fast dirty check.
+    // In random data, it occurs with a probability of ~6*10^-8 only.
+    if chunk.ends_with(b"))\n") {
+        extract_exception_slow(chunk)
+    } else {
+        None
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn extract_exception_slow(chunk: &[u8]) -> Option<BoxError> {
+    let index = chunk.rfind(b"Code:")?;
+
+    if !chunk[index..].contains_str(b"DB::Exception:") {
+        return None;
+    }
+
+    let exception = String::from_utf8_lossy(&chunk[index..chunk.len() - 1]);
+    Some(format!("ClickhouseExporter got a bad response: {}", exception).into())
+}


### PR DESCRIPTION
Even though the HTTP response may be a 200, it [can contain DB exceptions](https://clickhouse.com/docs/interfaces/http#http_response_codes_caveats) in the response body that indicates otherwise. Grab the matching code from the clickhouse rust lib and transform DB response exceptions into errors.

Completes: STR-3332