### PR TITLE
Drop to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             os: ubuntu
             cross: false
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             os: ubuntu
             cross: false
           - target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             os: ubuntu
             cross: false
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             os: ubuntu
             cross: false
           - target: aarch64-apple-darwin


### PR DESCRIPTION
Dropping this to Ubuntu 22.04 to reduce the GLIBC version dependency. We'll measure any performance difference, but this should provide a larger window of compatibility.

Completes: STR-3369