### PR TITLE
Fix float bug for python 3.10 processor releases

### DIFF
--- a/.github/workflows/processor-release.yml
+++ b/.github/workflows/processor-release.yml
@@ -17,7 +17,7 @@ jobs:
             runner: ubuntu-22.04
             os: ubuntu
             cross: false
-            python-version: 3.10
+            python-version: "3.10"
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
@@ -37,7 +37,7 @@ jobs:
             runner: ubuntu-22.04-arm
             os: ubuntu
             cross: false
-            python-version: 3.10
+            python-version: "3.10"
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu


### PR DESCRIPTION
There is a bug in github actions which rounds 3.10 to 3.1 and this resulted in processor releases for libpython 3.10 being named with a prefix 3.1, rather than 3.10 in alpha14. This change resolves that naming issue.