### PR TITLE
Experimental file exporter that supports parquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ rotel_python_processor_sdk/.env/
 rotel_python_processor_sdk/rotel_sdk/*.so
 rotel_python_processor_sdk/.idea
 rotel_python_processor_sdk/processors/__pycache__
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
@@ -46,6 +47,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
 dependencies = [
  "equator",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -130,6 +146,214 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bb018b6960c87fd9d025009820406f74e83281185a8bdcb44880d2aa5c9a87"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de76b51473aa888ecd6ad93ceb262fb8d40d1f1154a4df2f069b3590aa7575"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ed77e22744475a9a53d00026cf8e166fe73cf42d89c4c4ae63607ee1cfcc3f"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.15.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0391c96eb58bf7389171d1e103112d3fc3e5625ca6b372d606f2688f1ea4cce"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39e1d774ece9292697fcbe06b5584401b26bd34be1bec25c33edae65c2420ff"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9055c972a07bf12c2a827debfd34f88d3b93da1941d36e1d9fee85eebe38a12a"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf75ac27a08c7f48b88e5c923f267e980f27070147ab74615ad85b5c5f90473d"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a222f0d93772bd058d1268f4c28ea421a603d66f7979479048c429292fac7b2e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9085342bbca0f75e8cb70513c0807cc7351f1fbf5cb98192a67d5e3044acb033"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.9.0",
+ "lexical-core",
+ "memchr",
+ "num",
+ "serde",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2f1065a5cad7b9efa9e22ce5747ce826aa3855766755d4904535123ef431e7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3703a0e3e92d23c3f756df73d2dc9476873f873a76ae63ef9d3de17fda83b2d8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a47aa0c771b5381de2b7f16998d351a6f4eb839f1e13d48353e17e873d969b"
+
+[[package]]
+name = "arrow-select"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b7b85575702b23b85272b01bc1c25a01c9b9852305e5d0078c79ba25d995d4"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9260fddf1cdf2799ace2b4c2fc0356a9789fa7551e0953e35435536fecefebbd"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.5",
+]
 
 [[package]]
 name = "ascii-canvas"
@@ -368,6 +592,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +804,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +1014,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +1162,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1081,13 +1376,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
+name = "flatbuffers"
+version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
+dependencies = [
+ "bitflags 2.8.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1332,6 +1638,7 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
 
 [[package]]
@@ -1798,6 +2105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "inventory"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +2256,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +2334,12 @@ dependencies = [
  "cfg-if",
  "windows-targets",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -1976,6 +2359,15 @@ checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
 dependencies = [
  "cmake",
  "libc",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2021,7 +2413,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -2093,9 +2485,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -2179,6 +2571,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,12 +2629,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2329,6 +2768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2809,39 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "parquet"
+version = "55.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be7b2d778f6b841d37083ebdf32e33a524acde1266b5884a8ca29bf00dfa1231"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.15.2",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash 2.1.1",
+ "zstd",
 ]
 
 [[package]]
@@ -2465,6 +2946,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -3003,6 +3490,8 @@ dependencies = [
 name = "rotel"
 version = "0.0.1-alpha10"
 dependencies = [
+ "arrow",
+ "base64 0.22.1",
  "bstr",
  "bytes",
  "chrono",
@@ -3033,6 +3522,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "parquet",
  "pin-project",
  "pprof",
  "prost 0.13.4",
@@ -3097,6 +3587,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3242,6 +3741,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,6 +3839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3870,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -3555,6 +4078,17 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -3969,6 +4503,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typenum"
@@ -4473,4 +5013,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ hmac = "0.12"
 sha2 = "0.10"
 regex = "1.11.1"
 figment = {  version = "0.10.19", default-features = false, features = ["env"] }
+parquet = "55.1.0"
+arrow = "55.1.0"
+base64 = "0.22.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Any option above that does not contain a default is considered false or unset by
 | --otlp-grpc-endpoint              | localhost:4317       |                                                |
 | --otlp-http-endpoint              | localhost:4318       |                                                |
 | --otlp-grpc-max-recv-msg-size-mib | 4                    |                                                |
-| --exporter                        | otlp                 | otlp, blackhole, datadog, clickhouse, aws-xray |
+| --exporter                        | otlp                 | otlp, blackhole, datadog, clickhouse, aws-xray, file |
 | --otlp-receiver-traces-disabled   |                      |                                                |
 | --otlp-receiver-metrics-disabled  |                      |                                                |
 | --otlp-receiver-logs-disabled     |                      |                                                |
@@ -241,6 +241,30 @@ automatically sourced from Rotel's environment on startup.
 | --xray-exporter-custom-endpoint |           |                  |
 
 For a list of available AWS X-Ray region codes here: https://docs.aws.amazon.com/general/latest/gr/xray.html
+
+### File exporter configuration
+
+The File exporter can be selected with `--exporter file`.  It writes telemetry
+out as periodic files on the local filesystem.  Currently **Parquet** and
+**JSON** formats are supported.
+
+| Option                                    | Default       | Description                                   |
+|-------------------------------------------|---------------|-----------------------------------------------|
+| --file-exporter-format                   | parquet       | `parquet` or `json`                           |
+| --file-exporter-output-dir               | /tmp/rotel    | Directory to place output files               |
+| --file-exporter-flush-interval           | 5s            | How often to flush accumulated telemetry to a
+                                                              new file (accepts Go-style durations like
+                                                              `30s`, `2m`, `1h`) |
+| --file-exporter-parquet-compression      | snappy        | Compression for Parquet files: `uncompressed`,
+                                                              `snappy`, `gzip`, `lz4`, `zstd`
+                                                              (only applies when format is parquet) |
+
+Each flush creates a file named `<telemetry-type>-<timestamp>.<ext>` inside the
+specified directory.  For example, with default settings Rotel will emit files
+such as `traces-20250614-120000.parquet` every five seconds.
+
+_The File exporter is useful for local debugging, offline analysis, and for
+feeding telemetry into batch-processing systems._
 
 ### Batch configuration
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ For a list of available AWS X-Ray region codes here: https://docs.aws.amazon.com
 
 ### File exporter configuration
 
+**WARNING**: The Parquet and JSON file format is evolving and subject to breaking changes between releases. There is consolidation planned with official Arrow schemas from the OpenTelemetry Arrow project.
+
 The File exporter can be selected with `--exporter file`.  It writes telemetry
 out as periodic files on the local filesystem.  Currently **Parquet** and
 **JSON** formats are supported.
@@ -261,7 +263,7 @@ out as periodic files on the local filesystem.  Currently **Parquet** and
 
 Each flush creates a file named `<telemetry-type>-<timestamp>.<ext>` inside the
 specified directory.  For example, with default settings Rotel will emit files
-such as `traces-20250614-120000.parquet` every five seconds.
+such as `traces-20250614-120000.parquet` every five seconds. Files are saved into the `traces`, `logs`, and `metrics` subdirectories.
 
 _The File exporter is useful for local debugging, offline analysis, and for
 feeding telemetry into batch-processing systems._

--- a/src/exporters/file/config.rs
+++ b/src/exporters/file/config.rs
@@ -1,0 +1,134 @@
+use crate::init::file_exporter::{FileExporterFormat, ParquetCompression};
+use std::path::PathBuf;
+use std::time::Duration;
+use thiserror::Error;
+
+/// Errors that can occur during configuration parsing and validation.
+///
+/// - `InvalidFormat`: The format field is missing or not supported.
+///   Recovery: Set a valid format (e.g., "parquet").
+/// - `InvalidPath`: The output path does not exist or is not a directory.
+///   Recovery: Create the directory or correct the path.
+/// - `InvalidFlushInterval`: The flush interval is zero or invalid.
+///   Recovery: Set a non-zero flush interval (e.g., "5s").
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("Invalid format: {0}")]
+    InvalidFormat(String),
+
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
+
+    #[error("Invalid flush interval: {0}")]
+    InvalidFlushInterval(String),
+}
+
+/// Configuration for the file exporter
+#[derive(Debug, Clone)]
+pub struct FileExporterConfig {
+    /// The format to use for exporting files
+    pub format: FileExporterFormat,
+
+    /// The directory where files will be written
+    pub path: PathBuf,
+
+    /// How often to flush data to disk (e.g., "5s")
+    pub flush_interval: Duration,
+
+    /// Compression type for Parquet files
+    pub parquet_compression: ParquetCompression,
+}
+
+impl FileExporterConfig {
+    /// Creates a new configuration with the required fields
+    pub fn new(
+        format: FileExporterFormat,
+        path: PathBuf,
+        flush_interval: Duration,
+        parquet_compression: ParquetCompression,
+    ) -> Self {
+        Self {
+            format,
+            path,
+            flush_interval,
+            parquet_compression,
+        }
+    }
+
+    /// Validates the configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidPath` if the path does not exist or is not a directory,
+    /// or `ConfigError::InvalidFlushInterval` if the flush interval is zero.
+    ///
+    /// # Recovery
+    /// - Create the output directory if it does not exist.
+    /// - Set a non-zero flush interval.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        // Format validation is now handled by the enum type itself, no need to validate
+
+        // Validate path
+        if !self.path.exists() {
+            // Recovery: Suggest creating the directory
+            return Err(ConfigError::InvalidPath(format!(
+                "Path does not exist: {}. Create the directory or set a valid path.",
+                self.path.display()
+            )));
+        }
+
+        if !self.path.is_dir() {
+            return Err(ConfigError::InvalidPath(format!(
+                "Path is not a directory: {}",
+                self.path.display()
+            )));
+        }
+
+        // Validate flush interval
+        if self.flush_interval.is_zero() {
+            return Err(ConfigError::InvalidFlushInterval(
+                "Flush interval cannot be zero. Set a non-zero value (e.g., '5s').".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_valid_config() {
+        let temp_dir = tempdir().unwrap();
+        let config = FileExporterConfig {
+            format: FileExporterFormat::Parquet,
+            path: temp_dir.path().to_path_buf(),
+            flush_interval: Duration::from_secs(5),
+            parquet_compression: ParquetCompression::Snappy,
+        };
+
+        assert!(config.validate().is_ok());
+    }
+
+    // Note: Format validation test removed since enum prevents invalid formats at compile time
+
+    #[test]
+    fn test_invalid_flush_interval() {
+        let temp_dir = tempdir().unwrap();
+        let config = FileExporterConfig {
+            format: FileExporterFormat::Parquet,
+            path: temp_dir.path().to_path_buf(),
+            flush_interval: Duration::from_secs(0),
+            parquet_compression: ParquetCompression::Snappy,
+        };
+
+        assert!(matches!(
+            config.validate(),
+            Err(ConfigError::InvalidFlushInterval(_))
+        ));
+    }
+}

--- a/src/exporters/file/config.rs
+++ b/src/exporters/file/config.rs
@@ -30,7 +30,7 @@ pub struct FileExporterConfig {
     pub format: FileExporterFormat,
 
     /// The directory where files will be written
-    pub path: PathBuf,
+    pub output_dir: PathBuf,
 
     /// How often to flush data to disk (e.g., "5s")
     pub flush_interval: Duration,
@@ -49,7 +49,7 @@ impl FileExporterConfig {
     ) -> Self {
         Self {
             format,
-            path,
+            output_dir: path,
             flush_interval,
             parquet_compression,
         }
@@ -69,18 +69,18 @@ impl FileExporterConfig {
         // Format validation is now handled by the enum type itself, no need to validate
 
         // Validate path
-        if !self.path.exists() {
+        if !self.output_dir.exists() {
             // Recovery: Suggest creating the directory
             return Err(ConfigError::InvalidPath(format!(
                 "Path does not exist: {}. Create the directory or set a valid path.",
-                self.path.display()
+                self.output_dir.display()
             )));
         }
 
-        if !self.path.is_dir() {
+        if !self.output_dir.is_dir() {
             return Err(ConfigError::InvalidPath(format!(
                 "Path is not a directory: {}",
-                self.path.display()
+                self.output_dir.display()
             )));
         }
 
@@ -106,7 +106,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let config = FileExporterConfig {
             format: FileExporterFormat::Parquet,
-            path: temp_dir.path().to_path_buf(),
+            output_dir: temp_dir.path().to_path_buf(),
             flush_interval: Duration::from_secs(5),
             parquet_compression: ParquetCompression::Snappy,
         };
@@ -121,7 +121,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let config = FileExporterConfig {
             format: FileExporterFormat::Parquet,
-            path: temp_dir.path().to_path_buf(),
+            output_dir: temp_dir.path().to_path_buf(),
             flush_interval: Duration::from_secs(0),
             parquet_compression: ParquetCompression::Snappy,
         };

--- a/src/exporters/file/json.rs
+++ b/src/exporters/file/json.rs
@@ -1,0 +1,68 @@
+use std::fs::File;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::exporters::file::{FileExporterError, Result};
+
+use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
+use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+
+/// A JSON file exporter for native OTLP protobuf structures (ResourceSpans,
+/// ResourceMetrics, ResourceLogs).  Each exported file contains a JSON array of
+/// the received resources, matching the official OTLP/HTTP JSON encoding.
+pub struct JsonExporter;
+
+impl JsonExporter {
+    /// Creates a new `JsonExporter` instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Serialize and write any `Serialize` payload to the given path.
+    fn export_payload<T: Serialize + ?Sized>(&self, payload: &T, path: &Path) -> Result<()> {
+        let file = File::create(path).map_err(FileExporterError::Io)?;
+        serde_json::to_writer_pretty(file, payload)
+            .map_err(|e| FileExporterError::Export(format!("Failed to write JSON: {}", e)))
+    }
+
+    /// Export traces (`Vec<ResourceSpans>`) as JSON.
+    pub fn export_traces(&self, traces: &[ResourceSpans], path: &Path) -> Result<()> {
+        self.export_payload(traces, path)
+    }
+
+    /// Export metrics (`Vec<ResourceMetrics>`) as JSON.
+    pub fn export_metrics(&self, metrics: &[ResourceMetrics], path: &Path) -> Result<()> {
+        self.export_payload(metrics, path)
+    }
+
+    /// Export logs (`Vec<ResourceLogs>`) as JSON.
+    pub fn export_logs(&self, logs: &[ResourceLogs], path: &Path) -> Result<()> {
+        self.export_payload(logs, path)
+    }
+}
+
+impl Default for JsonExporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_export_traces_empty() {
+        // Ensure exporter can handle empty slice (writes []).
+        let exporter = JsonExporter::new();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("traces.json");
+        let traces: Vec<ResourceSpans> = Vec::new();
+        assert!(exporter.export_traces(&traces, &path).is_ok());
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents.trim(), "[]");
+    }
+}

--- a/src/exporters/file/mod.rs
+++ b/src/exporters/file/mod.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+use thiserror::Error;
+
+/// Errors that can occur during file export operations.
+///
+/// - `Io`: Underlying I/O error (e.g., file not found, permission denied).
+///   Recovery: Check file system permissions and path existence.
+/// - `InvalidData`: The input data is malformed or not supported.
+///   Recovery: Validate and sanitize input data before export.
+/// - `Config`: Configuration is invalid or missing required fields.
+///   Recovery: Review and correct configuration parameters.
+/// - `Export`: Error occurred during the export process (e.g., Arrow/Parquet failure).
+///   Recovery: Check data types, schema compatibility, and disk space.
+#[derive(Debug, Error)]
+pub enum FileExporterError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid data format: {0}")]
+    InvalidData(String),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    #[error("Export error: {0}")]
+    Export(String),
+}
+
+/// Result type for file exporter operations.
+pub type Result<T> = std::result::Result<T, FileExporterError>;
+
+/// Trait defining the core functionality for file exporters.
+///
+/// All methods return a `Result` with detailed error context. Implementations should provide
+/// actionable error messages and propagate context for easier debugging and recovery.
+pub trait FileExporter: Send + Sync {
+    /// Export data to a file at the specified path.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FileExporterError::Io` for file system errors,
+    /// `FileExporterError::InvalidData` for malformed data,
+    /// or `FileExporterError::Export` for Parquet/Arrow failures.
+    fn export(&self, data: &[u8], path: &Path) -> Result<()>;
+
+    /// Validate the data before export.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FileExporterError::InvalidData` if the data is not valid for export.
+    fn validate(&self, data: &[u8]) -> Result<()>;
+
+    /// Get list of supported file formats.
+    fn get_supported_formats(&self) -> Vec<String>;
+}
+
+pub mod config;
+pub mod json;
+pub mod parquet;
+pub mod task;

--- a/src/exporters/file/parquet/common.rs
+++ b/src/exporters/file/parquet/common.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{ListArray, StringArray};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Field};
+use arrow::record_batch::RecordBatch;
+
+use crate::exporters::file::FileExporterError;
+
+/// Unified representation used in Arrow columns where the data could be a
+/// key/value map (flattened) or an already-encoded JSON string.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum MapOrJson {
+    Map(HashMap<String, String>),
+    Json(String),
+}
+
+/// Trait that converts a vec of row structs into an Arrow `RecordBatch` ready
+/// for Parquet/Arrow IPC writing.
+pub trait ToRecordBatch {
+    fn to_record_batch(rows: Vec<Self>) -> Result<RecordBatch, FileExporterError>
+    where
+        Self: Sized;
+}
+
+// ---------------------------------------------------------------------------
+// Helper macros & functions to reduce boiler-plate when creating Arrow arrays
+// ---------------------------------------------------------------------------
+
+/// Build a `StringArray` from a field on every row.
+#[macro_export]
+macro_rules! build_string_array {
+    ($rows:expr, $field:ident) => {
+        arrow::array::StringArray::from($rows.into_iter().map(|r| r.$field).collect::<Vec<_>>())
+    };
+}
+
+/// Build a `UInt64Array` from an integer field.
+#[macro_export]
+macro_rules! build_u64_array {
+    ($rows:expr, $field:ident) => {
+        arrow::array::UInt64Array::from($rows.into_iter().map(|r| r.$field).collect::<Vec<_>>())
+    };
+}
+
+/// Build a `Int64Array` from an integer field.
+#[macro_export]
+macro_rules! build_i64_array {
+    ($rows:expr, $field:ident) => {
+        arrow::array::Int64Array::from($rows.into_iter().map(|r| r.$field).collect::<Vec<_>>())
+    };
+}
+
+/// Build a `UInt8Array` from a `u8` field.
+#[macro_export]
+macro_rules! build_u8_array {
+    ($rows:expr, $field:ident) => {
+        arrow::array::UInt8Array::from($rows.into_iter().map(|r| r.$field).collect::<Vec<_>>())
+    };
+}
+
+/// Convert `MapOrJson` to its serialized string representation.
+pub(crate) fn map_or_json_to_string(m: &MapOrJson) -> String {
+    match m {
+        MapOrJson::Map(map) => serde_json::to_string(map).unwrap_or_default(),
+        MapOrJson::Json(s) => s.clone(),
+    }
+}
+
+/// Helper that builds a `ListArray<UInt64Array>` from a `Vec<Vec<u64>>` field.
+pub(crate) fn vec_u64_to_list_array(data: Vec<Vec<u64>>) -> ListArray {
+    let offsets = OffsetBuffer::from_lengths(data.iter().map(|v| v.len()));
+    let values = arrow::array::UInt64Array::from_iter(data.into_iter().flatten());
+    ListArray::new(
+        Arc::new(Field::new("item", DataType::UInt64, true)),
+        offsets,
+        Arc::new(values),
+        None,
+    )
+}
+
+/// Helper that builds a `ListArray<StringArray>` from a `Vec<Vec<String>>` field.
+pub(crate) fn vec_string_to_list_array(data: Vec<Vec<String>>) -> ListArray {
+    let offsets = OffsetBuffer::from_lengths(data.iter().map(|v| v.len()));
+    let values = StringArray::from(data.into_iter().flatten().collect::<Vec<_>>());
+    ListArray::new(
+        Arc::new(Field::new("item", DataType::Utf8, true)),
+        offsets,
+        Arc::new(values),
+        None,
+    )
+}
+
+/// Helper that builds a `ListArray<StringArray>` from a `Vec<Vec<MapOrJson>>` field.
+pub(crate) fn vec_maporjson_to_list_array(data: Vec<Vec<MapOrJson>>) -> ListArray {
+    let offsets = OffsetBuffer::from_lengths(data.iter().map(|v| v.len()));
+    let values = StringArray::from(
+        data.into_iter()
+            .flatten()
+            .map(|m| map_or_json_to_string(&m))
+            .collect::<Vec<_>>(),
+    );
+    ListArray::new(
+        Arc::new(Field::new("item", DataType::Utf8, true)),
+        offsets,
+        Arc::new(values),
+        None,
+    )
+}

--- a/src/exporters/file/parquet/exporter.rs
+++ b/src/exporters/file/parquet/exporter.rs
@@ -1,0 +1,189 @@
+use super::{LogRecordRow, MetricRow, SpanRow, ToRecordBatch};
+use crate::exporters::file::{FileExporter, FileExporterError, Result};
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use serde_json::Value;
+use std::path::Path;
+
+/// A Parquet file exporter implementation
+pub struct ParquetExporter {
+    /// Writer properties for Parquet file generation
+    writer_properties: WriterProperties,
+}
+
+impl ParquetExporter {
+    /// Creates a new ParquetExporter with default settings (SNAPPY compression)
+    pub fn new() -> Self {
+        Self::with_compression(Compression::SNAPPY)
+    }
+
+    /// Creates a new ParquetExporter with specified compression
+    pub fn with_compression(compression: Compression) -> Self {
+        let writer_properties = WriterProperties::builder()
+            .set_compression(compression)
+            .build();
+
+        Self { writer_properties }
+    }
+
+    /// Creates a new ParquetExporter with custom writer properties
+    pub fn with_properties(writer_properties: WriterProperties) -> Self {
+        Self { writer_properties }
+    }
+
+    /// Export a batch of SpanRow to Parquet
+    pub fn export_span_rows(&self, rows: &[SpanRow], path: &Path) -> Result<()> {
+        let batch = SpanRow::to_record_batch(rows.to_vec())?;
+        self.export_record_batch(&batch, path)
+    }
+
+    /// Export a batch of MetricRow to Parquet
+    pub fn export_metric_rows(&self, rows: &[MetricRow], path: &Path) -> Result<()> {
+        let batch = MetricRow::to_record_batch(rows.to_vec())?;
+        self.export_record_batch(&batch, path)
+    }
+
+    /// Export a batch of LogRecordRow to Parquet
+    pub fn export_log_record_rows(&self, rows: &[LogRecordRow], path: &Path) -> Result<()> {
+        let batch = LogRecordRow::to_record_batch(rows.to_vec())?;
+        self.export_record_batch(&batch, path)
+    }
+
+    /// Export a generic RecordBatch to Parquet
+    pub fn export_record_batch(&self, batch: &RecordBatch, path: &Path) -> Result<()> {
+        let file = std::fs::File::create(path).map_err(FileExporterError::Io)?;
+        let mut writer =
+            ArrowWriter::try_new(file, batch.schema(), Some(self.writer_properties.clone()))
+                .map_err(|e| {
+                    FileExporterError::Export(format!("Failed to create ArrowWriter: {}", e))
+                })?;
+        writer.write(batch).map_err(|e| {
+            FileExporterError::Export(format!("Failed to write RecordBatch: {}", e))
+        })?;
+        writer
+            .close()
+            .map_err(|e| FileExporterError::Export(format!("Failed to close writer: {}", e)))?;
+        Ok(())
+    }
+}
+
+// The FileExporter trait is still implemented for legacy/JSON compatibility, but
+// the new API is preferred for typed row export.
+impl FileExporter for ParquetExporter {
+    /// Exports raw JSON data after basic validation. While Parquet export is
+    /// primarily intended for typed Arrow `RecordBatch` input, a minimal JSON
+    /// compatibility layer is retained to satisfy legacy unit-tests.
+    fn export(&self, data: &[u8], path: &Path) -> Result<()> {
+        // Re-use `validate` to ensure the data is acceptable.
+        self.validate(data)?;
+        std::fs::write(path, data).map_err(FileExporterError::Io)
+    }
+
+    /// Performs lightweight validation ensuring the payload is a **non-empty**
+    /// JSON array (e.g. `[{...}, {...}]`).
+    fn validate(&self, data: &[u8]) -> Result<()> {
+        let value: Value = serde_json::from_slice(data)
+            .map_err(|e| FileExporterError::InvalidData(format!("Failed to parse JSON: {}", e)))?;
+
+        let arr = value.as_array().ok_or_else(|| {
+            FileExporterError::InvalidData("Expected JSON array of objects".to_string())
+        })?;
+
+        if arr.is_empty() {
+            return Err(FileExporterError::InvalidData(
+                "JSON array cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn get_supported_formats(&self) -> Vec<String> {
+        vec!["parquet".to_string()]
+    }
+}
+
+impl Default for ParquetExporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_get_supported_formats() {
+        let exporter = ParquetExporter::new();
+        let formats = exporter.get_supported_formats();
+        assert_eq!(formats, vec!["parquet"]);
+    }
+
+    #[test]
+    fn test_validate_valid_json() {
+        let exporter = ParquetExporter::new();
+        let data = r#"[
+            {"id": 1, "name": "test1"},
+            {"id": 2, "name": "test2"}
+        ]"#
+        .as_bytes();
+        let result = exporter.validate(data);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_json() {
+        let exporter = ParquetExporter::new();
+        let data = r#"invalid json"#.as_bytes();
+        let result = exporter.validate(data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_empty_array() {
+        let exporter = ParquetExporter::new();
+        let data = r#"[]"#.as_bytes();
+        let result = exporter.validate(data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_export_valid_data() {
+        let exporter = ParquetExporter::new();
+        let data = r#"[
+            {"id": 1, "name": "test1"},
+            {"id": 2, "name": "test2"}
+        ]"#
+        .as_bytes();
+        let path = PathBuf::from("test.parquet");
+        let result = exporter.export(data, &path);
+        assert!(result.is_ok());
+
+        // Clean up
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn test_with_compression() {
+        use parquet::basic::Compression;
+
+        // Test different compression types
+        let gzip_exporter =
+            ParquetExporter::with_compression(Compression::GZIP(Default::default()));
+        let lz4_exporter = ParquetExporter::with_compression(Compression::LZ4);
+        let uncompressed_exporter = ParquetExporter::with_compression(Compression::UNCOMPRESSED);
+
+        // Just verify they can be created without error
+        // In a real test, we'd check that the compression is actually applied to the output files
+        assert_eq!(gzip_exporter.get_supported_formats(), vec!["parquet"]);
+        assert_eq!(lz4_exporter.get_supported_formats(), vec!["parquet"]);
+        assert_eq!(
+            uncompressed_exporter.get_supported_formats(),
+            vec!["parquet"]
+        );
+    }
+}

--- a/src/exporters/file/parquet/log.rs
+++ b/src/exporters/file/parquet/log.rs
@@ -1,0 +1,325 @@
+use std::sync::Arc;
+
+use arrow::array::ArrayRef;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
+
+use super::common::{MapOrJson, ToRecordBatch, map_or_json_to_string};
+use crate::exporters::file::FileExporterError;
+// No longer using the macros since we consume data directly
+
+// Static schema created once and reused for all log record batches
+static LOG_SCHEMA: std::sync::LazyLock<Arc<Schema>> = std::sync::LazyLock::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::UInt64, false),
+        Field::new("trace_id", DataType::Utf8, false),
+        Field::new("span_id", DataType::Utf8, false),
+        Field::new("trace_flags", DataType::UInt8, false),
+        Field::new("severity_text", DataType::Utf8, false),
+        Field::new("severity_number", DataType::UInt8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("body", DataType::Utf8, false),
+        Field::new("resource_schema_url", DataType::Utf8, false),
+        Field::new("resource_attributes", DataType::Utf8, false),
+        Field::new("scope_schema_url", DataType::Utf8, false),
+        Field::new("scope_name", DataType::Utf8, false),
+        Field::new("scope_version", DataType::Utf8, false),
+        Field::new("scope_attributes", DataType::Utf8, false),
+        Field::new("log_attributes", DataType::Utf8, false),
+    ]))
+});
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LogRecordRow {
+    pub timestamp: u64,
+    pub trace_id: String,
+    pub span_id: String,
+    pub trace_flags: u8,
+    pub severity_text: String,
+    pub severity_number: u8,
+    pub service_name: String,
+    pub body: String,
+    pub resource_schema_url: String,
+    pub resource_attributes: MapOrJson,
+    pub scope_schema_url: String,
+    pub scope_name: String,
+    pub scope_version: String,
+    pub scope_attributes: MapOrJson,
+    pub log_attributes: MapOrJson,
+}
+
+impl ToRecordBatch for LogRecordRow {
+    fn to_record_batch(rows: Vec<Self>) -> Result<RecordBatch, FileExporterError> {
+        // Pre-allocate all the collections
+        let mut timestamps = Vec::with_capacity(rows.len());
+        let mut trace_ids = Vec::with_capacity(rows.len());
+        let mut span_ids = Vec::with_capacity(rows.len());
+        let mut trace_flags = Vec::with_capacity(rows.len());
+        let mut severity_texts = Vec::with_capacity(rows.len());
+        let mut severity_numbers = Vec::with_capacity(rows.len());
+        let mut service_names = Vec::with_capacity(rows.len());
+        let mut bodies = Vec::with_capacity(rows.len());
+        let mut resource_schema_urls = Vec::with_capacity(rows.len());
+        let mut resource_attributes = Vec::with_capacity(rows.len());
+        let mut scope_schema_urls = Vec::with_capacity(rows.len());
+        let mut scope_names = Vec::with_capacity(rows.len());
+        let mut scope_versions = Vec::with_capacity(rows.len());
+        let mut scope_attributes = Vec::with_capacity(rows.len());
+        let mut log_attributes = Vec::with_capacity(rows.len());
+
+        // Move data from rows, consuming it
+        for row in rows {
+            timestamps.push(row.timestamp);
+            trace_ids.push(row.trace_id);
+            span_ids.push(row.span_id);
+            trace_flags.push(row.trace_flags);
+            severity_texts.push(row.severity_text);
+            severity_numbers.push(row.severity_number);
+            service_names.push(row.service_name);
+            bodies.push(row.body);
+            resource_schema_urls.push(row.resource_schema_url);
+            resource_attributes.push(map_or_json_to_string(&row.resource_attributes));
+            scope_schema_urls.push(row.scope_schema_url);
+            scope_names.push(row.scope_name);
+            scope_versions.push(row.scope_version);
+            scope_attributes.push(map_or_json_to_string(&row.scope_attributes));
+            log_attributes.push(map_or_json_to_string(&row.log_attributes));
+        }
+
+        // Build arrays from the consumed data
+        let timestamp = arrow::array::UInt64Array::from(timestamps);
+        let trace_id = arrow::array::StringArray::from(trace_ids);
+        let span_id = arrow::array::StringArray::from(span_ids);
+        let trace_flags = arrow::array::UInt8Array::from(trace_flags);
+        let severity_text = arrow::array::StringArray::from(severity_texts);
+        let severity_number = arrow::array::UInt8Array::from(severity_numbers);
+        let service_name = arrow::array::StringArray::from(service_names);
+        let body = arrow::array::StringArray::from(bodies);
+        let resource_schema_url = arrow::array::StringArray::from(resource_schema_urls);
+        let resource_attributes = arrow::array::StringArray::from(resource_attributes);
+        let scope_schema_url = arrow::array::StringArray::from(scope_schema_urls);
+        let scope_name = arrow::array::StringArray::from(scope_names);
+        let scope_version = arrow::array::StringArray::from(scope_versions);
+        let scope_attributes = arrow::array::StringArray::from(scope_attributes);
+        let log_attributes = arrow::array::StringArray::from(log_attributes);
+
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(timestamp),
+            Arc::new(trace_id),
+            Arc::new(span_id),
+            Arc::new(trace_flags),
+            Arc::new(severity_text),
+            Arc::new(severity_number),
+            Arc::new(service_name),
+            Arc::new(body),
+            Arc::new(resource_schema_url),
+            Arc::new(resource_attributes),
+            Arc::new(scope_schema_url),
+            Arc::new(scope_name),
+            Arc::new(scope_version),
+            Arc::new(scope_attributes),
+            Arc::new(log_attributes),
+        ];
+
+        // Use the static schema instead of creating a new one
+        RecordBatch::try_new(LOG_SCHEMA.clone(), columns)
+            .map_err(|e| FileExporterError::Export(e.to_string()))
+    }
+}
+
+impl LogRecordRow {
+    pub fn from_resource_logs(
+        resource_logs: &ResourceLogs,
+    ) -> Result<Vec<LogRecordRow>, FileExporterError> {
+        use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValue;
+
+        fn attrs_to_map(attrs: &[opentelemetry_proto::tonic::common::v1::KeyValue]) -> MapOrJson {
+            let mut map = std::collections::HashMap::new();
+            for attr in attrs {
+                if let Some(any_value) = &attr.value {
+                    let value_str = match &any_value.value {
+                        Some(AnyValue::StringValue(s)) => s.clone(),
+                        Some(AnyValue::BoolValue(b)) => b.to_string(),
+                        Some(AnyValue::IntValue(i)) => i.to_string(),
+                        Some(AnyValue::DoubleValue(d)) => d.to_string(),
+                        _ => "".to_string(),
+                    };
+                    map.insert(attr.key.clone(), value_str);
+                }
+            }
+            MapOrJson::Map(map)
+        }
+
+        // Resource-level attributes & service name
+        let resource_attrs = resource_logs
+            .resource
+            .as_ref()
+            .map(|r| attrs_to_map(&r.attributes))
+            .unwrap_or(MapOrJson::Map(Default::default()));
+
+        let service_name = if let MapOrJson::Map(map) = &resource_attrs {
+            map.get("service.name").cloned().unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let mut rows = Vec::new();
+
+        for scope_logs in &resource_logs.scope_logs {
+            let scope_name = scope_logs
+                .scope
+                .as_ref()
+                .map(|s| s.name.clone())
+                .unwrap_or_default();
+            let scope_version = scope_logs
+                .scope
+                .as_ref()
+                .map(|s| s.version.clone())
+                .unwrap_or_default();
+            let scope_attrs = scope_logs
+                .scope
+                .as_ref()
+                .map(|s| attrs_to_map(&s.attributes))
+                .unwrap_or(MapOrJson::Map(Default::default()));
+            let scope_schema_url = scope_logs.schema_url.clone();
+
+            for log_record in &scope_logs.log_records {
+                let body_str = match &log_record.body {
+                    None => String::new(),
+                    Some(any_value) => match &any_value.value {
+                        Some(AnyValue::StringValue(s)) => s.clone(),
+                        Some(AnyValue::BoolValue(b)) => b.to_string(),
+                        Some(AnyValue::IntValue(i)) => i.to_string(),
+                        Some(AnyValue::DoubleValue(d)) => d.to_string(),
+                        _ => "".to_string(),
+                    },
+                };
+
+                rows.push(LogRecordRow {
+                    timestamp: log_record.time_unix_nano,
+                    trace_id: hex::encode(&log_record.trace_id),
+                    span_id: hex::encode(&log_record.span_id),
+                    trace_flags: log_record.flags as u8,
+                    severity_text: log_record.severity_text.clone(),
+                    severity_number: log_record.severity_number as u8,
+                    service_name: service_name.clone(),
+                    body: body_str,
+                    resource_schema_url: resource_logs.schema_url.clone(),
+                    resource_attributes: resource_attrs.clone(),
+                    scope_schema_url: scope_schema_url.clone(),
+                    scope_name: scope_name.clone(),
+                    scope_version: scope_version.clone(),
+                    scope_attributes: scope_attrs.clone(),
+                    log_attributes: attrs_to_map(&log_record.attributes),
+                });
+            }
+        }
+
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+    use opentelemetry_proto::tonic::logs::v1::{LogRecord, ScopeLogs};
+    use opentelemetry_proto::tonic::resource::v1::Resource;
+
+    #[test]
+    fn test_from_resource_logs_basic() {
+        let resource_logs = ResourceLogs {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("test-service".to_string())),
+                    }),
+                }],
+                ..Default::default()
+            }),
+            scope_logs: vec![ScopeLogs {
+                scope: Some(InstrumentationScope {
+                    name: "test-scope".to_string(),
+                    version: "1.0".to_string(),
+                    ..Default::default()
+                }),
+                log_records: vec![LogRecord {
+                    time_unix_nano: 1234567890,
+                    trace_id: vec![1, 2, 3, 4],
+                    span_id: vec![5, 6, 7, 8],
+                    flags: 1,
+                    severity_text: "INFO".to_string(),
+                    severity_number: 9,
+                    body: Some(AnyValue {
+                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("test message".to_string())),
+                    }),
+                    attributes: vec![KeyValue {
+                        key: "log.key".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("log.value".to_string())),
+                        }),
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            schema_url: "test-schema".to_string(),
+        };
+
+        let result = LogRecordRow::from_resource_logs(&resource_logs).unwrap();
+        assert_eq!(result.len(), 1);
+
+        let row = &result[0];
+        assert_eq!(row.timestamp, 1234567890);
+        assert_eq!(row.trace_id, "01020304");
+        assert_eq!(row.span_id, "05060708");
+        assert_eq!(row.trace_flags, 1);
+        assert_eq!(row.severity_text, "INFO");
+        assert_eq!(row.severity_number, 9);
+        assert_eq!(row.service_name, "test-service");
+        assert_eq!(row.body, "test message");
+        assert_eq!(row.resource_schema_url, "test-schema");
+        assert_eq!(row.scope_name, "test-scope");
+        assert_eq!(row.scope_version, "1.0");
+    }
+
+    #[test]
+    fn test_from_resource_logs_empty() {
+        let resource_logs = ResourceLogs {
+            resource: None,
+            scope_logs: vec![],
+            schema_url: String::new(),
+        };
+
+        let result = LogRecordRow::from_resource_logs(&resource_logs).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_to_record_batch() {
+        let rows = vec![LogRecordRow {
+            timestamp: 1234567890,
+            trace_id: "01020304".to_string(),
+            span_id: "05060708".to_string(),
+            trace_flags: 1,
+            severity_text: "INFO".to_string(),
+            severity_number: 9,
+            service_name: "test-service".to_string(),
+            body: "test message".to_string(),
+            resource_schema_url: "test-schema".to_string(),
+            resource_attributes: MapOrJson::Map(Default::default()),
+            scope_schema_url: String::new(),
+            scope_name: "test-scope".to_string(),
+            scope_version: "1.0".to_string(),
+            scope_attributes: MapOrJson::Map(Default::default()),
+            log_attributes: MapOrJson::Map(Default::default()),
+        }];
+
+        let batch = LogRecordRow::to_record_batch(rows).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 15);
+    }
+}

--- a/src/exporters/file/parquet/metric.rs
+++ b/src/exporters/file/parquet/metric.rs
@@ -1,0 +1,499 @@
+use std::sync::Arc;
+
+use arrow::array::ArrayRef;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
+use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+
+use super::common::{MapOrJson, ToRecordBatch, map_or_json_to_string};
+use crate::exporters::file::FileExporterError;
+// No longer using the macros since we consume data directly
+
+// Static schema created once and reused for all metric record batches
+static METRIC_SCHEMA: std::sync::LazyLock<Arc<Schema>> = std::sync::LazyLock::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::UInt64, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("unit", DataType::Utf8, false),
+        Field::new("type_", DataType::Utf8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("value_int", DataType::Int64, true), // nullable for integer values
+        Field::new("value_double", DataType::Float64, true), // nullable for double values
+        Field::new("value_type", DataType::Utf8, false), // "int" | "double" | "histogram" | "summary"
+        Field::new("attributes", DataType::Utf8, false), // metric-level attributes
+        Field::new("complex_value", DataType::Utf8, true), // JSON for histograms/summaries (nullable)
+        Field::new("resource_attributes", DataType::Utf8, false),
+        Field::new("scope_name", DataType::Utf8, false),
+        Field::new("scope_version", DataType::Utf8, false),
+        Field::new("scope_attributes", DataType::Utf8, false),
+    ]))
+});
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct MetricRow {
+    pub timestamp: u64,
+    pub name: String,
+    pub description: String,
+    pub unit: String,
+    pub type_: String,
+    pub service_name: String,
+    pub value_int: Option<i64>,        // For integer metric values
+    pub value_double: Option<f64>,     // For double metric values
+    pub value_type: String,            // "int" | "double" | "histogram" | "summary"
+    pub attributes: MapOrJson,         // Data point attributes
+    pub complex_value: Option<String>, // JSON for histogram/summary data
+    pub resource_attributes: MapOrJson,
+    pub scope_name: String,
+    pub scope_version: String,
+    pub scope_attributes: MapOrJson,
+}
+
+impl ToRecordBatch for MetricRow {
+    fn to_record_batch(rows: Vec<Self>) -> Result<RecordBatch, FileExporterError> {
+        // Pre-allocate all the collections
+        let mut timestamps = Vec::with_capacity(rows.len());
+        let mut names = Vec::with_capacity(rows.len());
+        let mut descriptions = Vec::with_capacity(rows.len());
+        let mut units = Vec::with_capacity(rows.len());
+        let mut types = Vec::with_capacity(rows.len());
+        let mut service_names = Vec::with_capacity(rows.len());
+        let mut value_ints = Vec::with_capacity(rows.len());
+        let mut value_doubles = Vec::with_capacity(rows.len());
+        let mut value_types = Vec::with_capacity(rows.len());
+        let mut attributes = Vec::with_capacity(rows.len());
+        let mut complex_values = Vec::with_capacity(rows.len());
+        let mut resource_attributes = Vec::with_capacity(rows.len());
+        let mut scope_names = Vec::with_capacity(rows.len());
+        let mut scope_versions = Vec::with_capacity(rows.len());
+        let mut scope_attributes = Vec::with_capacity(rows.len());
+
+        // Move data from rows, consuming it
+        for row in rows {
+            timestamps.push(row.timestamp);
+            names.push(row.name);
+            descriptions.push(row.description);
+            units.push(row.unit);
+            types.push(row.type_);
+            service_names.push(row.service_name);
+            value_ints.push(row.value_int);
+            value_doubles.push(row.value_double);
+            value_types.push(row.value_type);
+            attributes.push(map_or_json_to_string(&row.attributes));
+            complex_values.push(row.complex_value);
+            resource_attributes.push(map_or_json_to_string(&row.resource_attributes));
+            scope_names.push(row.scope_name);
+            scope_versions.push(row.scope_version);
+            scope_attributes.push(map_or_json_to_string(&row.scope_attributes));
+        }
+
+        // Build arrays from the consumed data
+        let timestamp = arrow::array::UInt64Array::from(timestamps);
+        let name = arrow::array::StringArray::from(names);
+        let description = arrow::array::StringArray::from(descriptions);
+        let unit = arrow::array::StringArray::from(units);
+        let type_ = arrow::array::StringArray::from(types);
+        let service_name = arrow::array::StringArray::from(service_names);
+        let value_int = arrow::array::Int64Array::from(value_ints);
+        let value_double = arrow::array::Float64Array::from(value_doubles);
+        let value_type = arrow::array::StringArray::from(value_types);
+        let attributes_array = arrow::array::StringArray::from(attributes);
+        let complex_value = arrow::array::StringArray::from(complex_values);
+        let resource_attributes = arrow::array::StringArray::from(resource_attributes);
+        let scope_name = arrow::array::StringArray::from(scope_names);
+        let scope_version = arrow::array::StringArray::from(scope_versions);
+        let scope_attributes = arrow::array::StringArray::from(scope_attributes);
+
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(timestamp),
+            Arc::new(name),
+            Arc::new(description),
+            Arc::new(unit),
+            Arc::new(type_),
+            Arc::new(service_name),
+            Arc::new(value_int),
+            Arc::new(value_double),
+            Arc::new(value_type),
+            Arc::new(attributes_array),
+            Arc::new(complex_value),
+            Arc::new(resource_attributes),
+            Arc::new(scope_name),
+            Arc::new(scope_version),
+            Arc::new(scope_attributes),
+        ];
+
+        // Use the static schema instead of creating a new one
+        RecordBatch::try_new(METRIC_SCHEMA.clone(), columns)
+            .map_err(|e| FileExporterError::Export(e.to_string()))
+    }
+}
+
+// Helper function to extract numeric values from NumberDataPoint
+fn extract_number_value(
+    dp: &opentelemetry_proto::tonic::metrics::v1::NumberDataPoint,
+) -> (Option<i64>, Option<f64>, String) {
+    use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
+
+    match &dp.value {
+        Some(Value::AsInt(i)) => (Some(*i), None, "int".to_string()),
+        Some(Value::AsDouble(d)) => (None, Some(*d), "double".to_string()),
+        None => (None, None, "null".to_string()),
+    }
+}
+
+impl MetricRow {
+    pub fn from_resource_metrics(
+        resource_metrics: &ResourceMetrics,
+    ) -> Result<Vec<MetricRow>, FileExporterError> {
+        // retain core imports only
+        use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValue;
+
+        fn attrs_to_map(attrs: &[opentelemetry_proto::tonic::common::v1::KeyValue]) -> MapOrJson {
+            let mut map = std::collections::HashMap::new();
+            for attr in attrs {
+                if let Some(any_value) = &attr.value {
+                    let value_str = match &any_value.value {
+                        Some(AnyValue::StringValue(s)) => s.clone(),
+                        Some(AnyValue::BoolValue(b)) => b.to_string(),
+                        Some(AnyValue::IntValue(i)) => i.to_string(),
+                        Some(AnyValue::DoubleValue(d)) => d.to_string(),
+                        _ => "".to_string(),
+                    };
+                    map.insert(attr.key.clone(), value_str);
+                }
+            }
+            MapOrJson::Map(map)
+        }
+
+        // Resource-level attributes ----------------------------
+        let resource_attrs = resource_metrics
+            .resource
+            .as_ref()
+            .map(|r| attrs_to_map(&r.attributes))
+            .unwrap_or(MapOrJson::Map(Default::default()));
+
+        // Extract service.name from resource attributes
+        let service_name = if let MapOrJson::Map(map) = &resource_attrs {
+            map.get("service.name").cloned().unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let mut rows = Vec::new();
+
+        for scope_metrics in &resource_metrics.scope_metrics {
+            let scope_name = scope_metrics
+                .scope
+                .as_ref()
+                .map(|s| s.name.clone())
+                .unwrap_or_default();
+            let scope_version = scope_metrics
+                .scope
+                .as_ref()
+                .map(|s| s.version.clone())
+                .unwrap_or_default();
+            let scope_attributes = scope_metrics
+                .scope
+                .as_ref()
+                .map(|s| attrs_to_map(&s.attributes))
+                .unwrap_or(MapOrJson::Map(Default::default()));
+
+            for metric in &scope_metrics.metrics {
+                match metric.data.as_ref() {
+                    Some(Data::Gauge(g)) => {
+                        for dp in &g.data_points {
+                            let (value_int, value_double, value_type) = extract_number_value(dp);
+                            rows.push(MetricRow {
+                                timestamp: dp.time_unix_nano,
+                                name: metric.name.clone(),
+                                description: metric.description.clone(),
+                                unit: metric.unit.clone(),
+                                type_: "gauge".to_string(),
+                                service_name: service_name.clone(),
+                                value_int,
+                                value_double,
+                                value_type,
+                                attributes: attrs_to_map(&dp.attributes),
+                                complex_value: None,
+                                resource_attributes: resource_attrs.clone(),
+                                scope_name: scope_name.clone(),
+                                scope_version: scope_version.clone(),
+                                scope_attributes: scope_attributes.clone(),
+                            });
+                        }
+                    }
+                    Some(Data::Sum(s)) => {
+                        for dp in &s.data_points {
+                            let (value_int, value_double, value_type) = extract_number_value(dp);
+                            rows.push(MetricRow {
+                                timestamp: dp.time_unix_nano,
+                                name: metric.name.clone(),
+                                description: metric.description.clone(),
+                                unit: metric.unit.clone(),
+                                type_: "sum".to_string(),
+                                service_name: service_name.clone(),
+                                value_int,
+                                value_double,
+                                value_type,
+                                attributes: attrs_to_map(&dp.attributes),
+                                complex_value: None,
+                                resource_attributes: resource_attrs.clone(),
+                                scope_name: scope_name.clone(),
+                                scope_version: scope_version.clone(),
+                                scope_attributes: scope_attributes.clone(),
+                            });
+                        }
+                    }
+                    Some(Data::Histogram(h)) => {
+                        for dp in &h.data_points {
+                            rows.push(MetricRow {
+                                timestamp: dp.time_unix_nano,
+                                name: metric.name.clone(),
+                                description: metric.description.clone(),
+                                unit: metric.unit.clone(),
+                                type_: "histogram".to_string(),
+                                service_name: service_name.clone(),
+                                value_int: None,
+                                value_double: Some(dp.sum.unwrap_or(0.0)), // Store histogram sum as the main value
+                                value_type: "histogram".to_string(),
+                                attributes: attrs_to_map(&dp.attributes),
+                                complex_value: Some(histogram_datapoint_to_json(dp)),
+                                resource_attributes: resource_attrs.clone(),
+                                scope_name: scope_name.clone(),
+                                scope_version: scope_version.clone(),
+                                scope_attributes: scope_attributes.clone(),
+                            });
+                        }
+                    }
+                    Some(Data::ExponentialHistogram(eh)) => {
+                        for dp in &eh.data_points {
+                            rows.push(MetricRow {
+                                timestamp: dp.time_unix_nano,
+                                name: metric.name.clone(),
+                                description: metric.description.clone(),
+                                unit: metric.unit.clone(),
+                                type_: "exponential_histogram".to_string(),
+                                service_name: service_name.clone(),
+                                value_int: None,
+                                value_double: dp.sum, // Store histogram sum as the main value
+                                value_type: "exponential_histogram".to_string(),
+                                attributes: attrs_to_map(&dp.attributes),
+                                complex_value: Some(exp_hist_datapoint_to_json(dp)),
+                                resource_attributes: resource_attrs.clone(),
+                                scope_name: scope_name.clone(),
+                                scope_version: scope_version.clone(),
+                                scope_attributes: scope_attributes.clone(),
+                            });
+                        }
+                    }
+                    Some(Data::Summary(su)) => {
+                        for dp in &su.data_points {
+                            rows.push(MetricRow {
+                                timestamp: dp.time_unix_nano,
+                                name: metric.name.clone(),
+                                description: metric.description.clone(),
+                                unit: metric.unit.clone(),
+                                type_: "summary".to_string(),
+                                service_name: service_name.clone(),
+                                value_int: None,
+                                value_double: Some(dp.sum), // Store summary sum as the main value
+                                value_type: "summary".to_string(),
+                                attributes: attrs_to_map(&dp.attributes),
+                                complex_value: Some(summary_datapoint_to_json(dp)),
+                                resource_attributes: resource_attrs.clone(),
+                                scope_name: scope_name.clone(),
+                                scope_version: scope_version.clone(),
+                                scope_attributes: scope_attributes.clone(),
+                            });
+                        }
+                    }
+                    None => {
+                        // Unknown metric type, skip or handle as needed
+                    }
+                }
+            }
+        }
+
+        Ok(rows)
+    }
+}
+
+// ---- helper functions --------------------------------------------
+
+fn histogram_datapoint_to_json(
+    dp: &opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint,
+) -> String {
+    let v = serde_json::json!({
+        "count": dp.count,
+        "sum": dp.sum,
+        "bucket_counts": dp.bucket_counts,
+        "explicit_bounds": dp.explicit_bounds,
+    });
+    v.to_string()
+}
+
+fn exp_hist_datapoint_to_json(
+    dp: &opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint,
+) -> String {
+    let v = serde_json::json!({
+        "count": dp.count,
+        "sum": dp.sum.unwrap_or(0.0),
+        "scale": dp.scale,
+        "zero_count": dp.zero_count,
+        "positive": {
+            "offset": dp.positive.as_ref().map(|p| p.offset).unwrap_or(0),
+            "bucket_counts": dp.positive.as_ref().map(|p| &p.bucket_counts).unwrap_or(&vec![]),
+        },
+        "negative": {
+            "offset": dp.negative.as_ref().map(|n| n.offset).unwrap_or(0),
+            "bucket_counts": dp.negative.as_ref().map(|n| &n.bucket_counts).unwrap_or(&vec![]),
+        }
+    });
+    v.to_string()
+}
+
+fn summary_datapoint_to_json(
+    dp: &opentelemetry_proto::tonic::metrics::v1::SummaryDataPoint,
+) -> String {
+    let quantiles: Vec<_> = dp
+        .quantile_values
+        .iter()
+        .map(|qv| {
+            serde_json::json!({
+                "quantile": qv.quantile,
+                "value": qv.value,
+            })
+        })
+        .collect();
+    let v = serde_json::json!({
+        "count": dp.count,
+        "sum": dp.sum,
+        "quantile_values": quantiles,
+    });
+    v.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+    use opentelemetry_proto::tonic::metrics::v1::{
+        Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics,
+    };
+    use opentelemetry_proto::tonic::resource::v1::Resource;
+
+    #[test]
+    fn test_from_resource_metrics_multiple_gauge_datapoints() {
+        // Create two data points
+        let dp1 = NumberDataPoint {
+            time_unix_nano: 111,
+            value: Some(
+                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(42),
+            ),
+            ..Default::default()
+        };
+        let dp2 = NumberDataPoint {
+            time_unix_nano: 222,
+            value: Some(
+                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsDouble(3.14),
+            ),
+            ..Default::default()
+        };
+        let gauge = Gauge {
+            data_points: vec![dp1.clone(), dp2.clone()],
+            ..Default::default()
+        };
+        let metric = Metric {
+            name: "test_metric".to_string(),
+            description: "desc".to_string(),
+            unit: "unit".to_string(),
+            data: Some(Data::Gauge(gauge)),
+            ..Default::default()
+        };
+        let scope_metrics = ScopeMetrics {
+            scope: Some(InstrumentationScope {
+                name: "myscope".to_string(),
+                version: "1.0".to_string(),
+                ..Default::default()
+            }),
+            metrics: vec![metric],
+            ..Default::default()
+        };
+        let resource = Resource {
+            attributes: vec![KeyValue {
+                key: "service.name".to_string(),
+                value: Some(AnyValue {
+                    value: Some(
+                        opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                            "svc".to_string(),
+                        ),
+                    ),
+                }),
+            }],
+            ..Default::default()
+        };
+        let resource_metrics = ResourceMetrics {
+            resource: Some(resource),
+            scope_metrics: vec![scope_metrics],
+            ..Default::default()
+        };
+
+        let rows = MetricRow::from_resource_metrics(&resource_metrics).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].timestamp, 111);
+        assert_eq!(rows[1].timestamp, 222);
+        assert_eq!(rows[0].name, "test_metric");
+        assert_eq!(rows[0].type_, "gauge");
+        assert_eq!(rows[0].service_name, "svc");
+        assert_eq!(rows[0].scope_name, "myscope");
+        assert_eq!(rows[0].scope_version, "1.0");
+        // Check numeric value extraction
+        assert_eq!(rows[0].value_int, Some(42));
+        assert_eq!(rows[0].value_double, None);
+        assert_eq!(rows[0].value_type, "int");
+
+        assert_eq!(rows[1].value_int, None);
+        assert_eq!(rows[1].value_double, Some(3.14));
+        assert_eq!(rows[1].value_type, "double");
+    }
+
+    #[test]
+    fn test_numeric_value_extraction() {
+        use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value;
+
+        // Test integer value
+        let dp_int = NumberDataPoint {
+            time_unix_nano: 1000,
+            value: Some(Value::AsInt(123)),
+            ..Default::default()
+        };
+        let (value_int, value_double, value_type) = super::extract_number_value(&dp_int);
+        assert_eq!(value_int, Some(123));
+        assert_eq!(value_double, None);
+        assert_eq!(value_type, "int");
+
+        // Test double value
+        let dp_double = NumberDataPoint {
+            time_unix_nano: 2000,
+            value: Some(Value::AsDouble(45.67)),
+            ..Default::default()
+        };
+        let (value_int, value_double, value_type) = super::extract_number_value(&dp_double);
+        assert_eq!(value_int, None);
+        assert_eq!(value_double, Some(45.67));
+        assert_eq!(value_type, "double");
+
+        // Test null value
+        let dp_null = NumberDataPoint {
+            time_unix_nano: 3000,
+            value: None,
+            ..Default::default()
+        };
+        let (value_int, value_double, value_type) = super::extract_number_value(&dp_null);
+        assert_eq!(value_int, None);
+        assert_eq!(value_double, None);
+        assert_eq!(value_type, "null");
+    }
+}

--- a/src/exporters/file/parquet/mod.rs
+++ b/src/exporters/file/parquet/mod.rs
@@ -1,0 +1,11 @@
+pub mod common;
+pub mod exporter;
+pub mod log;
+pub mod metric;
+pub mod span;
+
+pub use common::{MapOrJson, ToRecordBatch};
+pub use exporter::ParquetExporter;
+pub use log::LogRecordRow;
+pub use metric::MetricRow;
+pub use span::SpanRow;

--- a/src/exporters/file/parquet/span.rs
+++ b/src/exporters/file/parquet/span.rs
@@ -1,0 +1,546 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+
+use super::common::{
+    MapOrJson, ToRecordBatch, map_or_json_to_string, vec_maporjson_to_list_array,
+    vec_string_to_list_array, vec_u64_to_list_array,
+};
+use crate::exporters::file::FileExporterError;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use serde_json;
+// No longer using the macros since we consume data directly
+
+// Static schema created once and reused for all span record batches
+static SPAN_SCHEMA: std::sync::LazyLock<Arc<Schema>> = std::sync::LazyLock::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::UInt64, false),
+        Field::new("trace_id", DataType::Utf8, false),
+        Field::new("span_id", DataType::Utf8, false),
+        Field::new("parent_span_id", DataType::Utf8, false),
+        Field::new("trace_state", DataType::Utf8, false),
+        Field::new("span_name", DataType::Utf8, false),
+        Field::new("span_kind", DataType::Utf8, false),
+        Field::new("service_name", DataType::Utf8, false),
+        Field::new("resource_attributes", DataType::Utf8, false),
+        Field::new("scope_name", DataType::Utf8, false),
+        Field::new("scope_version", DataType::Utf8, false),
+        Field::new("span_attributes", DataType::Utf8, false),
+        Field::new("duration", DataType::Int64, false),
+        Field::new("status_code", DataType::Utf8, false),
+        Field::new("status_message", DataType::Utf8, false),
+        Field::new(
+            "events_timestamp",
+            DataType::List(Arc::new(Field::new("item", DataType::UInt64, true))),
+            false,
+        ),
+        Field::new(
+            "events_name",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        Field::new(
+            "events_attributes",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        Field::new(
+            "links_trace_id",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        Field::new(
+            "links_span_id",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        Field::new(
+            "links_trace_state",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        Field::new(
+            "links_attributes",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+    ]))
+});
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct SpanRow {
+    pub timestamp: u64,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: String,
+    pub trace_state: String,
+    pub span_name: String,
+    pub span_kind: String,
+    pub service_name: String,
+    pub resource_attributes: MapOrJson,
+    pub scope_name: String,
+    pub scope_version: String,
+    pub span_attributes: MapOrJson,
+    pub duration: i64,
+    pub status_code: String,
+    pub status_message: String,
+    pub events_timestamp: Vec<u64>,
+    pub events_name: Vec<String>,
+    pub events_attributes: Vec<MapOrJson>,
+    pub links_trace_id: Vec<String>,
+    pub links_span_id: Vec<String>,
+    pub links_trace_state: Vec<String>,
+    pub links_attributes: Vec<MapOrJson>,
+}
+
+impl ToRecordBatch for SpanRow {
+    fn to_record_batch(rows: Vec<Self>) -> Result<RecordBatch, FileExporterError> {
+        // Pre-allocate all the collections
+        let mut timestamps = Vec::with_capacity(rows.len());
+        let mut trace_ids = Vec::with_capacity(rows.len());
+        let mut span_ids = Vec::with_capacity(rows.len());
+        let mut parent_span_ids = Vec::with_capacity(rows.len());
+        let mut trace_states = Vec::with_capacity(rows.len());
+        let mut span_names = Vec::with_capacity(rows.len());
+        let mut span_kinds = Vec::with_capacity(rows.len());
+        let mut service_names = Vec::with_capacity(rows.len());
+        let mut resource_attributes = Vec::with_capacity(rows.len());
+        let mut scope_names = Vec::with_capacity(rows.len());
+        let mut scope_versions = Vec::with_capacity(rows.len());
+        let mut span_attributes = Vec::with_capacity(rows.len());
+        let mut durations = Vec::with_capacity(rows.len());
+        let mut status_codes = Vec::with_capacity(rows.len());
+        let mut status_messages = Vec::with_capacity(rows.len());
+        let mut events_timestamps = Vec::with_capacity(rows.len());
+        let mut events_names = Vec::with_capacity(rows.len());
+        let mut events_attrs = Vec::with_capacity(rows.len());
+        let mut links_trace_ids = Vec::with_capacity(rows.len());
+        let mut links_span_ids = Vec::with_capacity(rows.len());
+        let mut links_trace_states = Vec::with_capacity(rows.len());
+        let mut links_attrs = Vec::with_capacity(rows.len());
+
+        // Move data from rows, consuming it
+        for row in rows {
+            timestamps.push(row.timestamp);
+            trace_ids.push(row.trace_id);
+            span_ids.push(row.span_id);
+            parent_span_ids.push(row.parent_span_id);
+            trace_states.push(row.trace_state);
+            span_names.push(row.span_name);
+            span_kinds.push(row.span_kind);
+            service_names.push(row.service_name);
+            resource_attributes.push(map_or_json_to_string(&row.resource_attributes));
+            scope_names.push(row.scope_name);
+            scope_versions.push(row.scope_version);
+            span_attributes.push(map_or_json_to_string(&row.span_attributes));
+            durations.push(row.duration);
+            status_codes.push(row.status_code);
+            status_messages.push(row.status_message);
+            events_timestamps.push(row.events_timestamp);
+            events_names.push(row.events_name);
+            events_attrs.push(row.events_attributes);
+            links_trace_ids.push(row.links_trace_id);
+            links_span_ids.push(row.links_span_id);
+            links_trace_states.push(row.links_trace_state);
+            links_attrs.push(row.links_attributes);
+        }
+
+        // Build arrays from the consumed data
+        let timestamp = arrow::array::UInt64Array::from(timestamps);
+        let trace_id = arrow::array::StringArray::from(trace_ids);
+        let span_id = arrow::array::StringArray::from(span_ids);
+        let parent_span_id = arrow::array::StringArray::from(parent_span_ids);
+        let trace_state = arrow::array::StringArray::from(trace_states);
+        let span_name = arrow::array::StringArray::from(span_names);
+        let span_kind = arrow::array::StringArray::from(span_kinds);
+        let service_name = arrow::array::StringArray::from(service_names);
+        let resource_attributes = StringArray::from(resource_attributes);
+        let scope_name = arrow::array::StringArray::from(scope_names);
+        let scope_version = arrow::array::StringArray::from(scope_versions);
+        let span_attributes = StringArray::from(span_attributes);
+        let duration = arrow::array::Int64Array::from(durations);
+        let status_code = arrow::array::StringArray::from(status_codes);
+        let status_message = arrow::array::StringArray::from(status_messages);
+        let events_timestamp = vec_u64_to_list_array(events_timestamps);
+        let events_name = vec_string_to_list_array(events_names);
+        let events_attributes = vec_maporjson_to_list_array(events_attrs);
+        let links_trace_id = vec_string_to_list_array(links_trace_ids);
+        let links_span_id = vec_string_to_list_array(links_span_ids);
+        let links_trace_state = vec_string_to_list_array(links_trace_states);
+        let links_attributes = vec_maporjson_to_list_array(links_attrs);
+
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(timestamp),
+            Arc::new(trace_id),
+            Arc::new(span_id),
+            Arc::new(parent_span_id),
+            Arc::new(trace_state),
+            Arc::new(span_name),
+            Arc::new(span_kind),
+            Arc::new(service_name),
+            Arc::new(resource_attributes),
+            Arc::new(scope_name),
+            Arc::new(scope_version),
+            Arc::new(span_attributes),
+            Arc::new(duration),
+            Arc::new(status_code),
+            Arc::new(status_message),
+            Arc::new(events_timestamp),
+            Arc::new(events_name),
+            Arc::new(events_attributes),
+            Arc::new(links_trace_id),
+            Arc::new(links_span_id),
+            Arc::new(links_trace_state),
+            Arc::new(links_attributes),
+        ];
+
+        // Use the static schema instead of creating a new one
+        RecordBatch::try_new(SPAN_SCHEMA.clone(), columns)
+            .map_err(|e| FileExporterError::Export(e.to_string()))
+    }
+}
+
+impl SpanRow {
+    pub fn from_resource_spans(
+        resource_spans: &ResourceSpans,
+    ) -> Result<Vec<SpanRow>, FileExporterError> {
+        let mut rows = Vec::new();
+
+        // Convert resource attributes into a map ---------------------------------
+        let resource_attributes: MapOrJson = {
+            let mut map = HashMap::new();
+            if let Some(resource) = &resource_spans.resource {
+                for attr in &resource.attributes {
+                    if let Some(any_value) = &attr.value {
+                        let value_str = match &any_value.value {
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => s.clone(),
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(b)) => b.to_string(),
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i)) => i.to_string(),
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(d)) => d.to_string(),
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::ArrayValue(arr)) => serde_json::to_string(&arr.values).unwrap_or_else(|_| "[]".to_string()),
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(kvlist)) => {
+                                let map: std::collections::HashMap<_, _> = kvlist.values.iter().map(|kv| {
+                                    let v = match &kv.value {
+                                        Some(val) => match &val.value {
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => serde_json::json!(s),
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(b)) => serde_json::json!(b),
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i)) => serde_json::json!(i),
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(d)) => serde_json::json!(d),
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::ArrayValue(arr)) => serde_json::json!(arr.values.iter().map(|v| format!("{:?}", v)).collect::<Vec<_>>()),
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(_)) => serde_json::json!("{}"), // Nested kvlist: skip or flatten recursively if needed
+                                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(bytes)) => serde_json::json!(BASE64_STANDARD.encode(bytes)),
+                                            None => serde_json::json!(null),
+                                        },
+                                        None => serde_json::json!(null),
+                                    };
+                                    (kv.key.clone(), v)
+                                }).collect();
+                                serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+                            }
+                            Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(bytes)) => BASE64_STANDARD.encode(bytes),
+                            None => "".to_string(),
+                        };
+                        map.insert(attr.key.clone(), value_str);
+                    }
+                }
+            }
+            MapOrJson::Map(map)
+        };
+
+        // Extract service.name from resource attributes, default to "unknown" ---
+        let service_name = if let MapOrJson::Map(map) = &resource_attributes {
+            map.get("service.name")
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string())
+        } else {
+            "unknown".to_string()
+        };
+
+        // Helper to convert attribute list to MapOrJson --------------------------
+        fn attrs_to_map(
+            attrs: &Vec<opentelemetry_proto::tonic::common::v1::KeyValue>,
+        ) -> MapOrJson {
+            let mut map = HashMap::new();
+            for attr in attrs {
+                if let Some(any_value) = &attr.value {
+                    let value_str = match &any_value.value {
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                                s,
+                            ),
+                        ) => s.clone(),
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(b),
+                        ) => b.to_string(),
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i),
+                        ) => i.to_string(),
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(
+                                d,
+                            ),
+                        ) => d.to_string(),
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::ArrayValue(
+                                arr,
+                            ),
+                        ) => {
+                            serde_json::to_string(&arr.values).unwrap_or_else(|_| "[]".to_string())
+                        }
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(
+                                kvlist,
+                            ),
+                        ) => {
+                            let map: std::collections::HashMap<_, _> = kvlist.values.iter().map(|kv| {
+                                let v = match &kv.value {
+                                    Some(val) => match &val.value {
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => serde_json::json!(s),
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(b)) => serde_json::json!(b),
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i)) => serde_json::json!(i),
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(d)) => serde_json::json!(d),
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::ArrayValue(arr)) => serde_json::json!(arr.values.iter().map(|v| format!("{:?}", v)).collect::<Vec<_>>()),
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(_)) => serde_json::json!("{}"), // Nested kvlist: skip or flatten recursively if needed
+                                        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(bytes)) => serde_json::json!(BASE64_STANDARD.encode(bytes)),
+                                        None => serde_json::json!(null),
+                                    },
+                                    None => serde_json::json!(null),
+                                };
+                                (kv.key.clone(), v)
+                            }).collect();
+                            serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+                        }
+                        Some(
+                            opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(
+                                bytes,
+                            ),
+                        ) => BASE64_STANDARD.encode(bytes),
+                        None => "".to_string(),
+                    };
+                    map.insert(attr.key.clone(), value_str);
+                }
+            }
+            MapOrJson::Map(map)
+        }
+
+        // Helper to convert span kind to string ----------------------------------
+        fn span_kind_to_string(kind: i32) -> String {
+            match kind {
+                0 => "Unspecified".to_string(),
+                1 => "Internal".to_string(),
+                2 => "Server".to_string(),
+                3 => "Client".to_string(),
+                4 => "Producer".to_string(),
+                5 => "Consumer".to_string(),
+                _ => "Unspecified".to_string(),
+            }
+        }
+
+        // Helper to convert status code to string --------------------------------
+        fn status_code(span: &opentelemetry_proto::tonic::trace::v1::Span) -> String {
+            match &span.status {
+                None => "Unset".to_string(),
+                Some(s) => match s.code {
+                    0 => "Unset".to_string(),
+                    1 => "Ok".to_string(),
+                    2 => "Error".to_string(),
+                    _ => "Unset".to_string(),
+                },
+            }
+        }
+
+        fn status_message(span: &opentelemetry_proto::tonic::trace::v1::Span) -> String {
+            match &span.status {
+                None => "".to_string(),
+                Some(s) => s.message.clone(),
+            }
+        }
+
+        // -----------------------------------------------------------------------
+        for scope_spans in &resource_spans.scope_spans {
+            let scope_name = scope_spans
+                .scope
+                .as_ref()
+                .map_or("".to_string(), |s| s.name.clone());
+            let scope_version = scope_spans
+                .scope
+                .as_ref()
+                .map_or("".to_string(), |s| s.version.clone());
+
+            let _scope_attributes = attrs_to_map(
+                &scope_spans
+                    .scope
+                    .as_ref()
+                    .map_or(vec![], |s| s.attributes.clone()),
+            );
+
+            for span in &scope_spans.spans {
+                // Build the row --------------------------------------------------
+                let mut row = SpanRow {
+                    timestamp: span.start_time_unix_nano,
+                    trace_id: hex::encode(span.trace_id.clone()),
+                    span_id: hex::encode(span.span_id.clone()),
+                    parent_span_id: hex::encode(span.parent_span_id.clone()),
+                    trace_state: span.trace_state.clone(),
+                    span_name: span.name.clone(),
+                    span_kind: span_kind_to_string(span.kind),
+                    service_name: service_name.clone(),
+                    resource_attributes: resource_attributes.clone(),
+                    scope_name: scope_name.clone(),
+                    scope_version: scope_version.clone(),
+                    span_attributes: attrs_to_map(&span.attributes),
+                    duration: (span.end_time_unix_nano as i64 - span.start_time_unix_nano as i64),
+                    status_code: status_code(span),
+                    status_message: status_message(span),
+                    events_timestamp: Vec::new(),
+                    events_name: Vec::new(),
+                    events_attributes: Vec::new(),
+                    links_trace_id: Vec::new(),
+                    links_span_id: Vec::new(),
+                    links_trace_state: Vec::new(),
+                    links_attributes: Vec::new(),
+                };
+
+                // Populate events ----------------------------------------------
+                for event in &span.events {
+                    row.events_timestamp.push(event.time_unix_nano);
+                    row.events_name.push(event.name.clone());
+                    row.events_attributes.push(attrs_to_map(&event.attributes));
+                }
+
+                // Populate links -----------------------------------------------
+                for link in &span.links {
+                    row.links_trace_id.push(hex::encode(link.trace_id.clone()));
+                    row.links_span_id.push(hex::encode(link.span_id.clone()));
+                    row.links_trace_state.push(link.trace_state.clone());
+                    row.links_attributes.push(attrs_to_map(&link.attributes));
+                }
+
+                rows.push(row);
+            }
+        }
+
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+    use opentelemetry_proto::tonic::resource::v1::Resource;
+    use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span, Status};
+
+    #[test]
+    fn test_from_resource_spans_basic() {
+        let resource_spans = ResourceSpans {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue {
+                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("test-service".to_string())),
+                    }),
+                }],
+                ..Default::default()
+            }),
+            scope_spans: vec![ScopeSpans {
+                scope: Some(InstrumentationScope {
+                    name: "test-scope".to_string(),
+                    version: "1.0".to_string(),
+                    ..Default::default()
+                }),
+                spans: vec![Span {
+                    trace_id: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                    span_id: vec![1, 2, 3, 4, 5, 6, 7, 8],
+                    parent_span_id: vec![],
+                    name: "test-span".to_string(),
+                    kind: 2, // Server
+                    start_time_unix_nano: 1234567890,
+                    end_time_unix_nano: 1234567900,
+                    attributes: vec![KeyValue {
+                        key: "span.key".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("span.value".to_string())),
+                        }),
+                    }],
+                    status: Some(Status {
+                        code: 1, // Ok
+                        message: "success".to_string(),
+                    }),
+                    trace_state: "test=1".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            schema_url: "test-schema".to_string(),
+        };
+
+        let result = SpanRow::from_resource_spans(&resource_spans).unwrap();
+        assert_eq!(result.len(), 1);
+
+        let row = &result[0];
+        assert_eq!(row.timestamp, 1234567890);
+        assert_eq!(row.trace_id, "0102030405060708090a0b0c0d0e0f10");
+        assert_eq!(row.span_id, "0102030405060708");
+        assert_eq!(row.parent_span_id, "");
+        assert_eq!(row.span_name, "test-span");
+        assert_eq!(row.span_kind, "Server");
+        assert_eq!(row.service_name, "test-service");
+        assert_eq!(row.scope_name, "test-scope");
+        assert_eq!(row.scope_version, "1.0");
+        assert_eq!(row.duration, 10);
+        assert_eq!(row.status_code, "Ok");
+        assert_eq!(row.status_message, "success");
+        assert_eq!(row.trace_state, "test=1");
+    }
+
+    #[test]
+    fn test_from_resource_spans_empty() {
+        let resource_spans = ResourceSpans {
+            resource: None,
+            scope_spans: vec![],
+            schema_url: String::new(),
+        };
+
+        let result = SpanRow::from_resource_spans(&resource_spans).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_to_record_batch() {
+        let rows = vec![SpanRow {
+            timestamp: 1234567890,
+            trace_id: "0102030405060708090a0b0c0d0e0f10".to_string(),
+            span_id: "0102030405060708".to_string(),
+            parent_span_id: "".to_string(),
+            trace_state: "test=1".to_string(),
+            span_name: "test-span".to_string(),
+            span_kind: "Server".to_string(),
+            service_name: "test-service".to_string(),
+            resource_attributes: MapOrJson::Map(Default::default()),
+            scope_name: "test-scope".to_string(),
+            scope_version: "1.0".to_string(),
+            span_attributes: MapOrJson::Map(Default::default()),
+            duration: 10,
+            status_code: "Ok".to_string(),
+            status_message: "success".to_string(),
+            events_timestamp: vec![],
+            events_name: vec![],
+            events_attributes: vec![],
+            links_trace_id: vec![],
+            links_span_id: vec![],
+            links_trace_state: vec![],
+            links_attributes: vec![],
+        }];
+
+        let batch = SpanRow::to_record_batch(rows).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 22);
+    }
+}

--- a/src/exporters/file/task.rs
+++ b/src/exporters/file/task.rs
@@ -1,0 +1,442 @@
+use crate::bounded_channel::BoundedReceiver;
+use crate::exporters::file::config::FileExporterConfig;
+use crate::exporters::file::json::JsonExporter;
+use crate::exporters::file::parquet::{LogRecordRow, MetricRow, ParquetExporter, SpanRow};
+use crate::exporters::file::{FileExporterError, Result};
+use crate::init::file_exporter::FileExporterFormat;
+use chrono::Utc;
+use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
+use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+use std::path::Path;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+/// Generic trait for file exporters that can handle different data formats
+pub trait TypedFileExporter {
+    /// The type used to represent span data in this exporter
+    type SpanData: Clone + Send;
+    /// The type used to represent metric data in this exporter
+    type MetricData: Clone + Send;
+    /// The type used to represent log data in this exporter
+    type LogData: Clone + Send;
+
+    /// Convert ResourceSpans to the exporter's span data format
+    fn convert_spans(&self, resource_spans: &ResourceSpans) -> Result<Vec<Self::SpanData>>;
+    /// Convert ResourceMetrics to the exporter's metric data format
+    fn convert_metrics(&self, resource_metrics: &ResourceMetrics) -> Result<Vec<Self::MetricData>>;
+    /// Convert ResourceLogs to the exporter's log data format
+    fn convert_logs(&self, resource_logs: &ResourceLogs) -> Result<Vec<Self::LogData>>;
+
+    /// Export span data to a file
+    fn export_spans(&self, data: &[Self::SpanData], path: &Path) -> Result<()>;
+    /// Export metric data to a file
+    fn export_metrics(&self, data: &[Self::MetricData], path: &Path) -> Result<()>;
+    /// Export log data to a file
+    fn export_logs(&self, data: &[Self::LogData], path: &Path) -> Result<()>;
+
+    /// Get the file extension for this exporter
+    fn file_extension(&self) -> &'static str;
+}
+
+/// Implementation of TypedFileExporter for ParquetExporter
+impl TypedFileExporter for ParquetExporter {
+    type SpanData = SpanRow;
+    type MetricData = MetricRow;
+    type LogData = LogRecordRow;
+
+    fn convert_spans(&self, resource_spans: &ResourceSpans) -> Result<Vec<Self::SpanData>> {
+        SpanRow::from_resource_spans(resource_spans)
+    }
+
+    fn convert_metrics(&self, resource_metrics: &ResourceMetrics) -> Result<Vec<Self::MetricData>> {
+        MetricRow::from_resource_metrics(resource_metrics)
+    }
+
+    fn convert_logs(&self, resource_logs: &ResourceLogs) -> Result<Vec<Self::LogData>> {
+        LogRecordRow::from_resource_logs(resource_logs)
+    }
+
+    fn export_spans(&self, data: &[Self::SpanData], path: &Path) -> Result<()> {
+        self.export_span_rows(data, path)
+    }
+
+    fn export_metrics(&self, data: &[Self::MetricData], path: &Path) -> Result<()> {
+        self.export_metric_rows(data, path)
+    }
+
+    fn export_logs(&self, data: &[Self::LogData], path: &Path) -> Result<()> {
+        self.export_log_record_rows(data, path)
+    }
+
+    fn file_extension(&self) -> &'static str {
+        ".parquet"
+    }
+}
+
+/// Implementation of TypedFileExporter for JsonExporter
+impl TypedFileExporter for JsonExporter {
+    type SpanData = ResourceSpans;
+    type MetricData = ResourceMetrics;
+    type LogData = ResourceLogs;
+
+    fn convert_spans(&self, resource_spans: &ResourceSpans) -> Result<Vec<Self::SpanData>> {
+        Ok(vec![resource_spans.clone()])
+    }
+
+    fn convert_metrics(&self, resource_metrics: &ResourceMetrics) -> Result<Vec<Self::MetricData>> {
+        Ok(vec![resource_metrics.clone()])
+    }
+
+    fn convert_logs(&self, resource_logs: &ResourceLogs) -> Result<Vec<Self::LogData>> {
+        Ok(vec![resource_logs.clone()])
+    }
+
+    fn export_spans(&self, data: &[Self::SpanData], path: &Path) -> Result<()> {
+        self.export_traces(data, path)
+    }
+
+    fn export_metrics(&self, data: &[Self::MetricData], path: &Path) -> Result<()> {
+        self.export_metrics(data, path)
+    }
+
+    fn export_logs(&self, data: &[Self::LogData], path: &Path) -> Result<()> {
+        self.export_logs(data, path)
+    }
+
+    fn file_extension(&self) -> &'static str {
+        ".json"
+    }
+}
+
+pub async fn run_file_exporter(
+    config: FileExporterConfig,
+    traces_rx: BoundedReceiver<Vec<ResourceSpans>>,
+    metrics_rx: BoundedReceiver<Vec<ResourceMetrics>>,
+    logs_rx: BoundedReceiver<Vec<ResourceLogs>>,
+    token: CancellationToken,
+) -> Result<()> {
+    let format = config.format;
+    let path = config.path;
+    let flush_interval = config.flush_interval;
+
+    // Create output directories if they don't exist
+    let traces_dir = path.join("spans");
+    let metrics_dir = path.join("metrics");
+    let logs_dir = path.join("logs");
+
+    std::fs::create_dir_all(&traces_dir).map_err(FileExporterError::Io)?;
+    std::fs::create_dir_all(&metrics_dir).map_err(FileExporterError::Io)?;
+    std::fs::create_dir_all(&logs_dir).map_err(FileExporterError::Io)?;
+
+    info!(
+        "File exporter started, writing {} data to {}",
+        format,
+        path.display()
+    );
+
+    match format {
+        FileExporterFormat::Parquet => {
+            let compression = config.parquet_compression.to_parquet_compression();
+            let exporter = std::sync::Arc::new(ParquetExporter::with_compression(compression));
+            run_exporter_tasks(
+                exporter,
+                traces_dir,
+                metrics_dir,
+                logs_dir,
+                traces_rx,
+                metrics_rx,
+                logs_rx,
+                flush_interval,
+                token,
+            )
+            .await
+        }
+        FileExporterFormat::Json => {
+            let exporter = std::sync::Arc::new(JsonExporter::new());
+            run_exporter_tasks(
+                exporter,
+                traces_dir,
+                metrics_dir,
+                logs_dir,
+                traces_rx,
+                metrics_rx,
+                logs_rx,
+                flush_interval,
+                token,
+            )
+            .await
+        }
+    }
+}
+
+/// Helper function to spawn and join exporter tasks for traces, metrics, and logs
+async fn run_exporter_tasks<E>(
+    exporter: std::sync::Arc<E>,
+    traces_dir: std::path::PathBuf,
+    metrics_dir: std::path::PathBuf,
+    logs_dir: std::path::PathBuf,
+    traces_rx: BoundedReceiver<Vec<ResourceSpans>>,
+    metrics_rx: BoundedReceiver<Vec<ResourceMetrics>>,
+    logs_rx: BoundedReceiver<Vec<ResourceLogs>>,
+    flush_interval: std::time::Duration,
+    token: CancellationToken,
+) -> Result<()>
+where
+    E: TypedFileExporter + Send + Sync + 'static,
+{
+    let traces_task = {
+        let exporter = exporter.clone();
+        let traces_dir = traces_dir.clone();
+        let token = token.clone();
+        tokio::spawn(async move {
+            run_traces_loop(exporter, traces_dir, traces_rx, flush_interval, token).await
+        })
+    };
+
+    let metrics_task = {
+        let exporter = exporter.clone();
+        let metrics_dir = metrics_dir.clone();
+        let token = token.clone();
+        tokio::spawn(async move {
+            run_metrics_loop(exporter, metrics_dir, metrics_rx, flush_interval, token).await
+        })
+    };
+
+    let logs_task = {
+        let exporter = exporter.clone();
+        let logs_dir = logs_dir.clone();
+        let token = token.clone();
+        tokio::spawn(async move {
+            run_logs_loop(exporter, logs_dir, logs_rx, flush_interval, token).await
+        })
+    };
+
+    let (traces_result, metrics_result, logs_result) =
+        tokio::join!(traces_task, metrics_task, logs_task);
+
+    if let Err(e) = traces_result {
+        return Err(FileExporterError::Export(format!(
+            "Traces task failed: {}",
+            e
+        )));
+    }
+    if let Err(e) = metrics_result {
+        return Err(FileExporterError::Export(format!(
+            "Metrics task failed: {}",
+            e
+        )));
+    }
+    if let Err(e) = logs_result {
+        return Err(FileExporterError::Export(format!(
+            "Logs task failed: {}",
+            e
+        )));
+    }
+
+    Ok(())
+}
+
+/// Event loop for processing trace data
+pub async fn run_traces_loop<E>(
+    exporter: std::sync::Arc<E>,
+    traces_dir: std::path::PathBuf,
+    mut traces_rx: BoundedReceiver<Vec<ResourceSpans>>,
+    flush_interval: std::time::Duration,
+    token: CancellationToken,
+) -> Result<()>
+where
+    E: TypedFileExporter + Send + Sync,
+{
+    let file_ext = exporter.file_extension();
+    let mut span_buffer: Vec<E::SpanData> = Vec::new();
+    let mut flush_timer = tokio::time::interval(flush_interval);
+
+    loop {
+        tokio::select! {
+            traces_result = traces_rx.next() => {
+                match traces_result {
+                    Some(traces) => {
+                        // Process incoming traces
+                        for resource_spans in traces {
+                            let mut converted_spans = exporter.convert_spans(&resource_spans)?;
+                            span_buffer.append(&mut converted_spans);
+                        }
+                    }
+                    None => {
+                        // Channel closed, flush and shutdown gracefully
+                        debug!("Traces channel closed, flushing final data");
+                        flush_spans(&*exporter, &mut span_buffer, &traces_dir, file_ext)?;
+                        info!("Traces exporter shutting down gracefully");
+                        return Ok(());
+                    }
+                }
+            }
+            _ = flush_timer.tick() => {
+                flush_spans(&*exporter, &mut span_buffer, &traces_dir, file_ext)?;
+            }
+            _ = token.cancelled() => {
+                info!("Traces exporter received shutdown signal");
+                flush_spans(&*exporter, &mut span_buffer, &traces_dir, file_ext)?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Event loop for processing metrics data
+pub async fn run_metrics_loop<E>(
+    exporter: std::sync::Arc<E>,
+    metrics_dir: std::path::PathBuf,
+    mut metrics_rx: BoundedReceiver<Vec<ResourceMetrics>>,
+    flush_interval: std::time::Duration,
+    token: CancellationToken,
+) -> Result<()>
+where
+    E: TypedFileExporter + Send + Sync,
+{
+    let file_ext = exporter.file_extension();
+    let mut metric_buffer: Vec<E::MetricData> = Vec::new();
+    let mut flush_timer = tokio::time::interval(flush_interval);
+
+    loop {
+        tokio::select! {
+            metrics_result = metrics_rx.next() => {
+                match metrics_result {
+                    Some(metrics) => {
+                        // Process incoming metrics
+                        for resource_metrics in metrics {
+                            let mut converted_metrics = exporter.convert_metrics(&resource_metrics)?;
+                            metric_buffer.append(&mut converted_metrics);
+                        }
+                    }
+                    None => {
+                        // Channel closed, flush and shutdown gracefully
+                        debug!("Metrics channel closed, flushing final data");
+                        flush_metrics(&*exporter, &mut metric_buffer, &metrics_dir, file_ext)?;
+                        info!("Metrics exporter shutting down gracefully");
+                        return Ok(());
+                    }
+                }
+            }
+            _ = flush_timer.tick() => {
+                flush_metrics(&*exporter, &mut metric_buffer, &metrics_dir, file_ext)?;
+            }
+            _ = token.cancelled() => {
+                info!("Metrics exporter received shutdown signal");
+                flush_metrics(&*exporter, &mut metric_buffer, &metrics_dir, file_ext)?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Event loop for processing logs data
+pub async fn run_logs_loop<E>(
+    exporter: std::sync::Arc<E>,
+    logs_dir: std::path::PathBuf,
+    mut logs_rx: BoundedReceiver<Vec<ResourceLogs>>,
+    flush_interval: std::time::Duration,
+    token: CancellationToken,
+) -> Result<()>
+where
+    E: TypedFileExporter + Send + Sync,
+{
+    let file_ext = exporter.file_extension();
+    let mut log_buffer: Vec<E::LogData> = Vec::new();
+    let mut flush_timer = tokio::time::interval(flush_interval);
+
+    loop {
+        tokio::select! {
+            logs_result = logs_rx.next() => {
+                match logs_result {
+                    Some(logs) => {
+                        // Process incoming logs
+                        for resource_logs in logs {
+                            let mut converted_logs = exporter.convert_logs(&resource_logs)?;
+                            log_buffer.append(&mut converted_logs);
+                        }
+                    }
+                    None => {
+                        // Channel closed, flush and shutdown gracefully
+                        debug!("Logs channel closed, flushing final data");
+                        flush_logs(&*exporter, &mut log_buffer, &logs_dir, file_ext)?;
+                        info!("Logs exporter shutting down gracefully");
+                        return Ok(());
+                    }
+                }
+            }
+            _ = flush_timer.tick() => {
+                flush_logs(&*exporter, &mut log_buffer, &logs_dir, file_ext)?;
+            }
+            _ = token.cancelled() => {
+                info!("Logs exporter received shutdown signal");
+                flush_logs(&*exporter, &mut log_buffer, &logs_dir, file_ext)?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Helper function to flush span data to disk
+fn flush_spans<E>(
+    exporter: &E,
+    span_buffer: &mut Vec<E::SpanData>,
+    traces_dir: &std::path::Path,
+    file_ext: &str,
+) -> Result<()>
+where
+    E: TypedFileExporter,
+{
+    if !span_buffer.is_empty() {
+        let timestamp = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+        let rows = span_buffer.len();
+        let file_path = traces_dir.join(format!("spans_{}{}", timestamp, file_ext));
+        exporter.export_spans(span_buffer, &file_path)?;
+        debug!(rows, path=%file_path.display(), "Flushed spans file");
+        span_buffer.clear();
+    }
+    Ok(())
+}
+
+/// Helper function to flush metrics data to disk
+fn flush_metrics<E>(
+    exporter: &E,
+    metric_buffer: &mut Vec<E::MetricData>,
+    metrics_dir: &std::path::Path,
+    file_ext: &str,
+) -> Result<()>
+where
+    E: TypedFileExporter,
+{
+    if !metric_buffer.is_empty() {
+        let timestamp = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+        let rows = metric_buffer.len();
+        let file_path = metrics_dir.join(format!("metrics_{}{}", timestamp, file_ext));
+        exporter.export_metrics(metric_buffer, &file_path)?;
+        debug!(rows, path=%file_path.display(), "Flushed metrics file");
+        metric_buffer.clear();
+    }
+    Ok(())
+}
+
+/// Helper function to flush logs data to disk
+fn flush_logs<E>(
+    exporter: &E,
+    log_buffer: &mut Vec<E::LogData>,
+    logs_dir: &std::path::Path,
+    file_ext: &str,
+) -> Result<()>
+where
+    E: TypedFileExporter,
+{
+    if !log_buffer.is_empty() {
+        let timestamp = Utc::now().format("%Y%m%d_%H%M%S").to_string();
+        let rows = log_buffer.len();
+        let file_path = logs_dir.join(format!("logs_{}{}", timestamp, file_ext));
+        exporter.export_logs(log_buffer, &file_path)?;
+        debug!(rows, path=%file_path.display(), "Flushed logs file");
+        log_buffer.clear();
+    }
+    Ok(())
+}

--- a/src/exporters/file/task.rs
+++ b/src/exporters/file/task.rs
@@ -117,7 +117,7 @@ pub async fn run_file_exporter(
     token: CancellationToken,
 ) -> Result<()> {
     let format = config.format;
-    let path = config.path;
+    let path = config.output_dir;
     let flush_interval = config.flush_interval;
 
     // Create output directories if they don't exist

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -3,6 +3,7 @@
 pub mod blackhole;
 pub mod clickhouse;
 pub mod datadog;
+pub mod file;
 pub mod otlp;
 pub mod xray;
 

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -347,6 +347,34 @@ impl Agent {
                         Ok(())
                     });
                 }
+                Some(ExporterConfig::File(config)) => {
+                    let format = config.format;
+                    let flush_interval = config.flush_interval;
+                    let traces_dir = config.path.join("spans");
+                    
+                    std::fs::create_dir_all(&traces_dir).map_err(|e| format!("Failed to create traces directory: {}", e))?;
+                    
+                    let token = exporters_cancel.clone();
+                    match format {
+                        crate::init::file_exporter::FileExporterFormat::Parquet => {
+                            let compression = config.parquet_compression.to_parquet_compression();
+                            let exporter = std::sync::Arc::new(crate::exporters::file::parquet::ParquetExporter::with_compression(compression));
+                            exporters_task_set.spawn(async move {
+                                crate::exporters::file::task::run_traces_loop(
+                                    exporter, traces_dir, trace_pipeline_out_rx, flush_interval, token
+                                ).await.map_err(|e| e.into())
+                            });
+                        }
+                        crate::init::file_exporter::FileExporterFormat::Json => {
+                            let exporter = std::sync::Arc::new(crate::exporters::file::json::JsonExporter::new());
+                            exporters_task_set.spawn(async move {
+                                crate::exporters::file::task::run_traces_loop(
+                                    exporter, traces_dir, trace_pipeline_out_rx, flush_interval, token
+                                ).await.map_err(|e| e.into())
+                            });
+                        }
+                    }
+                }
                 None => {}
             }
         }
@@ -417,6 +445,34 @@ impl Agent {
                         Ok(())
                     });
                 }
+                Some(ExporterConfig::File(config)) => {
+                    let format = config.format;
+                    let flush_interval = config.flush_interval;
+                    let metrics_dir = config.path.join("metrics");
+                    
+                    std::fs::create_dir_all(&metrics_dir).map_err(|e| format!("Failed to create metrics directory: {}", e))?;
+                    
+                    let token = exporters_cancel.clone();
+                    match format {
+                        crate::init::file_exporter::FileExporterFormat::Parquet => {
+                            let compression = config.parquet_compression.to_parquet_compression();
+                            let exporter = std::sync::Arc::new(crate::exporters::file::parquet::ParquetExporter::with_compression(compression));
+                            exporters_task_set.spawn(async move {
+                                crate::exporters::file::task::run_metrics_loop(
+                                    exporter, metrics_dir, metrics_pipeline_out_rx, flush_interval, token
+                                ).await.map_err(|e| e.into())
+                            });
+                        }
+                        crate::init::file_exporter::FileExporterFormat::Json => {
+                            let exporter = std::sync::Arc::new(crate::exporters::file::json::JsonExporter::new());
+                            exporters_task_set.spawn(async move {
+                                crate::exporters::file::task::run_metrics_loop(
+                                    exporter, metrics_dir, metrics_pipeline_out_rx, flush_interval, token
+                                ).await.map_err(|e| e.into())
+                            });
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -470,6 +526,34 @@ impl Agent {
                         exp.start(token).await;
                         Ok(())
                     });
+                }
+                Some(ExporterConfig::File(config)) => {
+                    let format = config.format;
+                    let flush_interval = config.flush_interval;
+                    let logs_dir = config.path.join("logs");
+                    
+                    std::fs::create_dir_all(&logs_dir).map_err(|e| format!("Failed to create logs directory: {}", e))?;
+                    
+                    let token = exporters_cancel.clone();
+                    match format {
+                        crate::init::file_exporter::FileExporterFormat::Parquet => {
+                            let compression = config.parquet_compression.to_parquet_compression();
+                            let exporter = std::sync::Arc::new(crate::exporters::file::parquet::ParquetExporter::with_compression(compression));
+                            exporters_task_set.spawn(async move {
+                                crate::exporters::file::task::run_logs_loop(
+                                    exporter, logs_dir, logs_pipeline_out_rx, flush_interval, token
+                                ).await.map_err(|e| e.into())
+                            });
+                        }
+                        crate::init::file_exporter::FileExporterFormat::Json => {
+                            let exporter = std::sync::Arc::new(crate::exporters::file::json::JsonExporter::new());
+                            exporters_task_set.spawn(async move {
+                                crate::exporters::file::task::run_logs_loop(
+                                    exporter, logs_dir, logs_pipeline_out_rx, flush_interval, token
+                                ).await.map_err(|e| e.into())
+                            });
+                        }
+                    }
                 }
                 _ => {}
             }

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -350,27 +350,46 @@ impl Agent {
                 Some(ExporterConfig::File(config)) => {
                     let format = config.format;
                     let flush_interval = config.flush_interval;
-                    let traces_dir = config.path.join("spans");
-                    
-                    std::fs::create_dir_all(&traces_dir).map_err(|e| format!("Failed to create traces directory: {}", e))?;
-                    
+                    let traces_dir = config.output_dir.join("spans");
+
+                    std::fs::create_dir_all(&traces_dir)
+                        .map_err(|e| format!("Failed to create traces directory: {}", e))?;
+
                     let token = exporters_cancel.clone();
                     match format {
                         crate::init::file_exporter::FileExporterFormat::Parquet => {
                             let compression = config.parquet_compression.to_parquet_compression();
-                            let exporter = std::sync::Arc::new(crate::exporters::file::parquet::ParquetExporter::with_compression(compression));
+                            let exporter = std::sync::Arc::new(
+                                crate::exporters::file::parquet::ParquetExporter::with_compression(
+                                    compression,
+                                ),
+                            );
                             exporters_task_set.spawn(async move {
                                 crate::exporters::file::task::run_traces_loop(
-                                    exporter, traces_dir, trace_pipeline_out_rx, flush_interval, token
-                                ).await.map_err(|e| e.into())
+                                    exporter,
+                                    traces_dir,
+                                    trace_pipeline_out_rx,
+                                    flush_interval,
+                                    token,
+                                )
+                                .await
+                                .map_err(|e| e.into())
                             });
                         }
                         crate::init::file_exporter::FileExporterFormat::Json => {
-                            let exporter = std::sync::Arc::new(crate::exporters::file::json::JsonExporter::new());
+                            let exporter = std::sync::Arc::new(
+                                crate::exporters::file::json::JsonExporter::new(),
+                            );
                             exporters_task_set.spawn(async move {
                                 crate::exporters::file::task::run_traces_loop(
-                                    exporter, traces_dir, trace_pipeline_out_rx, flush_interval, token
-                                ).await.map_err(|e| e.into())
+                                    exporter,
+                                    traces_dir,
+                                    trace_pipeline_out_rx,
+                                    flush_interval,
+                                    token,
+                                )
+                                .await
+                                .map_err(|e| e.into())
                             });
                         }
                     }
@@ -448,27 +467,46 @@ impl Agent {
                 Some(ExporterConfig::File(config)) => {
                     let format = config.format;
                     let flush_interval = config.flush_interval;
-                    let metrics_dir = config.path.join("metrics");
-                    
-                    std::fs::create_dir_all(&metrics_dir).map_err(|e| format!("Failed to create metrics directory: {}", e))?;
-                    
+                    let metrics_dir = config.output_dir.join("metrics");
+
+                    std::fs::create_dir_all(&metrics_dir)
+                        .map_err(|e| format!("Failed to create metrics directory: {}", e))?;
+
                     let token = exporters_cancel.clone();
                     match format {
                         crate::init::file_exporter::FileExporterFormat::Parquet => {
                             let compression = config.parquet_compression.to_parquet_compression();
-                            let exporter = std::sync::Arc::new(crate::exporters::file::parquet::ParquetExporter::with_compression(compression));
+                            let exporter = std::sync::Arc::new(
+                                crate::exporters::file::parquet::ParquetExporter::with_compression(
+                                    compression,
+                                ),
+                            );
                             exporters_task_set.spawn(async move {
                                 crate::exporters::file::task::run_metrics_loop(
-                                    exporter, metrics_dir, metrics_pipeline_out_rx, flush_interval, token
-                                ).await.map_err(|e| e.into())
+                                    exporter,
+                                    metrics_dir,
+                                    metrics_pipeline_out_rx,
+                                    flush_interval,
+                                    token,
+                                )
+                                .await
+                                .map_err(|e| e.into())
                             });
                         }
                         crate::init::file_exporter::FileExporterFormat::Json => {
-                            let exporter = std::sync::Arc::new(crate::exporters::file::json::JsonExporter::new());
+                            let exporter = std::sync::Arc::new(
+                                crate::exporters::file::json::JsonExporter::new(),
+                            );
                             exporters_task_set.spawn(async move {
                                 crate::exporters::file::task::run_metrics_loop(
-                                    exporter, metrics_dir, metrics_pipeline_out_rx, flush_interval, token
-                                ).await.map_err(|e| e.into())
+                                    exporter,
+                                    metrics_dir,
+                                    metrics_pipeline_out_rx,
+                                    flush_interval,
+                                    token,
+                                )
+                                .await
+                                .map_err(|e| e.into())
                             });
                         }
                     }
@@ -530,27 +568,46 @@ impl Agent {
                 Some(ExporterConfig::File(config)) => {
                     let format = config.format;
                     let flush_interval = config.flush_interval;
-                    let logs_dir = config.path.join("logs");
-                    
-                    std::fs::create_dir_all(&logs_dir).map_err(|e| format!("Failed to create logs directory: {}", e))?;
-                    
+                    let logs_dir = config.output_dir.join("logs");
+
+                    std::fs::create_dir_all(&logs_dir)
+                        .map_err(|e| format!("Failed to create logs directory: {}", e))?;
+
                     let token = exporters_cancel.clone();
                     match format {
                         crate::init::file_exporter::FileExporterFormat::Parquet => {
                             let compression = config.parquet_compression.to_parquet_compression();
-                            let exporter = std::sync::Arc::new(crate::exporters::file::parquet::ParquetExporter::with_compression(compression));
+                            let exporter = std::sync::Arc::new(
+                                crate::exporters::file::parquet::ParquetExporter::with_compression(
+                                    compression,
+                                ),
+                            );
                             exporters_task_set.spawn(async move {
                                 crate::exporters::file::task::run_logs_loop(
-                                    exporter, logs_dir, logs_pipeline_out_rx, flush_interval, token
-                                ).await.map_err(|e| e.into())
+                                    exporter,
+                                    logs_dir,
+                                    logs_pipeline_out_rx,
+                                    flush_interval,
+                                    token,
+                                )
+                                .await
+                                .map_err(|e| e.into())
                             });
                         }
                         crate::init::file_exporter::FileExporterFormat::Json => {
-                            let exporter = std::sync::Arc::new(crate::exporters::file::json::JsonExporter::new());
+                            let exporter = std::sync::Arc::new(
+                                crate::exporters::file::json::JsonExporter::new(),
+                            );
                             exporters_task_set.spawn(async move {
                                 crate::exporters::file::task::run_logs_loop(
-                                    exporter, logs_dir, logs_pipeline_out_rx, flush_interval, token
-                                ).await.map_err(|e| e.into())
+                                    exporter,
+                                    logs_dir,
+                                    logs_pipeline_out_rx,
+                                    flush_interval,
+                                    token,
+                                )
+                                .await
+                                .map_err(|e| e.into())
                             });
                         }
                     }

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -2,6 +2,7 @@ use crate::exporters::otlp::Authenticator;
 use crate::init::batch::BatchArgs;
 use crate::init::clickhouse_exporter::ClickhouseExporterArgs;
 use crate::init::datadog_exporter::DatadogExporterArgs;
+use crate::init::file_exporter::FileExporterArgs;
 use crate::init::otlp_exporter::OTLPExporterArgs;
 use crate::init::parse;
 use crate::init::xray_exporter::XRayExporterArgs;
@@ -149,6 +150,9 @@ pub struct AgentRun {
     #[command(flatten)]
     pub aws_xray_exporter: XRayExporterArgs,
 
+    #[command(flatten)]
+    pub file_exporter: FileExporterArgs,
+
     #[cfg(feature = "pprof")]
     #[clap(flatten)]
     pub profile_group: ProfileGroup,
@@ -186,6 +190,7 @@ impl Default for AgentRun {
             datadog_exporter: DatadogExporterArgs::default(),
             clickhouse_exporter: ClickhouseExporterArgs::default(),
             aws_xray_exporter: XRayExporterArgs::default(),
+            file_exporter: FileExporterArgs::default(),
             #[cfg(feature = "pprof")]
             profile_group: ProfileGroup {
                 pprof_flame_graph: false,
@@ -238,14 +243,11 @@ pub struct ProfileGroup {
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
 pub enum Exporter {
     Otlp,
-
     Blackhole,
-
     Datadog,
-
     Clickhouse,
-
     AwsXray,
+    File,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]

--- a/src/init/file_exporter.rs
+++ b/src/init/file_exporter.rs
@@ -1,0 +1,156 @@
+use clap::{Args, ValueEnum};
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum FileExporterFormat {
+    /// Parquet format
+    Parquet,
+    /// JSON format
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ParquetCompression {
+    /// No compression
+    Uncompressed,
+    /// Snappy compression
+    Snappy,
+    /// Gzip compression
+    Gzip,
+    /// LZ4 compression
+    Lz4,
+    /// ZSTD compression
+    Zstd,
+}
+
+impl FileExporterFormat {
+    /// Convert to lowercase string for backward compatibility
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FileExporterFormat::Parquet => "parquet",
+            FileExporterFormat::Json => "json",
+        }
+    }
+}
+
+impl ParquetCompression {
+    /// Convert to parquet::basic::Compression
+    pub fn to_parquet_compression(&self) -> parquet::basic::Compression {
+        match self {
+            ParquetCompression::Uncompressed => parquet::basic::Compression::UNCOMPRESSED,
+            ParquetCompression::Snappy => parquet::basic::Compression::SNAPPY,
+            ParquetCompression::Gzip => parquet::basic::Compression::GZIP(Default::default()),
+            ParquetCompression::Lz4 => parquet::basic::Compression::LZ4,
+            ParquetCompression::Zstd => parquet::basic::Compression::ZSTD(Default::default()),
+        }
+    }
+
+    /// Convert to lowercase string for display
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ParquetCompression::Uncompressed => "uncompressed",
+            ParquetCompression::Snappy => "snappy",
+            ParquetCompression::Gzip => "gzip",
+            ParquetCompression::Lz4 => "lz4",
+            ParquetCompression::Zstd => "zstd",
+        }
+    }
+}
+
+impl std::fmt::Display for FileExporterFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl std::fmt::Display for ParquetCompression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct FileExporterArgs {
+    /// File format for export
+    #[arg(
+        value_enum,
+        long,
+        env = "ROTEL_FILE_EXPORTER_FORMAT",
+        default_value = "parquet"
+    )]
+    pub file_exporter_format: FileExporterFormat,
+
+    /// Directory where files will be written
+    #[arg(
+        long,
+        env = "ROTEL_FILE_EXPORTER_OUTPUT_DIR",
+        default_value = "/tmp/rotel"
+    )]
+    pub file_exporter_output_dir: PathBuf,
+
+    /// How often to flush data to disk (e.g., "5s")
+    #[arg(long, env = "ROTEL_FILE_EXPORTER_FLUSH_INTERVAL", default_value = "5s", value_parser = humantime::parse_duration)]
+    pub file_exporter_flush_interval: Duration,
+
+    /// Compression type for Parquet files (only applies when format is parquet)
+    #[arg(
+        value_enum,
+        long,
+        env = "ROTEL_FILE_EXPORTER_PARQUET_COMPRESSION",
+        default_value = "snappy"
+    )]
+    pub file_exporter_parquet_compression: ParquetCompression,
+}
+
+impl Default for FileExporterArgs {
+    fn default() -> Self {
+        FileExporterArgs {
+            file_exporter_format: FileExporterFormat::Parquet,
+            file_exporter_output_dir: PathBuf::from("/tmp/rotel"),
+            file_exporter_flush_interval: Duration::from_secs(5),
+            file_exporter_parquet_compression: ParquetCompression::Snappy,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parquet_compression_conversion() {
+        use parquet::basic::Compression;
+
+        // Test all compression type conversions
+        assert!(matches!(
+            ParquetCompression::Uncompressed.to_parquet_compression(),
+            Compression::UNCOMPRESSED
+        ));
+        assert!(matches!(
+            ParquetCompression::Snappy.to_parquet_compression(),
+            Compression::SNAPPY
+        ));
+        assert!(matches!(
+            ParquetCompression::Gzip.to_parquet_compression(),
+            Compression::GZIP(_)
+        ));
+        assert!(matches!(
+            ParquetCompression::Lz4.to_parquet_compression(),
+            Compression::LZ4
+        ));
+        assert!(matches!(
+            ParquetCompression::Zstd.to_parquet_compression(),
+            Compression::ZSTD(_)
+        ));
+    }
+
+    #[test]
+    fn test_parquet_compression_display() {
+        assert_eq!(ParquetCompression::Uncompressed.as_str(), "uncompressed");
+        assert_eq!(ParquetCompression::Snappy.as_str(), "snappy");
+        assert_eq!(ParquetCompression::Gzip.as_str(), "gzip");
+        assert_eq!(ParquetCompression::Lz4.as_str(), "lz4");
+        assert_eq!(ParquetCompression::Zstd.as_str(), "zstd");
+    }
+}

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -6,6 +6,7 @@ pub mod wait;
 
 mod clickhouse_exporter;
 mod datadog_exporter;
+pub mod file_exporter;
 mod otlp_exporter;
 mod xray_exporter;
 


### PR DESCRIPTION
Experimental file exporter that supports outputting parquet files.

- [x] Rename to "file" exporter
- [x] Support parquet
- [x] Support JSON
- [x] Support basic file exporting options based on the otel collector

(Full disclosure: no idea what I'm doing in Rust -- this is my first Rust PR)

via #118 