### PR TITLE
Complete __delitem__ support for collection types for Traces and Logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
 name = "rotel_python_processor_sdk"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "opentelemetry-proto",
  "pyo3",
  "pyo3-stub-gen",

--- a/contrib/processor/tests/traces_delitem_test.py
+++ b/contrib/processor/tests/traces_delitem_test.py
@@ -21,3 +21,11 @@ def process(resource_spans: ResourceSpans):
             if arlist is not None:
                 arlist = cast(ArrayValue, arlist)
                 del arlist[1]
+
+    del resource_spans.scope_spans[1]
+    del resource_spans.scope_spans[0].spans[1]
+
+    span = resource_spans.scope_spans[0].spans[0]
+    del span.events[0]
+    del span.links[0]
+

--- a/contrib/processor/tests/traces_delitem_test.py
+++ b/contrib/processor/tests/traces_delitem_test.py
@@ -1,0 +1,23 @@
+from rotel_sdk.open_telemetry.common.v1 import KeyValueList, ArrayValue
+from rotel_sdk.open_telemetry.trace.v1 import ResourceSpans
+from typing import cast
+
+
+def process(resource_spans: ResourceSpans):
+    if resource_spans.resource is not None:
+        resource = resource_spans.resource
+        del resource.attributes[2]
+
+        # Remove from the KeyValueList which is the first element
+        if resource.attributes[0].value is not None:
+            kvlist = resource.attributes[0].value.value
+            if kvlist is not None:
+                kvlist = cast(KeyValueList, kvlist)
+                del kvlist[0]
+            
+        # Remove from the ArrayList which is the second element
+        if resource.attributes[1].value is not None:
+            arlist = resource.attributes[1].value.value
+            if arlist is not None:
+                arlist = cast(ArrayValue, arlist)
+                del arlist[1]

--- a/rotel_python_processor_sdk/Cargo.lock
+++ b/rotel_python_processor_sdk/Cargo.lock
@@ -936,6 +936,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 name = "rotel_python_processor_sdk"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "opentelemetry-proto",
  "pyo3",
  "pyo3-stub-gen",

--- a/rotel_python_processor_sdk/Cargo.toml
+++ b/rotel_python_processor_sdk/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1"
 tracing-log = "0.2.0"
 pyo3-stub-gen = "0.7.0"
 pyo3-stub-gen-derive = "0.7.0"
+chrono = "0.4.40"
 
 [lib]
 # The name of the native library. This is the name which will be used in Python to import the

--- a/rotel_python_processor_sdk/src/model/py_transform.rs
+++ b/rotel_python_processor_sdk/src/model/py_transform.rs
@@ -291,10 +291,10 @@ pub fn convert_value(v: RAnyValue) -> opentelemetry_proto::tonic::common::v1::An
         RVArrayValue(a) => {
             let mut values = vec![];
             let inner_values = Arc::into_inner(a.values).unwrap();
-            let inner_values = inner_values.into_inner().unwrap();
-            // TODO: We might need to remove these from the vec?
-            for v in inner_values.iter() {
-                let inner_v = Arc::into_inner(v.clone()).unwrap();
+            let mut inner_values = inner_values.into_inner().unwrap();
+            while !inner_values.is_empty() {
+                let inner_v = inner_values.pop().expect("inner value should not be none");
+                let inner_v = Arc::into_inner(inner_v).unwrap();
                 let inner_v = inner_v.into_inner().unwrap();
                 if inner_v.is_none() {
                     values.push(opentelemetry_proto::tonic::common::v1::AnyValue { value: None })

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -4301,5 +4301,21 @@ mod tests {
                 panic!("exected ArrayValue");
             }
         }
+
+        // Verify the second scope span has been removed
+        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_spans_vec = crate::model::py_transform::transform_spans(scope_spans_vec);
+        assert_eq!(1, scope_spans_vec.len());
+        let scope_spans = scope_spans_vec.remove(0);
+        let mut spans = scope_spans.spans;
+        assert_eq!(1, spans.len());
+        let span = spans.remove(0);
+        assert_eq!(1, span.events.len());
+        assert_eq!(span.events[0].name, "second test event");
+        assert_eq!(1, span.links.len());
+        assert_eq!(span.links[0].trace_state, "secondtrace=00f067aa0ba902b7")
     }
 }

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -196,6 +196,18 @@ impl ArrayValue {
         inner[index] = value.inner.clone();
         Ok(())
     }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
     fn append(&self, item: &AnyValue) -> PyResult<()> {
         let mut k = self.0.lock().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
@@ -270,6 +282,18 @@ impl KeyValueList {
         }
         let v = value.inner.lock().unwrap();
         inner[index] = v.clone();
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
         Ok(())
     }
     fn __len__(&self) -> PyResult<usize> {
@@ -560,6 +584,18 @@ impl Attributes {
         inner[index] = value.inner.clone();
         Ok(())
     }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
     fn append<'py>(&self, item: &KeyValue) -> PyResult<()> {
         let mut k = self.0.lock().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
@@ -721,6 +757,18 @@ impl ScopeSpansList {
             spans: value.spans.clone(),
             schema_url: value.schema_url.clone(),
         }));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
         Ok(())
     }
     fn __len__(&self) -> PyResult<usize> {
@@ -1023,6 +1071,18 @@ impl AttributesList {
         };
         Ok(())
     }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
     fn append<'py>(&self, item: &KeyValue) -> PyResult<()> {
         let mut k = self.0.lock().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
@@ -1112,6 +1172,18 @@ impl Spans {
             ));
         }
         inner[index] = value.inner.clone();
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
         Ok(())
     }
     fn append(&self, item: &Span) -> PyResult<()> {
@@ -1542,6 +1614,18 @@ impl Events {
         inner[index] = value.inner.clone();
         Ok(())
     }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
     fn __len__(&self) -> PyResult<usize> {
         let inner = self.0.lock().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
@@ -1705,6 +1789,18 @@ impl Links {
             ));
         }
         inner[index] = value.inner.clone();
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
         Ok(())
     }
     fn append<'py>(&self, item: &Link) -> PyResult<()> {
@@ -2083,7 +2179,18 @@ impl ScopeLogsList {
         }));
         Ok(())
     }
-
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")
+        })?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
     fn __len__(&self) -> PyResult<usize> {
         let inner = self.0.lock().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Failed to lock mutex")


### PR DESCRIPTION
Completes: STR-3380

This PR adds support for deleting items from collection types for OTel traces and logs to satisfy filtering use cases. 