### PR TITLE
Support Cloudwatch OTLP log/traces with Sigv4 auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,6 +2975,7 @@ dependencies = [
  "pyo3",
  "rand 0.8.5",
  "read-restrict",
+ "regex",
  "rotel_python_processor_sdk",
  "rustls",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ bstr = "1.12.0"
 indexmap = "2.9.0"
 hmac = "0.12"
 sha2 = "0.10"
+regex = "1.11.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The OTLP exporter is the default, or can be explicitly selected with `--exporter
 | --otlp-exporter-protocol               | grpc    | grpc, http |
 | --otlp-exporter-custom-headers         |         |            |
 | --otlp-exporter-compression            | gzip    | gzip, none |
+| --otlp-exporter-authenticator          |         | sigv4auth  |
 | --otlp-exporter-tls-cert-file          |         |            |
 | --otlp-exporter-tls-cert-pem           |         |            |
 | --otlp-exporter-tls-key-file           |         |            |
@@ -120,6 +121,42 @@ The OTLP exporter is the default, or can be explicitly selected with `--exporter
 Any of the options that start with `--otlp-exporter*` can be set per telemetry type: metrics, traces or logs. For
 example, to set a custom endpoint to export traces to, set: `--otlp-exporter-traces-endpoint`. For other telemetry
 types their value falls back to the top-level OTLP exporter config.
+
+#### Cloudwatch OTLP Export
+
+The Rotel OTLP exporter can export to the
+[Cloudwatch OTLP endpoints](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html)
+for traces and logs. You'll need to select the HTTP protocol and enable the sigv4auth authenticator.
+
+The sigv4auth authenticator require the AWS environment variables for authentication are set.
+
+**Traces**
+
+_Tracing requires that you enable [Transaction Search](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Transaction-Search.html)
+in the AWS console before you can send OTLP traces._
+
+Here is the full environment variable configuration to send traces to Cloudwatch, swap the region code as needed. 
+```shell
+ROTEL_EXPORTER=otlp
+ROTEL_OTLP_EXPORTER_PROTOCOL=http
+ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://xray.<region code>.amazonaws.com/v1/traces
+ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
+```
+
+**Logs**
+
+_To send OTLP logs to Cloudwatch you must create a log group and log stream. Exporting will fail if these do not exist
+ahead of time and they are not created by default._
+
+Here is the full environment variable configuration to send logs to Cloudwatch, swap the region code and
+log group/stream as needed.
+```shell
+ROTEL_EXPORTER=otlp
+ROTEL_OTLP_EXPORTER_PROTOCOL=http
+ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://logs.<region code>.amazonaws.com/v1/logs
+ROTEL_OTLP_EXPORTER_LOGS_CUSTOM_HEADERS=x-aws-log-group=<log group>,x-aws-log-stream=<log stream>
+ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
+```
 
 ### Datadog exporter configuration
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The Rotel OTLP exporter can export to the
 [Cloudwatch OTLP endpoints](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html)
 for traces and logs. You'll need to select the HTTP protocol and enable the sigv4auth authenticator.
 
-The sigv4auth authenticator require the AWS environment variables for authentication are set.
+The sigv4auth authenticator requires the AWS authentication environment variables to be set.
 
 **Traces**
 
@@ -154,7 +154,7 @@ log group/stream as needed.
 ROTEL_EXPORTER=otlp
 ROTEL_OTLP_EXPORTER_PROTOCOL=http
 ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT=https://logs.<region code>.amazonaws.com/v1/logs
-ROTEL_OTLP_EXPORTER_LOGS_CUSTOM_HEADERS=x-aws-log-group=<log group>,x-aws-log-stream=<log stream>
+ROTEL_OTLP_EXPORTER_LOGS_CUSTOM_HEADERS="x-aws-log-group=<log group>,x-aws-log-stream=<log stream>"
 ROTEL_OTLP_EXPORTER_AUTHENTICATOR=sigv4auth
 ```
 

--- a/src/aws_api/auth.rs
+++ b/src/aws_api/auth.rs
@@ -61,7 +61,7 @@ where
         uri: Uri,
         method: Method,
         headers: HeaderMap,
-        payload: Vec<u8>,
+        payload: Bytes,
     ) -> Result<Request<Full<Bytes>>, Error> {
         let now = self.clock.now();
 
@@ -279,10 +279,9 @@ mod tests {
             .unwrap();
         let method = Method::GET;
         let headers = HeaderMap::new();
-        let payload = Vec::new(); // Empty payload for GET request
 
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer.sign(uri, method, headers, Bytes::new()).unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);
@@ -312,10 +311,9 @@ mod tests {
             .unwrap();
         let method = Method::GET;
         let headers = HeaderMap::new();
-        let payload = Vec::new();
 
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer.sign(uri, method, headers, Bytes::new()).unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);
@@ -341,10 +339,9 @@ mod tests {
             .unwrap();
         let method = Method::GET;
         let headers = HeaderMap::new();
-        let payload = Vec::new();
 
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer.sign(uri, method, headers, Bytes::new()).unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);
@@ -377,7 +374,9 @@ mod tests {
         let payload = b"Hello, world!".to_vec();
 
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer
+            .sign(uri, method, headers, Bytes::from(payload))
+            .unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);
@@ -409,10 +408,8 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(HOST, "custom-host.com".parse().unwrap());
 
-        let payload = Vec::new();
-
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer.sign(uri, method, headers, Bytes::new()).unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);
@@ -446,7 +443,9 @@ mod tests {
         let payload = b"test-payload".to_vec();
 
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer
+            .sign(uri, method, headers, Bytes::from(payload))
+            .unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);
@@ -479,10 +478,9 @@ mod tests {
             .unwrap();
         let method = Method::GET;
         let headers = HeaderMap::new();
-        let payload = Vec::new();
 
         // Act
-        let signed_request = signer.sign(uri, method, headers, payload).unwrap();
+        let signed_request = signer.sign(uri, method, headers, Bytes::new()).unwrap();
 
         // Assert
         let headers = extract_headers(&signed_request);

--- a/src/aws_api/host.rs
+++ b/src/aws_api/host.rs
@@ -1,0 +1,52 @@
+use regex::Regex;
+
+#[derive(Debug, PartialEq)]
+pub struct AwsService {
+    pub service: String,
+    pub region: String,
+}
+
+pub fn parse_aws_hostname(hostname: &str) -> Option<AwsService> {
+    // Pattern to match: service.region.amazonaws.com
+    let re = Regex::new(r"^([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.amazonaws\.com$").unwrap();
+
+    if let Some(caps) = re.captures(hostname) {
+        Some(AwsService {
+            service: caps[1].to_string(),
+            region: caps[2].to_string(),
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_hostnames() {
+        assert_eq!(
+            parse_aws_hostname("logs.us-west-2.amazonaws.com"),
+            Some(AwsService {
+                service: "logs".to_string(),
+                region: "us-west-2".to_string(),
+            })
+        );
+
+        assert_eq!(
+            parse_aws_hostname("xray.us-west-2.amazonaws.com"),
+            Some(AwsService {
+                service: "xray".to_string(),
+                region: "us-west-2".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_invalid_hostnames() {
+        assert_eq!(parse_aws_hostname("invalid-hostname.com"), None);
+        assert_eq!(parse_aws_hostname("not.amazonaws.com"), None);
+        assert_eq!(parse_aws_hostname("service.amazonaws.com"), None);
+    }
+}

--- a/src/aws_api/host.rs
+++ b/src/aws_api/host.rs
@@ -10,14 +10,10 @@ pub fn parse_aws_hostname(hostname: &str) -> Option<AwsService> {
     // Pattern to match: service.region.amazonaws.com
     let re = Regex::new(r"^([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.amazonaws\.com$").unwrap();
 
-    if let Some(caps) = re.captures(hostname) {
-        Some(AwsService {
-            service: caps[1].to_string(),
-            region: caps[2].to_string(),
-        })
-    } else {
-        None
-    }
+    re.captures(hostname).map(|caps| AwsService {
+        service: caps[1].to_string(),
+        region: caps[2].to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/src/aws_api/mod.rs
+++ b/src/aws_api/mod.rs
@@ -2,6 +2,7 @@ pub mod arn;
 pub(crate) mod auth;
 pub mod config;
 mod error;
+pub mod host;
 
 pub const SECRETS_MANAGER_SERVICE: &str = "secretsmanager";
 pub const PARAM_STORE_SERVICE: &str = "ssm";

--- a/src/exporters/otlp/config.rs
+++ b/src/exporters/otlp/config.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::exporters::http::tls::{Config, ConfigBuilder};
-use crate::exporters::otlp::{CompressionEncoding, DEFAULT_REQUEST_TIMEOUT, Endpoint, Protocol};
+use crate::exporters::otlp::{
+    Authenticator, CompressionEncoding, DEFAULT_REQUEST_TIMEOUT, Endpoint, Protocol,
+};
 use crate::exporters::retry::RetryConfig;
 use std::time::Duration;
 
@@ -15,6 +17,7 @@ pub struct OTLPExporterConfig {
     pub(crate) type_name: String,
     pub(crate) endpoint: Endpoint,
     pub(crate) protocol: Protocol,
+    pub(crate) authenticator: Option<Authenticator>,
     pub(crate) headers: Vec<(String, String)>,
     pub(crate) compression: Option<CompressionEncoding>,
     pub(crate) retry_config: RetryConfig,
@@ -30,6 +33,7 @@ impl Default for OTLPExporterConfig {
             type_name: "".to_string(),
             endpoint: Endpoint::Base("".to_string()),
             protocol: Protocol::Grpc,
+            authenticator: None,
             headers: vec![],
             tls_cfg_builder: Config::builder(),
             compression: Some(CompressionEncoding::Gzip),
@@ -42,6 +46,11 @@ impl Default for OTLPExporterConfig {
 }
 
 impl OTLPExporterConfig {
+    pub fn with_authenticator(mut self, authenticator: Option<Authenticator>) -> Self {
+        self.authenticator = authenticator;
+        self
+    }
+
     pub fn with_cert_file(mut self, cert_file: &str) -> Self {
         self.tls_cfg_builder = self.tls_cfg_builder.with_cert_file(cert_file.to_string());
         self

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -1077,7 +1077,12 @@ mod tests {
 
     // Wait for a msg to be sent, returns None if it was unable to deliver
     async fn send_test_msg(
-        mut traces: Exporter<ResourceSpans, ExportTraceServiceRequest, ExportTraceServiceResponse>,
+        mut traces: Exporter<
+            ResourceSpans,
+            ExportTraceServiceRequest,
+            AwsSigv4RequestSigner,
+            ExportTraceServiceResponse,
+        >,
         btx: BoundedSender<Vec<ResourceSpans>>,
         server_rx: &mut tokio::sync::mpsc::Receiver<()>,
     ) -> Option<()> {
@@ -1109,7 +1114,12 @@ mod tests {
     }
 
     async fn send_test_traces_msgs_and_stop(
-        traces: Exporter<ResourceSpans, ExportTraceServiceRequest, ExportTraceServiceResponse>,
+        traces: Exporter<
+            ResourceSpans,
+            ExportTraceServiceRequest,
+            AwsSigv4RequestSigner,
+            ExportTraceServiceResponse,
+        >,
         btx: BoundedSender<Vec<ResourceSpans>>,
         how_many: usize,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod errors;
 mod client;
 mod grpc_codec;
 mod http_codec;
+mod signer;
 
 use crate::exporters::otlp::config::OTLPExporterConfig;
 use clap::ValueEnum;
@@ -62,11 +63,17 @@ pub enum CompressionEncoding {
     None,
 }
 
-/// Transport protocols supported for OTLP export
+/// Transport protocols supported for OTLP exporter
 #[derive(Clone, Debug, PartialEq)]
 pub enum Protocol {
     Grpc,
     Http,
+}
+
+/// Authenticator for OTLP exporter
+#[derive(Clone, Debug, PartialEq)]
+pub enum Authenticator {
+    Sigv4auth,
 }
 
 /// OTLP endpoint configuration
@@ -170,6 +177,7 @@ mod tests {
     use crate::exporters::crypto_init_tests::init_crypto;
     use crate::exporters::otlp;
     use crate::exporters::otlp::exporter::Exporter;
+    use crate::exporters::otlp::signer::AwsSigv4RequestSigner;
     use crate::topology::flush_control::FlushBroadcast;
     use opentelemetry_proto::tonic::collector::logs::v1::logs_service_client::LogsServiceClient;
     use opentelemetry_proto::tonic::collector::logs::v1::logs_service_server::{
@@ -1117,6 +1125,7 @@ mod tests {
         metrics: Exporter<
             ResourceMetrics,
             ExportMetricsServiceRequest,
+            AwsSigv4RequestSigner,
             ExportMetricsServiceResponse,
         >,
         btx: BoundedSender<Vec<ResourceMetrics>>,
@@ -1131,7 +1140,12 @@ mod tests {
     }
 
     async fn send_test_logs_msg_and_stop(
-        logs: Exporter<ResourceLogs, ExportLogsServiceRequest, ExportLogsServiceResponse>,
+        logs: Exporter<
+            ResourceLogs,
+            ExportLogsServiceRequest,
+            AwsSigv4RequestSigner,
+            ExportLogsServiceResponse,
+        >,
         btx: BoundedSender<Vec<ResourceLogs>>,
         how_many: usize,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -1144,7 +1158,12 @@ mod tests {
     }
 
     async fn send_test_trace_and_stop(
-        mut traces: Exporter<ResourceSpans, ExportTraceServiceRequest, ExportTraceServiceResponse>,
+        mut traces: Exporter<
+            ResourceSpans,
+            ExportTraceServiceRequest,
+            AwsSigv4RequestSigner,
+            ExportTraceServiceResponse,
+        >,
         payloads: Vec<Vec<ResourceSpans>>,
         btx: BoundedSender<Vec<ResourceSpans>>,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -1171,6 +1190,7 @@ mod tests {
         mut metrics: Exporter<
             ResourceMetrics,
             ExportMetricsServiceRequest,
+            AwsSigv4RequestSigner,
             ExportMetricsServiceResponse,
         >,
         payloads: Vec<Vec<ResourceMetrics>>,
@@ -1196,7 +1216,12 @@ mod tests {
     }
 
     async fn send_test_logs_and_stop(
-        mut logs: Exporter<ResourceLogs, ExportLogsServiceRequest, ExportLogsServiceResponse>,
+        mut logs: Exporter<
+            ResourceLogs,
+            ExportLogsServiceRequest,
+            AwsSigv4RequestSigner,
+            ExportLogsServiceResponse,
+        >,
         payloads: Vec<Vec<ResourceLogs>>,
         btx: BoundedSender<Vec<ResourceLogs>>,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {

--- a/src/exporters/otlp/request.rs
+++ b/src/exporters/otlp/request.rs
@@ -50,7 +50,7 @@ const LOGS_RELATIVE_HTTP_PATH: &str = "v1/logs";
 #[derive(Clone)]
 pub struct RequestBuilder<T, Signer>
 where
-    Signer: std::clone::Clone,
+    Signer: Clone,
 {
     config: RequestBuilderConfig,
     _phantom: PhantomData<T>,

--- a/src/exporters/otlp/signer.rs
+++ b/src/exporters/otlp/signer.rs
@@ -1,0 +1,69 @@
+use crate::aws_api::auth::{AwsRequestSigner, SystemClock};
+use crate::aws_api::config::AwsConfig;
+use crate::aws_api::host::parse_aws_hostname;
+use bytes::Bytes;
+use http::{HeaderMap, Method, Request, Uri};
+use http_body_util::Full;
+use tower::BoxError;
+
+pub trait RequestSigner {
+    fn sign(
+        &self,
+        uri: &str,
+        method: Method,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<Request<Full<Bytes>>, BoxError>;
+}
+
+#[derive(Clone)]
+pub struct AwsSigv4RequestSigner {
+    config: AwsConfig,
+}
+
+impl AwsSigv4RequestSigner {
+    pub fn new(config: AwsConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl RequestSigner for AwsSigv4RequestSigner {
+    fn sign(
+        &self,
+        uri: &str,
+        method: Method,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<Request<Full<Bytes>>, BoxError> {
+        let uri_parse = match uri.parse::<Uri>() {
+            Ok(u) => u,
+            Err(_) => {
+                return Err(format!("unable to parse signing host from uri: {}", uri).into());
+            }
+        };
+
+        let host = match uri_parse.host() {
+            None => return Err(format!("unable to find host in signing uri: {}", uri).into()),
+            Some(h) => h,
+        };
+
+        let svc = match parse_aws_hostname(host) {
+            None => return Err(format!("unable to match AWS host in signing uri: {}", host).into()),
+            Some(svc) => svc,
+        };
+
+        let signer = AwsRequestSigner::new(
+            &svc.service,
+            &svc.region,
+            &self.config.aws_access_key_id,
+            &self.config.aws_secret_access_key,
+            self.config.aws_session_token.as_deref(),
+            SystemClock {},
+        );
+
+        match signer.sign(uri_parse, method, headers, body) {
+            Ok(req) => Ok(req),
+            Err(e) => Err(format!("unable to sign request: {}", e).into()),
+        }
+    }
+}

--- a/src/exporters/xray/xray_request.rs
+++ b/src/exporters/xray/xray_request.rs
@@ -71,13 +71,15 @@ impl<'a> XRayRequestBuilder<'a> {
 
         let data = json!({
         "TraceSegmentDocuments": segment_strings
-        });
+        })
+        .to_string();
+        let data = Bytes::from(data.into_bytes());
 
         let signed_request = self.signer.sign(
             self.uri.clone(),
             Method::POST,
             self.base_headers.clone(),
-            data.to_string().into_bytes(),
+            data,
         );
         match signed_request {
             Ok(r) => Ok(r),

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -1,3 +1,4 @@
+use crate::exporters::otlp::Authenticator;
 use crate::init::batch::BatchArgs;
 use crate::init::clickhouse_exporter::ClickhouseExporterArgs;
 use crate::init::datadog_exporter::DatadogExporterArgs;
@@ -136,6 +137,19 @@ pub enum DebugLogParam {
 pub enum OTLPExporterProtocol {
     Grpc,
     Http,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
+pub enum OTLPExporterAuthenticator {
+    Sigv4auth,
+}
+
+impl From<OTLPExporterAuthenticator> for Authenticator {
+    fn from(value: OTLPExporterAuthenticator) -> Self {
+        match value {
+            OTLPExporterAuthenticator::Sigv4auth => Authenticator::Sigv4auth,
+        }
+    }
 }
 
 #[derive(Debug, clap::Args)]

--- a/src/init/otlp_exporter.rs
+++ b/src/init/otlp_exporter.rs
@@ -4,7 +4,7 @@ use crate::exporters::otlp::config::{
 };
 use crate::exporters::otlp::{CompressionEncoding, Endpoint, Protocol};
 use crate::init::args;
-use crate::init::args::OTLPExporterProtocol;
+use crate::init::args::{OTLPExporterAuthenticator, OTLPExporterProtocol};
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct OTLPExporterArgs {
@@ -44,6 +44,10 @@ pub struct OTLPExporterArgs {
     /// OTLP Exporter Logs Protocol - Overrides otlp_exporter_protocol if specified
     #[arg(value_enum, long, env = "ROTEL_OTLP_EXPORTER_LOGS_PROTOCOL")]
     pub otlp_exporter_logs_protocol: Option<OTLPExporterProtocol>,
+
+    /// OTLP Exporter authenticator
+    #[arg(value_enum, long, env = "ROTEL_OTLP_EXPORTER_AUTHENTICATOR")]
+    pub otlp_exporter_authenticator: Option<OTLPExporterAuthenticator>,
 
     /// OTLP Exporter Headers - Used as default for all OTLP data types unless more specific flag specified
     #[arg(long, env = "ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS", value_parser = args::parse_key_val::<String, String>, value_delimiter = ','
@@ -369,6 +373,7 @@ pub fn build_traces_config(
             .unwrap_or(agent.otlp_exporter_protocol)
             .into(),
     )
+    .with_authenticator(agent.otlp_exporter_authenticator.map(|a| a.into()))
     .with_tls_skip_verify(
         agent
             .otlp_exporter_traces_tls_skip_verify
@@ -480,6 +485,7 @@ pub fn build_metrics_config(
             .unwrap_or(agent.otlp_exporter_protocol)
             .into(),
     )
+    .with_authenticator(agent.otlp_exporter_authenticator.map(|a| a.into()))
     .with_tls_skip_verify(
         agent
             .otlp_exporter_metrics_tls_skip_verify
@@ -591,6 +597,7 @@ pub fn build_logs_config(
             .unwrap_or(agent.otlp_exporter_protocol)
             .into(),
     )
+    .with_authenticator(agent.otlp_exporter_authenticator.map(|a| a.into()))
     .with_tls_skip_verify(
         agent
             .otlp_exporter_logs_tls_skip_verify


### PR DESCRIPTION
This adds support for signing OTLP exporter requests with the AWS sigv4 auth signing code. This enables Rotel to export OTLP logs and traces to Cloudwatch via the [OTLP endpoints](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html). This enables an alternative to the AWS X-ray support and may provide a more complete integration since service binding/interpretation can be done on the AWS service side.

I tested with the Rotel Lambda integration and I see AWS specific (eg DDB) trace spans/service maps.

Completes: STR-3426