### PR TITLE
Add flag to disable batching

### DIFF
--- a/src/init/batch.rs
+++ b/src/init/batch.rs
@@ -35,6 +35,10 @@ pub struct BatchArgs {
     /// OTLP logs batch timeout - Overrides batch_timeout for OTLP logs if specified.
     #[arg(long, env = "ROTEL_LOGS_BATCH_TIMEOUT")]
     pub logs_batch_timeout: Option<humantime::Duration>,
+
+    /// Disable batching, incoming messages are immediately exported (not recommended)
+    #[arg(long, env = "ROTEL_DISABLE_BATCHING", default_value = "false")]
+    pub disable_batching: bool,
 }
 
 // todo: add these as impl functions of the exporter args?
@@ -47,6 +51,7 @@ pub fn build_traces_batch_config(config: BatchArgs) -> BatchConfig {
             .traces_batch_timeout
             .unwrap_or(config.batch_timeout)
             .into(),
+        disabled: config.disable_batching,
     }
 }
 
@@ -59,6 +64,7 @@ pub fn build_metrics_batch_config(config: BatchArgs) -> BatchConfig {
             .metrics_batch_timeout
             .unwrap_or(config.batch_timeout)
             .into(),
+        disabled: config.disable_batching,
     }
 }
 
@@ -69,5 +75,6 @@ pub fn build_logs_batch_config(config: BatchArgs) -> BatchConfig {
             .logs_batch_timeout
             .unwrap_or(config.batch_timeout)
             .into(),
+        disabled: config.disable_batching,
     }
 }

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -195,8 +195,11 @@ where
         inspector: impl Inspect<T>,
         pipeline_token: CancellationToken,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        let mut batch =
-            NestedBatch::<T>::new(self.batch_config.max_size, self.batch_config.timeout);
+        let mut batch = NestedBatch::<T>::new(
+            self.batch_config.max_size,
+            self.batch_config.timeout,
+            self.batch_config.disabled,
+        );
 
         let mut batch_timeout = batch.get_timeout();
         if batch_timeout.is_zero() {

--- a/src/topology/pipeline.rs
+++ b/src/topology/pipeline.rs
@@ -59,11 +59,13 @@ impl Pipeline {
         let mut traces_batch = NestedBatch::<ResourceSpans>::new(
             self.batch_config.max_size,
             self.batch_config.timeout,
+            self.batch_config.disabled,
         );
 
         let mut metrics_batch = NestedBatch::<ResourceMetrics>::new(
             self.batch_config.max_size,
             self.batch_config.timeout,
+            self.batch_config.disabled,
         );
 
         let mut batch_timer = tokio::time::interval(self.batch_config.timeout);


### PR DESCRIPTION
Add an option `--disable-batching` to disable batching entirely. This is being added for compatibility with OTEL collector in certain testing scenarios. I haven't added it to the README config section, because I don't believe it should be a recommended option. Maybe could be added to a reference section in the future.

Completes: STR-3366