### PR TITLE
Add remaning support for __setitem__ on list types for OTel traces

### DIFF
--- a/contrib/processor/tests/read_and_write_attributes_key_value_list_test.py
+++ b/contrib/processor/tests/read_and_write_attributes_key_value_list_test.py
@@ -33,3 +33,9 @@ def process(resource):
 
     # Check len support
     assert 1 == len(resource.attributes[0].value.value)
+
+    # Perform a set on kv list
+    new_kv = KeyValue.new_int_value("int_key", 100)
+    new_key_value_list[0] = new_kv
+    av = new_key_value_list[0]
+    assert av.value.value == 100

--- a/contrib/processor/tests/read_and_write_spans_test.py
+++ b/contrib/processor/tests/read_and_write_spans_test.py
@@ -54,8 +54,6 @@ def process(resource_spans):
 
     span.attributes.append(KeyValue.new_string_value("span_attr_key", "span_attr_value"))
     span.dropped_attributes_count = 100
-    # TODO add events
-    # span.events
     span.dropped_links_count = 300
     span.dropped_events_count = 200
     # Append a new link
@@ -78,3 +76,8 @@ def process(resource_spans):
     event.name = "py_processed_event"
     event.attributes.append(KeyValue.new_string_value("event_attr_key", "event_attr_value"))
     event.dropped_attributes_count = 400
+
+    # Set a new attribute on the spans attribute list
+    span.attributes[2] = KeyValue.new_string_value("span_attr_key2", "span_attr_value2")
+    assert span.attributes[2].key == "span_attr_key2"
+    assert span.attributes[2].value.value == "span_attr_value2"

--- a/contrib/processor/tests/resource_attributes_set_attributes.py
+++ b/contrib/processor/tests/resource_attributes_set_attributes.py
@@ -11,3 +11,17 @@ def process(resource):
     new_attributes.append(KeyValue.new_string_value("os.name", os_name))
     new_attributes.append(KeyValue.new_string_value("os.version", os_version))
     resource.attributes = new_attributes
+    # Get the attributes and check their values
+    assert len(resource.attributes) == 2
+    first_attr = resource.attributes[0]
+    assert first_attr.key == "os.name"
+    assert first_attr.value.value != ""
+    second_attr = resource.attributes[1]
+    assert second_attr.key == "os.version"
+    assert second_attr.value.value != ""
+    # Now perform a set operation on the attributes
+    kv = KeyValue.new_double_value("double.value", 3.14)
+    resource.attributes[0] = kv
+    get_kv = resource.attributes[0]
+    assert get_kv.key == "double.value"
+    assert get_kv.value.value == 3.14

--- a/contrib/processor/tests/set_scope_spans_span_test.py
+++ b/contrib/processor/tests/set_scope_spans_span_test.py
@@ -1,0 +1,47 @@
+from rotel_sdk.open_telemetry.common.v1 import KeyValue
+from rotel_sdk.open_telemetry.trace.v1 import Span, Status, StatusCode, Event, Link
+
+
+def process(resource_spans):
+    span = Span()
+    span.trace_id = b"5555555555"
+    span.span_id = b"6666666666"
+    span.trace_state = "test=1234567890"
+    span.parent_span_id = b"7777777777"
+    span.flags = 1
+    span.name = "py_processed_span"
+    span.kind = 4  # producer
+    span.start_time_unix_nano = 1234567890
+    span.end_time_unix_nano = 1234567890
+    span.dropped_attributes_count = 100
+    span.dropped_events_count = 200
+    span.dropped_links_count = 300
+    span.attributes.append(KeyValue.new_string_value("span_attr_key", "span_attr_value"))
+
+    status = Status()
+    status.code = StatusCode.Error
+    status.message = "error message"
+    span.status = status
+
+    event = Event()
+    event.time_unix_nano = 1234567890
+    event.name = "py_processed_event"
+    event.attributes.append(KeyValue.new_string_value("event_attr_key", "event_attr_value"))
+    event.dropped_attributes_count = 400
+    # Push a dummy event and test setting our new event by index.
+    # We need to append here as current len of events is 0
+    span.events.append(Event())
+    span.events[0] = event
+
+    new_link = Link()
+    new_link.trace_id = b"88888888"
+    new_link.span_id = b"99999999"
+    new_link.trace_state = "test=1234567890"
+    new_link.attributes.append(KeyValue.new_string_value("link_attr_key", "link_attr_value"))
+    new_link.dropped_attributes_count = 300
+    new_link.flags = 1
+    # Same thing here, push a dummy and then test setting our new link by index.
+    span.links.append(Link())
+    span.links[0] = new_link
+
+    resource_spans.scope_spans[0].spans[0] = span

--- a/contrib/processor/tests/write_scope_spans_test.py
+++ b/contrib/processor/tests/write_scope_spans_test.py
@@ -28,3 +28,27 @@ def process(resource_spans):
 
     scope_spans_list.append(scope_spans)
     resource_spans.scope_spans = scope_spans_list
+    # Get the scope spans list
+    scope_spans_list = resource_spans.scope_spans
+    assert len(scope_spans_list) == 1
+    ss = scope_spans_list[0]
+    assert ss.scope.name == "rotel-sdk"
+    assert len(ss.spans) == 1
+    assert ss.spans[0].name == "py_processed_span"
+    new_scope_spans = ScopeSpans()
+    # Copy the span out c
+    new_scope_spans.schema_url = "https://github.com/streamfold/rotel"
+    inst_scope = InstrumentationScope()
+    inst_scope.name = "rotel-sdk-new"
+    inst_scope.version = "v1.0.1"
+    inst_scope.attributes.append(KeyValue.new_string_value("rotel-sdk", "v1.0.0"))
+    new_scope_spans.scope = inst_scope
+    new_scope_spans.spans.append(ss.spans[0])
+    resource_spans.scope_spans[0] = new_scope_spans
+
+    scope_spans_list = resource_spans.scope_spans
+    assert len(scope_spans_list) == 1
+    ss = scope_spans_list[0]
+    assert ss.scope.name == "rotel-sdk-new"
+    assert len(ss.spans) == 1
+    assert ss.spans[0].name == "py_processed_span"


### PR DESCRIPTION
Completes: STR-3273

Following up on adding support for assigning to list types via index/subscript. Changes include KeyValueLists, AttributesLists, ScopeSpansList, Spans, Links, and Events.

