### PR TITLE
Add a request iterator pattern

### DIFF
--- a/src/exporters/clickhouse/api_request.rs
+++ b/src/exporters/clickhouse/api_request.rs
@@ -66,11 +66,12 @@ impl ApiRequestBuilder {
     pub fn build(
         &self,
         payload: ClickhousePayload,
-    ) -> Result<Request<ClickhousePayload>, BoxError> {
+    ) -> Result<Vec<Request<ClickhousePayload>>, BoxError> {
         self.base
             .builder()
             .body(payload)?
             .build()
+            .map(|r| vec![r])
             .map_err(|e| format!("failed to build request: {:?}", e).into())
     }
 }

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -160,8 +160,8 @@ impl ClickhouseExporterBuilder {
             .timeout(Duration::from_secs(5))
             .service(client);
 
-        let enc_stream = RequestBuilderMapper::new(rx.into_stream(), req_builder);
-        let enc_stream = RequestIterator::new(enc_stream);
+        let enc_stream =
+            RequestIterator::new(RequestBuilderMapper::new(rx.into_stream(), req_builder));
 
         let exp = Exporter::new(
             "clickhouse",
@@ -213,8 +213,8 @@ impl ClickhouseExporterBuilder {
             .timeout(Duration::from_secs(5))
             .service(client);
 
-        let enc_stream = RequestBuilderMapper::new(rx.into_stream(), req_builder);
-        let enc_stream = RequestIterator::new(enc_stream);
+        let enc_stream =
+            RequestIterator::new(RequestBuilderMapper::new(rx.into_stream(), req_builder));
 
         let exp = Exporter::new(
             "clickhouse",

--- a/src/exporters/clickhouse/request_builder.rs
+++ b/src/exporters/clickhouse/request_builder.rs
@@ -43,7 +43,9 @@ impl<Resource, Transform> BuildRequest<Resource, ClickhousePayload>
 where
     Transform: TransformPayload<Resource>,
 {
-    fn build(&self, input: Vec<Resource>) -> Result<Request<ClickhousePayload>, BoxError> {
+    type Output = Vec<Request<ClickhousePayload>>;
+
+    fn build(&self, input: Vec<Resource>) -> Result<Self::Output, BoxError> {
         let payload = self.transformer.transform(input)?;
 
         self.api_req_builder.build(payload)

--- a/src/exporters/datadog/api_request.rs
+++ b/src/exporters/datadog/api_request.rs
@@ -49,7 +49,7 @@ impl ApiRequestBuilder {
         Ok(s)
     }
 
-    pub fn build(&self, payload: AgentPayload) -> Result<Request<Full<Bytes>>, BoxError> {
+    pub fn build(&self, payload: AgentPayload) -> Result<Vec<Request<Full<Bytes>>>, BoxError> {
         let mut buf = Vec::new();
         if let Err(e) = payload.encode(&mut buf) {
             // todo: We pass these on as errors which the final service immediately returns,
@@ -68,6 +68,7 @@ impl ApiRequestBuilder {
             .builder()
             .body(body)?
             .build()
+            .map(|r| vec![r])
             .map_err(|e| format!("failed to build request: {:?}", e).into())
     }
 }

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -142,8 +142,8 @@ impl DatadogTraceExporterBuilder {
             .timeout(Duration::from_secs(5))
             .service(client);
 
-        let enc_stream = RequestBuilderMapper::new(rx.into_stream(), req_builder);
-        let enc_stream = RequestIterator::new(enc_stream);
+        let enc_stream =
+            RequestIterator::new(RequestBuilderMapper::new(rx.into_stream(), req_builder));
 
         let exp = Exporter::new(
             "datadog",

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -3,18 +3,20 @@
 use crate::bounded_channel::BoundedReceiver;
 use crate::exporters::datadog::request_builder::RequestBuilder;
 use crate::exporters::datadog::transform::Transformer;
-use crate::exporters::http;
 use crate::exporters::http::retry::{RetryConfig, RetryPolicy};
 
 use crate::exporters::http::client::ResponseDecode;
 use crate::exporters::http::exporter::{Exporter, ResultLogger};
 use crate::exporters::http::http_client::HttpClient;
 use crate::exporters::http::request_builder_mapper::RequestBuilderMapper;
+use crate::exporters::http::request_iter::RequestIterator;
 use crate::exporters::http::response::Response;
+use crate::exporters::http::tls;
 use crate::exporters::http::types::ContentEncoding;
 use crate::topology::flush_control::FlushReceiver;
 use bytes::Bytes;
 use flume::r#async::RecvStream;
+use http::Request;
 use http_body_util::Full;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use std::time::Duration;
@@ -32,11 +34,15 @@ type SvcType =
     TowerRetry<RetryPolicy<()>, Timeout<HttpClient<Full<Bytes>, (), DatadogTraceDecoder>>>;
 
 type ExporterType<'a, Resource> = Exporter<
-    RequestBuilderMapper<
-        RecvStream<'a, Vec<Resource>>,
-        Resource,
+    RequestIterator<
+        RequestBuilderMapper<
+            RecvStream<'a, Vec<Resource>>,
+            Resource,
+            Full<Bytes>,
+            RequestBuilder<Resource, Transformer>,
+        >,
+        Vec<Request<Full<Bytes>>>,
         Full<Bytes>,
-        RequestBuilder<Resource, Transformer>,
     >,
     SvcType,
     Full<Bytes>,
@@ -118,7 +124,7 @@ impl DatadogTraceExporterBuilder {
         rx: BoundedReceiver<Vec<ResourceSpans>>,
         flush_receiver: Option<FlushReceiver>,
     ) -> Result<ExporterType<'a, ResourceSpans>, BoxError> {
-        let client = HttpClient::build(http::tls::Config::default(), Default::default())?;
+        let client = HttpClient::build(tls::Config::default(), Default::default())?;
 
         let transformer = Transformer::new(self.environment.clone(), self.hostname.clone());
 
@@ -137,6 +143,7 @@ impl DatadogTraceExporterBuilder {
             .service(client);
 
         let enc_stream = RequestBuilderMapper::new(rx.into_stream(), req_builder);
+        let enc_stream = RequestIterator::new(enc_stream);
 
         let exp = Exporter::new(
             "datadog",

--- a/src/exporters/datadog/request_builder.rs
+++ b/src/exporters/datadog/request_builder.rs
@@ -55,7 +55,9 @@ impl<Resource, Transform> BuildRequest<Resource, Full<Bytes>>
 where
     Transform: TransformPayload<Resource>,
 {
-    fn build(&self, input: Vec<Resource>) -> Result<Request<Full<Bytes>>, BoxError> {
+    type Output = Vec<Request<Full<Bytes>>>;
+
+    fn build(&self, input: Vec<Resource>) -> Result<Self::Output, BoxError> {
         let payload = self.transformer.transform(input);
 
         self.api_req_builder.build(payload)

--- a/src/exporters/http/mod.rs
+++ b/src/exporters/http/mod.rs
@@ -6,6 +6,7 @@ pub mod grpc_client;
 pub mod http_client;
 pub mod request;
 pub mod request_builder_mapper;
+pub mod request_iter;
 pub mod response;
 pub mod retry;
 pub mod tls;

--- a/src/exporters/http/request_iter.rs
+++ b/src/exporters/http/request_iter.rs
@@ -48,7 +48,8 @@ where
             Some(item) => {
                 let next = item.next();
                 if next.is_none() {
-                    // Once we hit the first none, clear the iterator
+                    // Once we hit the first none, clear the iterator. It might be undefined
+                    // to continue calling next.
                     self.curr_iter = None;
                 }
 

--- a/src/exporters/http/request_iter.rs
+++ b/src/exporters/http/request_iter.rs
@@ -1,0 +1,111 @@
+use futures_util::{Stream, StreamExt, stream::Fuse};
+use http::Request;
+use pin_project::pin_project;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::BoxError;
+use tracing::error;
+
+#[pin_project]
+pub struct RequestIterator<InStr, InputIter, Payload>
+where
+    InputIter: IntoIterator<Item = Request<Payload>>,
+    InStr: Stream<Item = Result<InputIter, BoxError>>,
+{
+    #[pin]
+    input: Fuse<InStr>,
+
+    inner: Inner<InputIter, Payload>,
+}
+
+struct Inner<InputIter, Payload>
+where
+    InputIter: IntoIterator<Item = Request<Payload>>,
+{
+    curr_iter: Option<<InputIter as IntoIterator>::IntoIter>,
+}
+
+impl<InStr, InputIter, Payload> RequestIterator<InStr, InputIter, Payload>
+where
+    InputIter: IntoIterator<Item = Request<Payload>>,
+    InStr: Stream<Item = Result<InputIter, BoxError>>,
+{
+    pub fn new(input: InStr) -> Self {
+        Self {
+            input: input.fuse(),
+            inner: Inner { curr_iter: None },
+        }
+    }
+}
+
+impl<InputIter, Payload> Inner<InputIter, Payload>
+where
+    InputIter: IntoIterator<Item = Request<Payload>>,
+{
+    fn next(&mut self) -> Option<<InputIter as IntoIterator>::Item> {
+        match &mut self.curr_iter {
+            None => None,
+            Some(item) => {
+                let next = item.next();
+                if next.is_none() {
+                    // Once we hit the first none, clear the iterator
+                    self.curr_iter = None;
+                }
+
+                next
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.curr_iter.as_ref() {
+            None => (0, None),
+            Some(item) => item.size_hint(),
+        }
+    }
+
+    fn update(&mut self, item: <InputIter as IntoIterator>::IntoIter) {
+        self.curr_iter = Some(item)
+    }
+}
+
+impl<InStr, InputIter, Payload> Stream for RequestIterator<InStr, InputIter, Payload>
+where
+    InputIter: IntoIterator<Item = Request<Payload>>,
+    InStr: Stream<Item = Result<InputIter, BoxError>>,
+{
+    type Item = Result<Request<Payload>, BoxError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        loop {
+            if let Some(next) = this.inner.next() {
+                return Poll::Ready(Some(Ok(next)));
+            }
+
+            // Either we hit the end of the iterator or we haven't pulled a new item from
+            // the stream
+            match this.input.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(ret) => match ret {
+                    None => return Poll::Ready(None),
+                    Some(res) => match res {
+                        Ok(item) => this.inner.update(item.into_iter()),
+                        Err(err) => {
+                            error!(error = err, "Failed to encode request, dropping")
+                        }
+                    },
+                },
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.input.size_hint() {
+            // If the input is a zero, defer to the size of the remaining iterator
+            (0, _) => self.inner.size_hint(),
+            (min, max) => (min, max),
+        }
+    }
+}

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -220,8 +220,8 @@ impl XRayTraceExporterBuilder {
             .timeout(Duration::from_secs(5))
             .service(client);
 
-        let enc_stream = RequestBuilderMapper::new(rx.into_stream(), req_builder);
-        let enc_stream = RequestIterator::new(enc_stream);
+        let enc_stream =
+            RequestIterator::new(RequestBuilderMapper::new(rx.into_stream(), req_builder));
 
         let exp = Exporter::new(
             "x-ray",

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -396,7 +396,7 @@ impl Agent {
                     config.aws_xray_exporter.xray_exporter_region,
                     config.aws_xray_exporter.xray_exporter_custom_endpoint,
                 );
-                let config = Box::leak(Box::new(AwsConfig::from_env()));
+                let config = AwsConfig::from_env();
                 let exp = builder.build(
                     trace_pipeline_out_rx,
                     self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),


### PR DESCRIPTION
This is purely a refactor in support of future Clickhouse metrics support. It adds a RequestIterator to the exporter's input stream and states that any request built from the request builder mapper must return an `IntoIterator<>` type. The RequestIterator wraps this, taking the IntoIterator output, converts it to an iterator and then responds with individual elements to the actual exporter. The exporter doesn't change, it still expects a single request to be output that it will try to deliver.

What this means is that an exporter like Clickhouse can take a single incoming payload (`Vec<ResourceXXX>`) and convert that into multiple outgoing requests, instead of the current 1:1 mapping. This is required for metrics because metrics are split across different tables by type and require an output request per metric type. It may also be useful for future changes to exporters, allowing an exporter to further split an incoming batch of `Vec<ResourceXXX>` into multiple requests if the output were too large for the exporter destination.

Alternatively, we could probably use an IntoStream in place of the iterator, allowing a multi request response to be streamed back. However, that seemed more complex to integrate right now.

STR-3352