### PR TITLE
Fix pipeline flush error and handle non-blocking flush

### DIFF
--- a/src/exporters/http/exporter.rs
+++ b/src/exporters/http/exporter.rs
@@ -1,12 +1,13 @@
 use crate::topology::flush_control::{FlushReceiver, conditional_flush};
 use futures_util::stream::FuturesUnordered;
-use futures_util::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt, poll};
 use http::Request;
 use std::error::Error;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Add;
 use std::pin::Pin;
+use std::task::Poll;
 use std::time::Duration;
 use tokio::time::{Instant, timeout_at};
 use tokio::{pin, select};
@@ -125,7 +126,7 @@ where
                             debug!(?meta, request = ?req, "Received force flush in exporter");
 
                             if let Err(res) = drain_futures(&meta, &mut input, &mut export_futures, self.encode_drain_max_time
-                                , self.export_drain_max_time, &mut self.svc).await {
+                                , self.export_drain_max_time, &mut self.svc, true).await {
 
                                 warn!(?meta, result = res, "Unable to drain exporter");
                             }
@@ -152,6 +153,7 @@ where
             self.encode_drain_max_time,
             self.export_drain_max_time,
             &mut self.svc,
+            false,
         )
         .await
     }
@@ -164,6 +166,7 @@ async fn drain_futures<InStr, Svc, Payload>(
     encode_drain_max_time: Duration,
     export_drain_max_time: Duration,
     svc: &mut Svc,
+    non_blocking: bool,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>>
 where
     InStr: Stream<Item = Result<Request<Payload>, BoxError>>,
@@ -173,8 +176,42 @@ where
     let finish_encoding = Instant::now().add(encode_drain_max_time);
     let finish_sending = Instant::now().add(export_drain_max_time);
 
+    // If non-blocking, we must poll at least once to force any messages into the encoding futures
+    // list. This allows us to do the size check later, knowing that if there was a pending msg
+    // it would have been added to the encoding futures.
+    if non_blocking {
+        match poll!(enc_stream.next()) {
+            Poll::Ready(None) => {
+                return drain_exports::<Svc, Payload>(
+                    finish_sending,
+                    export_futures,
+                    meta,
+                    non_blocking,
+                )
+                .await;
+            }
+            Poll::Ready(Some(res)) => match res {
+                Ok(req) => export_futures.push(Box::pin(svc.call(req))),
+                Err(e) => {
+                    error!(error = ?e, ?meta, "Failed to encode request, dropping.");
+                }
+            },
+            _ => {}
+        }
+    }
+
     // First we must wait on currently encoding futures
     loop {
+        // If we are non-blocking, then we only block up to the timeout if there are
+        // encoding futures pending. Use the size hint on the stream to check remaining
+        // encoding futures and skip waiting if it is empty.
+        if non_blocking {
+            let (min_sz, _) = enc_stream.size_hint();
+            if min_sz == 0 {
+                break;
+            }
+        }
+
         let poll_res = timeout_at(finish_encoding, enc_stream.next()).await;
         match poll_res {
             Err(_) => {
@@ -192,6 +229,19 @@ where
         }
     }
 
+    drain_exports::<Svc, Payload>(finish_sending, export_futures, meta, non_blocking).await
+}
+
+async fn drain_exports<Svc, Payload>(
+    finish_sending: Instant,
+    export_futures: &mut FuturesUnordered<ExportFuture<<Svc as Service<Request<Payload>>>::Future>>,
+    meta: &Meta,
+    non_blocking: bool,
+) -> Result<(), Box<dyn Error + Send + Sync + 'static>>
+where
+    <Svc as Service<Request<Payload>>>::Error: Debug,
+    Svc: Service<Request<Payload>>,
+{
     let mut drain_errors = 0;
     loop {
         if export_futures.is_empty() {

--- a/src/exporters/http/exporter.rs
+++ b/src/exporters/http/exporter.rs
@@ -182,13 +182,7 @@ where
     if non_blocking {
         match poll!(enc_stream.next()) {
             Poll::Ready(None) => {
-                return drain_exports::<Svc, Payload>(
-                    finish_sending,
-                    export_futures,
-                    meta,
-                    non_blocking,
-                )
-                .await;
+                return drain_exports::<Svc, Payload>(finish_sending, export_futures, meta).await;
             }
             Poll::Ready(Some(res)) => match res {
                 Ok(req) => export_futures.push(Box::pin(svc.call(req))),
@@ -229,14 +223,13 @@ where
         }
     }
 
-    drain_exports::<Svc, Payload>(finish_sending, export_futures, meta, non_blocking).await
+    drain_exports::<Svc, Payload>(finish_sending, export_futures, meta).await
 }
 
 async fn drain_exports<Svc, Payload>(
     finish_sending: Instant,
     export_futures: &mut FuturesUnordered<ExportFuture<<Svc as Service<Request<Payload>>>::Future>>,
     meta: &Meta,
-    non_blocking: bool,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>>
 where
     <Svc as Service<Request<Payload>>>::Error: Debug,

--- a/src/exporters/http/request_builder_mapper.rs
+++ b/src/exporters/http/request_builder_mapper.rs
@@ -92,4 +92,8 @@ where
             },
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.encoding_futures.len(), None)
+    }
 }

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -222,33 +222,6 @@ impl Agent {
             );
             trace_batch_config.max_size = 50;
         }
-        //
-        // let mut trace_pipeline = topology::generic_pipeline::Pipeline::new(
-        //     trace_pipeline_in_rx.clone(),
-        //     trace_pipeline_out_tx,
-        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-        //     trace_batch_config,
-        //     config.otlp_with_trace_processor.clone(),
-        //     config.otel_resource_attributes.clone(),
-        // );
-        //
-        // let mut metrics_pipeline = topology::generic_pipeline::Pipeline::new(
-        //     metrics_pipeline_in_rx.clone(),
-        //     metrics_pipeline_out_tx,
-        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-        //     build_metrics_batch_config(config.batch.clone()),
-        //     vec![],
-        //     config.otel_resource_attributes.clone(),
-        // );
-        //
-        // let mut logs_pipeline = topology::generic_pipeline::Pipeline::new(
-        //     logs_pipeline_in_rx.clone(),
-        //     logs_pipeline_out_tx,
-        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-        //     build_logs_batch_config(config.batch.clone()),
-        //     config.otlp_with_logs_processor.clone(),
-        //     config.otel_resource_attributes.clone(),
-        // );
 
         // Internal metrics
         // N.B Internal metrics initialization MUST be done before starting other parts of the agent such as
@@ -256,14 +229,6 @@ impl Agent {
         // create instruments such as counters, etc. Be careful when refactoring this code to avoid breaking
         // this dependency.
         //
-        // let mut internal_metrics_pipeline = topology::generic_pipeline::Pipeline::new(
-        //     internal_metrics_pipeline_in_rx.clone(),
-        //     internal_metrics_pipeline_out_tx,
-        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-        //     build_metrics_batch_config(config.batch.clone()),
-        //     vec![],
-        //     config.otel_resource_attributes.clone(),
-        // );
 
         let internal_metrics_sdk_exporter =
             telemetry::internal_exporter::InternalOTLPMetricsExporter::new(

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -222,48 +222,48 @@ impl Agent {
             );
             trace_batch_config.max_size = 50;
         }
-
-        let mut trace_pipeline = topology::generic_pipeline::Pipeline::new(
-            trace_pipeline_in_rx.clone(),
-            trace_pipeline_out_tx,
-            pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            trace_batch_config,
-            config.otlp_with_trace_processor.clone(),
-            config.otel_resource_attributes.clone(),
-        );
-
-        let mut metrics_pipeline = topology::generic_pipeline::Pipeline::new(
-            metrics_pipeline_in_rx.clone(),
-            metrics_pipeline_out_tx,
-            pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_metrics_batch_config(config.batch.clone()),
-            vec![],
-            config.otel_resource_attributes.clone(),
-        );
-
-        let mut logs_pipeline = topology::generic_pipeline::Pipeline::new(
-            logs_pipeline_in_rx.clone(),
-            logs_pipeline_out_tx,
-            pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_logs_batch_config(config.batch.clone()),
-            config.otlp_with_logs_processor.clone(),
-            config.otel_resource_attributes.clone(),
-        );
+        //
+        // let mut trace_pipeline = topology::generic_pipeline::Pipeline::new(
+        //     trace_pipeline_in_rx.clone(),
+        //     trace_pipeline_out_tx,
+        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+        //     trace_batch_config,
+        //     config.otlp_with_trace_processor.clone(),
+        //     config.otel_resource_attributes.clone(),
+        // );
+        //
+        // let mut metrics_pipeline = topology::generic_pipeline::Pipeline::new(
+        //     metrics_pipeline_in_rx.clone(),
+        //     metrics_pipeline_out_tx,
+        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+        //     build_metrics_batch_config(config.batch.clone()),
+        //     vec![],
+        //     config.otel_resource_attributes.clone(),
+        // );
+        //
+        // let mut logs_pipeline = topology::generic_pipeline::Pipeline::new(
+        //     logs_pipeline_in_rx.clone(),
+        //     logs_pipeline_out_tx,
+        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+        //     build_logs_batch_config(config.batch.clone()),
+        //     config.otlp_with_logs_processor.clone(),
+        //     config.otel_resource_attributes.clone(),
+        // );
 
         // Internal metrics
         // N.B Internal metrics initialization MUST be done before starting other parts of the agent such as
         // receiver and exporters, so that the global meter provider is set before those components attempt to
         // create instruments such as counters, etc. Be careful when refactoring this code to avoid breaking
         // this dependency.
-
-        let mut internal_metrics_pipeline = topology::generic_pipeline::Pipeline::new(
-            internal_metrics_pipeline_in_rx.clone(),
-            internal_metrics_pipeline_out_tx,
-            pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
-            build_metrics_batch_config(config.batch.clone()),
-            vec![],
-            config.otel_resource_attributes.clone(),
-        );
+        //
+        // let mut internal_metrics_pipeline = topology::generic_pipeline::Pipeline::new(
+        //     internal_metrics_pipeline_in_rx.clone(),
+        //     internal_metrics_pipeline_out_tx,
+        //     pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+        //     build_metrics_batch_config(config.batch.clone()),
+        //     vec![],
+        //     config.otel_resource_attributes.clone(),
+        // );
 
         let internal_metrics_sdk_exporter =
             telemetry::internal_exporter::InternalOTLPMetricsExporter::new(
@@ -530,6 +530,15 @@ impl Agent {
         }
 
         if traces_output.is_some() {
+            let mut trace_pipeline = topology::generic_pipeline::Pipeline::new(
+                trace_pipeline_in_rx.clone(),
+                trace_pipeline_out_tx,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                trace_batch_config,
+                config.otlp_with_trace_processor.clone(),
+                config.otel_resource_attributes.clone(),
+            );
+
             let log_traces = config.debug_log.contains(&DebugLogParam::Traces);
             let dbg_log = DebugLogger::new(log_traces);
 
@@ -537,7 +546,17 @@ impl Agent {
             pipeline_task_set
                 .spawn(async move { trace_pipeline.start(dbg_log, pipeline_cancel).await });
         }
+
         if metrics_output.is_some() {
+            let mut metrics_pipeline = topology::generic_pipeline::Pipeline::new(
+                metrics_pipeline_in_rx.clone(),
+                metrics_pipeline_out_tx,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                build_metrics_batch_config(config.batch.clone()),
+                vec![],
+                config.otel_resource_attributes.clone(),
+            );
+
             let log_metrics = config.debug_log.contains(&DebugLogParam::Metrics);
             let dbg_log = DebugLogger::new(log_metrics);
 
@@ -545,7 +564,17 @@ impl Agent {
             pipeline_task_set
                 .spawn(async move { metrics_pipeline.start(dbg_log, pipeline_cancel).await });
         }
+
         if logs_output.is_some() {
+            let mut logs_pipeline = topology::generic_pipeline::Pipeline::new(
+                logs_pipeline_in_rx.clone(),
+                logs_pipeline_out_tx,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                build_logs_batch_config(config.batch.clone()),
+                config.otlp_with_logs_processor.clone(),
+                config.otel_resource_attributes.clone(),
+            );
+
             let log_logs = config.debug_log.contains(&DebugLogParam::Logs);
             let dbg_log = DebugLogger::new(log_logs);
 
@@ -553,7 +582,17 @@ impl Agent {
             pipeline_task_set
                 .spawn(async move { logs_pipeline.start(dbg_log, pipeline_cancel).await });
         }
+
         if internal_metrics_output.is_some() {
+            let mut internal_metrics_pipeline = topology::generic_pipeline::Pipeline::new(
+                internal_metrics_pipeline_in_rx.clone(),
+                internal_metrics_pipeline_out_tx,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                build_metrics_batch_config(config.batch.clone()),
+                vec![],
+                config.otel_resource_attributes.clone(),
+            );
+
             let log_metrics = config.debug_log.contains(&DebugLogParam::Metrics);
             let dbg_log = DebugLogger::new(log_metrics);
 


### PR DESCRIPTION
The first part of this PR fixes the warnings we were logging about failing to flush a pipeline. The root of this warning was that we setup flush subscribers for all pipelines, even in cases that we didn't start the pipeline (eg., no exporter for metrics existed). In this case the flush was never received and we timed out waiting for it.

Fixing that then exposed a bug draining the exporters during a non-blocking flush msg. For non OTLP exporters we only want to block indefinitely on encoding futures when there are active ones present. Implement the size hints on the stream and use that to decide if we should block on encoding futures.

Completes: STR-3418