### PR TITLE
Add support for appending or updating Resource Attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1765,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1786,7 +1786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "is-terminal",
  "itoa",
  "log",
@@ -2382,7 +2382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -3018,6 +3018,7 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-rustls",
  "hyper-util",
+ "indexmap 2.9.0",
  "libc",
  "lz4_flex",
  "num_cpus",
@@ -3729,7 +3730,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ thiserror = "2.0.12"
 lz4_flex = "0.11.3"
 cityhash-rs = "1.0.1"
 bstr = "1.12.0"
+indexmap = "2.8.0"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ thiserror = "2.0.12"
 lz4_flex = "0.11.3"
 cityhash-rs = "1.0.1"
 bstr = "1.12.0"
-indexmap = "2.8.0"
+indexmap = "2.9.0"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -1,11 +1,11 @@
-use crate::bounded_channel::{bounded, BoundedReceiver};
+use crate::bounded_channel::{BoundedReceiver, bounded};
 use crate::crypto::init_crypto_provider;
 use crate::exporters::blackhole::BlackholeExporter;
 use crate::exporters::clickhouse::ClickhouseExporterBuilder;
 use crate::exporters::datadog::{DatadogTraceExporterBuilder, Region};
 use crate::exporters::otlp;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
-use crate::init::args::{parse_bool_value, AgentRun, DebugLogParam, Exporter};
+use crate::init::args::{AgentRun, DebugLogParam, Exporter, parse_bool_value};
 use crate::init::batch::{
     build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config,
 };
@@ -26,8 +26,8 @@ use opentelemetry::global;
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
-use opentelemetry_sdk::metrics::{PeriodicReader, Temporality};
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::{PeriodicReader, Temporality};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::error::Error;

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -1,11 +1,11 @@
-use crate::bounded_channel::{BoundedReceiver, bounded};
+use crate::bounded_channel::{bounded, BoundedReceiver};
 use crate::crypto::init_crypto_provider;
 use crate::exporters::blackhole::BlackholeExporter;
 use crate::exporters::clickhouse::ClickhouseExporterBuilder;
 use crate::exporters::datadog::{DatadogTraceExporterBuilder, Region};
 use crate::exporters::otlp;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
-use crate::init::args::{AgentRun, DebugLogParam, Exporter, parse_bool_value};
+use crate::init::args::{parse_bool_value, AgentRun, DebugLogParam, Exporter};
 use crate::init::batch::{
     build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config,
 };
@@ -26,8 +26,8 @@ use opentelemetry::global;
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
-use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, Temporality};
+use opentelemetry_sdk::Resource;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::error::Error;
@@ -214,6 +214,7 @@ impl Agent {
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
             build_traces_batch_config(config.batch.clone()),
             config.otlp_with_trace_processor.clone(),
+            config.otel_resource_attributes.clone(),
         );
 
         let mut metrics_pipeline = topology::generic_pipeline::Pipeline::new(
@@ -222,6 +223,7 @@ impl Agent {
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
             build_metrics_batch_config(config.batch.clone()),
             vec![],
+            config.otel_resource_attributes.clone(),
         );
 
         let mut logs_pipeline = topology::generic_pipeline::Pipeline::new(
@@ -230,6 +232,7 @@ impl Agent {
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
             build_logs_batch_config(config.batch.clone()),
             vec![],
+            config.otel_resource_attributes.clone(),
         );
 
         // Internal metrics
@@ -244,6 +247,7 @@ impl Agent {
             pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
             build_metrics_batch_config(config.batch.clone()),
             vec![],
+            config.otel_resource_attributes.clone(),
         );
 
         let internal_metrics_sdk_exporter =

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -88,6 +88,9 @@ pub struct AgentRun {
     #[arg(long, env = "ROTEL_OTLP_WITH_TRACE_PROCESSOR", action = clap::ArgAction::Append)]
     pub otlp_with_trace_processor: Vec<String>,
 
+    #[arg(long, env = "ROTEL_OTEL_RESOURCE_ATTRIBUTES", value_parser = parse_key_val::<String, String>, value_delimiter = ',')]
+    pub otel_resource_attributes: Vec<(String, String)>,
+
     #[command(flatten)]
     pub batch: BatchArgs,
 

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -268,8 +268,10 @@ where
                     // todo: expand support for observability or transforms
                     inspector.inspect(&items);
                     // If any resource attributes were provided on start, set or append them to the resources
-                    for item in &mut items {
-                        item.set_or_append_attributes(self.resource_attributes.clone())
+                    if !self.resource_attributes.is_empty() {
+                        for item in &mut items {
+                            item.set_or_append_attributes(self.resource_attributes.clone())
+                        }
                     }
                     for p in &processor_modules {
                        let mut new_items = Vec::new();

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -2,13 +2,16 @@
 
 use crate::bounded_channel::{BoundedReceiver, BoundedSender};
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
-use crate::topology::flush_control::{FlushReceiver, conditional_flush};
+use crate::topology::flush_control::{conditional_flush, FlushReceiver};
+use opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
+use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
 #[cfg(feature = "pyo3")]
-use rotel_sdk::model::{PythonProcessable, register_processor};
+use rotel_sdk::model::{register_processor, PythonProcessable};
 #[cfg(feature = "pyo3")]
 use std::env;
 use std::error::Error;
@@ -29,10 +32,79 @@ pub struct Pipeline<T> {
     batch_config: BatchConfig,
     processors: Vec<String>,
     flush_listener: Option<FlushReceiver>,
+    resource_attributes: Vec<KeyValue>,
 }
 
 pub trait Inspect<T> {
     fn inspect(&self, value: &[T]);
+}
+
+pub trait ResourceAttributeSettable {
+    fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>);
+}
+
+impl ResourceAttributeSettable for ResourceSpans {
+    fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>) {
+        let mut drop_count = 0;
+        if self.resource.is_some() {
+            for rs in self.resource.iter() {
+                drop_count = rs.dropped_attributes_count;
+            }
+        }
+        self.resource = Some(Resource {
+            attributes: build_attrs(&self.resource, attributes),
+            dropped_attributes_count: drop_count,
+        });
+    }
+}
+
+impl ResourceAttributeSettable for ResourceMetrics {
+    fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>) {
+        let mut drop_count = 0;
+        if self.resource.is_some() {
+            for rs in self.resource.iter() {
+                drop_count = rs.dropped_attributes_count;
+            }
+        }
+        self.resource = Some(Resource {
+            attributes: build_attrs(&self.resource, attributes),
+            dropped_attributes_count: drop_count,
+        });
+    }
+}
+
+impl ResourceAttributeSettable for ResourceLogs {
+    fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>) {
+        let mut drop_count = 0;
+        if self.resource.is_some() {
+            for rs in self.resource.iter() {
+                drop_count = rs.dropped_attributes_count;
+            }
+        }
+        self.resource = Some(Resource {
+            attributes: build_attrs(&self.resource, attributes),
+            dropped_attributes_count: drop_count,
+        });
+    }
+}
+
+pub fn build_attrs(resource: &Option<Resource>, attributes: Vec<KeyValue>) -> Vec<KeyValue> {
+    if resource.is_none() {
+        return attributes;
+    }
+    // Let's retain the order and create a map of keys to reduce the number of iterations required to find/replace an existing key
+    let mut map = indexmap::IndexMap::<String, KeyValue>::new();
+    // Yes there is only one, but we've already determined that we have one.
+    for res in resource.iter() {
+        for attr in res.attributes.iter() {
+            map.insert(attr.key.clone(), attr.clone());
+        }
+    }
+    // Now iterate the new attributes and see if we already have a key or not
+    for new_attr in attributes {
+        map.insert(new_attr.key.clone(), new_attr);
+    }
+    map.values().cloned().collect()
 }
 
 #[cfg(not(feature = "pyo3"))]
@@ -66,7 +138,7 @@ impl PythonProcessable for opentelemetry_proto::tonic::logs::v1::ResourceLogs {
 
 impl<T> Pipeline<T>
 where
-    T: BatchSizer + BatchSplittable + PythonProcessable,
+    T: BatchSizer + BatchSplittable + PythonProcessable + ResourceAttributeSettable,
     Vec<T>: Send,
 {
     pub fn new(
@@ -75,13 +147,25 @@ where
         flush_listener: Option<FlushReceiver>,
         batch_config: BatchConfig,
         processors: Vec<String>,
+        attributes: Vec<(String, String)>,
     ) -> Self {
+        let resource_attributes = attributes
+            .iter()
+            .map(|a| KeyValue {
+                key: a.0.clone(),
+                value: Some(AnyValue {
+                    value: Some(StringValue(a.1.clone())),
+                }),
+            })
+            .collect();
+
         Self {
             receiver,
             sender,
             flush_listener,
             batch_config,
             processors,
+            resource_attributes,
         }
     }
 
@@ -183,6 +267,10 @@ where
                     // invoke current middleware layer
                     // todo: expand support for observability or transforms
                     inspector.inspect(&items);
+                    // If any resource attributes were provided on start, set or append them to the resources
+                    for item in &mut items {
+                        item.set_or_append_attributes(self.resource_attributes.clone())
+                    }
                     for p in &processor_modules {
                        let mut new_items = Vec::new();
                        while !items.is_empty() {
@@ -441,5 +529,117 @@ impl BatchSplittable for ResourceLogs {
         rs.schema_url = self.schema_url.clone();
         rs.resource = rs.resource.clone();
         rs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use utilities::otlp::FakeOTLP;
+
+    #[test]
+    fn test_append_attributes() {
+        let new_attrs = vec![KeyValue {
+            key: "new.attr.key".to_string(),
+            value: Some(AnyValue {
+                value: Some(StringValue("new_attr_value".to_string())),
+            }),
+        }];
+
+        let mut trace_request = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let mut spans = trace_request.resource_spans.pop().unwrap();
+        spans.set_or_append_attributes(new_attrs.clone());
+        verify_attr_appended(spans.resource.unwrap().attributes, 7, 6);
+
+        let mut logs_request = FakeOTLP::logs_service_request_with_logs(1, 1);
+        let mut logs = logs_request.resource_logs.pop().unwrap();
+        logs.set_or_append_attributes(new_attrs.clone());
+        verify_attr_appended(logs.resource.unwrap().attributes, 7, 6);
+
+        let mut metrics_request = FakeOTLP::metrics_service_request_with_metrics(1, 1);
+        let mut metrics = metrics_request.resource_metrics.pop().unwrap();
+        metrics.set_or_append_attributes(new_attrs);
+        verify_attr_appended(metrics.resource.unwrap().attributes, 7, 6);
+    }
+
+    #[test]
+    fn test_append_attributes_no_resource() {
+        let new_attrs = vec![KeyValue {
+            key: "new.attr.key".to_string(),
+            value: Some(AnyValue {
+                value: Some(StringValue("new_attr_value".to_string())),
+            }),
+        }];
+
+        let mut trace_request = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let mut spans = trace_request.resource_spans.pop().unwrap();
+        spans.resource = None;
+        spans.set_or_append_attributes(new_attrs.clone());
+        verify_attr_appended(spans.resource.unwrap().attributes, 1, 0);
+
+        let mut logs_request = FakeOTLP::logs_service_request_with_logs(1, 1);
+        let mut logs = logs_request.resource_logs.pop().unwrap();
+        logs.resource = None;
+        logs.set_or_append_attributes(new_attrs.clone());
+        verify_attr_appended(logs.resource.unwrap().attributes, 1, 0);
+
+        let mut metrics_request = FakeOTLP::metrics_service_request_with_metrics(1, 1);
+        let mut metrics = metrics_request.resource_metrics.pop().unwrap();
+        metrics.resource = None;
+        metrics.set_or_append_attributes(new_attrs);
+        verify_attr_appended(metrics.resource.unwrap().attributes, 1, 0);
+    }
+
+    fn verify_attr_appended(mut attrs: Vec<KeyValue>, len: usize, idx: usize) {
+        assert_eq!(len, attrs.len());
+        let new_attr = attrs.remove(idx);
+        assert_eq!("new.attr.key", new_attr.key);
+        match new_attr.value.unwrap().value.unwrap() {
+            StringValue(v) => {
+                assert_eq!("new_attr_value", v);
+            }
+            _ => {
+                panic!("unexpected type for attribute value")
+            }
+        }
+    }
+
+    #[test]
+    fn test_update_attributes() {
+        let new_attrs = vec![KeyValue {
+            key: "service.name".to_string(),
+            value: Some(AnyValue {
+                value: Some(StringValue("overwritten_service_name".to_string())),
+            }),
+        }];
+
+        let mut trace_request = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let mut spans = trace_request.resource_spans.pop().unwrap();
+        spans.set_or_append_attributes(new_attrs.clone());
+        verify_attr_updated(spans.resource.unwrap().attributes);
+
+        let mut logs_request = FakeOTLP::logs_service_request_with_logs(1, 1);
+        let mut logs = logs_request.resource_logs.pop().unwrap();
+        logs.set_or_append_attributes(new_attrs.clone());
+        verify_attr_updated(logs.resource.unwrap().attributes);
+
+        let mut metrics_request = FakeOTLP::metrics_service_request_with_metrics(1, 1);
+        let mut metrics = metrics_request.resource_metrics.pop().unwrap();
+        metrics.set_or_append_attributes(new_attrs.clone());
+        verify_attr_updated(metrics.resource.unwrap().attributes);
+    }
+
+    fn verify_attr_updated(mut attrs: Vec<KeyValue>) {
+        assert_eq!(6, attrs.len());
+        let new_attr = attrs.remove(0);
+        assert_eq!("service.name", new_attr.key);
+        match new_attr.value.unwrap().value.unwrap() {
+            StringValue(v) => {
+                assert_eq!("overwritten_service_name", v);
+            }
+            _ => {
+                panic!("unexpected type for attribute value")
+            }
+        }
     }
 }

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -2,7 +2,7 @@
 
 use crate::bounded_channel::{BoundedReceiver, BoundedSender};
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
-use crate::topology::flush_control::{FlushReceiver, conditional_flush};
+use crate::topology::flush_control::{conditional_flush, FlushReceiver};
 use opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
@@ -11,7 +11,7 @@ use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
 #[cfg(feature = "pyo3")]
-use rotel_sdk::model::{PythonProcessable, register_processor};
+use rotel_sdk::model::{register_processor, PythonProcessable};
 #[cfg(feature = "pyo3")]
 use std::env;
 use std::error::Error;
@@ -46,10 +46,8 @@ pub trait ResourceAttributeSettable {
 impl ResourceAttributeSettable for ResourceSpans {
     fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>) {
         let mut drop_count = 0;
-        if self.resource.is_some() {
-            for rs in self.resource.iter() {
-                drop_count = rs.dropped_attributes_count;
-            }
+        if let Some(rs) = &self.resource {
+            drop_count = rs.dropped_attributes_count;
         }
         self.resource = Some(Resource {
             attributes: build_attrs(&self.resource, attributes),
@@ -61,10 +59,8 @@ impl ResourceAttributeSettable for ResourceSpans {
 impl ResourceAttributeSettable for ResourceMetrics {
     fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>) {
         let mut drop_count = 0;
-        if self.resource.is_some() {
-            for rs in self.resource.iter() {
-                drop_count = rs.dropped_attributes_count;
-            }
+        if let Some(rs) = &self.resource {
+            drop_count = rs.dropped_attributes_count;
         }
         self.resource = Some(Resource {
             attributes: build_attrs(&self.resource, attributes),
@@ -76,10 +72,8 @@ impl ResourceAttributeSettable for ResourceMetrics {
 impl ResourceAttributeSettable for ResourceLogs {
     fn set_or_append_attributes(&mut self, attributes: Vec<KeyValue>) {
         let mut drop_count = 0;
-        if self.resource.is_some() {
-            for rs in self.resource.iter() {
-                drop_count = rs.dropped_attributes_count;
-            }
+        if let Some(rs) = &self.resource {
+            drop_count = rs.dropped_attributes_count;
         }
         self.resource = Some(Resource {
             attributes: build_attrs(&self.resource, attributes),

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -2,7 +2,7 @@
 
 use crate::bounded_channel::{BoundedReceiver, BoundedSender};
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
-use crate::topology::flush_control::{conditional_flush, FlushReceiver};
+use crate::topology::flush_control::{FlushReceiver, conditional_flush};
 use opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
@@ -11,7 +11,7 @@ use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
 #[cfg(feature = "pyo3")]
-use rotel_sdk::model::{register_processor, PythonProcessable};
+use rotel_sdk::model::{PythonProcessable, register_processor};
 #[cfg(feature = "pyo3")]
 use std::env;
 use std::error::Error;


### PR DESCRIPTION
Completes: STR-3349

Adds support for appending and overwriting OTLP Resource attributes via the cli and environment. In addition to unit tests, end-to-end tests were completed with load tester for both appending and updating existing attributes.