### PR TITLE
add support for __setitem__ on ArrayValue types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 utilities/target/
 tmp/
 target/
+.idea/
 rotel_python_processor_sdk/.env/
 rotel_python_processor_sdk/rotel_sdk/*.so
+rotel_python_processor_sdk/.idea

--- a/contrib/processor/tests/read_and_write_attributes_array_value_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_array_value_test.py
@@ -33,3 +33,13 @@ def process(resource):
 
     # Check len support
     assert 1 == len(resource.attributes[0].value.value)
+
+    # Now let's set and item directly on an index of the ArrayValue with __setitem__
+    new_any_value = AnyValue()
+    new_any_value.string_value = "qux"
+    resource.attributes[0].value.value.__setitem__(0, new_any_value)
+    assert resource.attributes[0].value.value[0].value == "qux"
+    # Set it again via index
+    new_any_value.int_value = 123456789
+    resource.attributes[0].value.value[0] = new_any_value
+    assert resource.attributes[0].value.value[0].value == 123456789


### PR DESCRIPTION
Completes: STR-3347

We're doing a sweep here through the traces SDK list types and adding __setitem__ support. More to follow on additional list types in future PRs. Check unit tests for additional details.