### PR TITLE
Add type hints for custom collection types

### DIFF
--- a/rotel_python_processor_sdk/pyproject-dist.toml
+++ b/rotel_python_processor_sdk/pyproject-dist.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rotel_sdk"
-version = "0.0.1a6"
+version = "0.0.1a7"
 authors = [
     { name = "Ray Jenkins", email = "ray@streamfold.com" },
     { name = "Michael Heffner", email = "mike@streamfold.com" },

--- a/rotel_python_processor_sdk/rotel_sdk/open_telemetry/common/v1/__init__.pyi
+++ b/rotel_python_processor_sdk/rotel_sdk/open_telemetry/common/v1/__init__.pyi
@@ -75,6 +75,24 @@ class ArrayValue:
     Appends a value to this array.
     """
 
+    def __delitem__(self, index: int) -> None: ...
+
+    """
+    Removes an item from this list.
+    """
+
+    def __getitem__(self, index: int) -> AnyValue: ...
+
+    """
+    Retrieves an item from this list.
+    """
+
+    def __setitem__(self, index: int, value: AnyValue) -> None: ...
+
+    """
+    Sets an item in this list.
+    """
+
 
 class KeyValueList:
     """
@@ -85,6 +103,24 @@ class KeyValueList:
 
     """
     Appends a KeyValue object to this list.
+    """
+
+    def __delitem__(self, index: int) -> None: ...
+
+    """
+    Removes an item from this list.
+    """
+
+    def __getitem__(self, index: int) -> KeyValue: ...
+
+    """
+    Retrieves an item from this list.
+    """
+
+    def __setitem__(self, index: int, value: KeyValue) -> None: ...
+
+    """
+    Sets an item in this list.
     """
 
 


### PR DESCRIPTION
Completes: STR-3401

The OTel spec includes some custom collection types that we've modeled in Python for the SDK. This PR adds type hints for getting/setting and deleting from those collection types. After this lands we'll push the latest a7 version of the sdk.