### PR TITLE
Clickhouse Metrics Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ Specifying a custom endpoint will override the region selection.
 
 ### Clickhouse exporter configuration
 
-The Clickhouse exporter can be selected by passing `--exporter clickhouse`. The Clickhouse exporter only supports logs
-and traces at the moment.
+The Clickhouse exporter can be selected by passing `--exporter clickhouse`. The Clickhouse exporter supports metrics, logs,
+and traces.
 
 | Option                                | Default | Options     |
 |---------------------------------------|---------|-------------|

--- a/src/bin/clickhouse-ddl/README.md
+++ b/src/bin/clickhouse-ddl/README.md
@@ -29,6 +29,7 @@ Options:
       --cluster <CLUSTER>            Cluster name
       --traces                       Create trace spans tables
       --logs                         Create logs tables
+      --metrics                      Create metrics tables
       --ttl <TTL>                    TTL [default: 0s]
       --enable-json                  Enable JSON column type
   -h, --help                         Print help

--- a/src/bin/clickhouse-ddl/ddl.rs
+++ b/src/bin/clickhouse-ddl/ddl.rs
@@ -1,244 +1,22 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-pub(crate) fn get_traces_ddl(
-    cluster: &Option<String>,
+pub(crate) fn build_table_name(
     database: &String,
     table_prefix: &String,
-    engine: &str,
-    ttl: &Duration,
-    use_json: bool,
-) -> Vec<String> {
-    let map_or_json = get_json_col_type(use_json);
-    let mut map_indices = "";
-    let mut json_setting = "";
-    if !use_json {
-        map_indices = TRACES_TABLE_MAP_INDICES_SQL;
-    } else {
-        json_setting = ", allow_experimental_json_type = 1";
-    }
-
-    let table_sql = replace_placeholders(
-        TRACES_TABLE_SQL,
-        &HashMap::from([
-            (
-                "TABLE",
-                build_table_name(database, table_prefix, "traces").as_str(),
-            ),
-            ("CLUSTER", build_cluster_string(cluster).as_str()),
-            ("MAP_OR_JSON", map_or_json),
-            ("ENGINE", engine),
-            ("MAP_INDICES", map_indices),
-            (
-                "TTL_EXPR",
-                build_ttl_string(ttl, "toDateTime(Timestamp)").as_str(),
-            ),
-            ("JSON_SETTING", json_setting),
-        ]),
-    );
-
-    let table_id_ts_sql = replace_placeholders(
-        TRACES_TABLE_ID_TS_SQL,
-        &HashMap::from([
-            (
-                "TABLE",
-                build_table_name(database, table_prefix, "traces_trace_id_ts").as_str(),
-            ),
-            ("CLUSTER", build_cluster_string(cluster).as_str()),
-            ("ENGINE", engine),
-            (
-                "TTL_EXPR",
-                build_ttl_string(ttl, "toDateTime(Start)").as_str(),
-            ),
-        ]),
-    );
-
-    let table_id_ts_mv_sql = replace_placeholders(
-        TRACES_TABLE_ID_TS_MV_SQL,
-        &HashMap::from([
-            (
-                "TABLE",
-                build_table_name(database, table_prefix, "traces_trace_id_ts_mv").as_str(),
-            ),
-            ("CLUSTER", build_cluster_string(cluster).as_str()),
-            (
-                "TABLE_ID_TS",
-                build_table_name(database, table_prefix, "traces_trace_id_ts").as_str(),
-            ),
-            (
-                "TABLE_TRACES",
-                build_table_name(database, table_prefix, "traces").as_str(),
-            ),
-        ]),
-    );
-
-    vec![table_sql, table_id_ts_sql, table_id_ts_mv_sql]
-}
-
-pub(crate) fn get_logs_ddl(
-    cluster: &Option<String>,
-    database: &String,
-    table_prefix: &String,
-    engine: &str,
-    ttl: &Duration,
-    use_json: bool,
-) -> Vec<String> {
-    let map_or_json = get_json_col_type(use_json);
-    let mut map_indices = "";
-    let mut json_setting = "";
-    if !use_json {
-        map_indices = LOGS_TABLE_MAP_INDICES_SQL;
-    } else {
-        json_setting = ", allow_experimental_json_type = 1";
-    }
-
-    let table_sql = replace_placeholders(
-        LOGS_TABLE_SQL,
-        &HashMap::from([
-            (
-                "TABLE",
-                build_table_name(database, table_prefix, "logs").as_str(),
-            ),
-            ("CLUSTER", build_cluster_string(cluster).as_str()),
-            ("MAP_OR_JSON", map_or_json),
-            ("ENGINE", engine),
-            ("MAP_INDICES", map_indices),
-            ("TTL_EXPR", build_ttl_string(ttl, "TimestampTime").as_str()),
-            ("JSON_SETTING", json_setting),
-        ]),
-    );
-
-    vec![table_sql]
-}
-
-const TRACES_TABLE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
-	Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
-	TraceId String CODEC(ZSTD(1)),
-	SpanId String CODEC(ZSTD(1)),
-	ParentSpanId String CODEC(ZSTD(1)),
-	TraceState String CODEC(ZSTD(1)),
-	SpanName LowCardinality(String) CODEC(ZSTD(1)),
-	SpanKind LowCardinality(String) CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	SpanAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
-	Duration UInt64 CODEC(ZSTD(1)),
-	StatusCode LowCardinality(String) CODEC(ZSTD(1)),
-	StatusMessage String CODEC(ZSTD(1)),
-	Events Nested (
-		Timestamp DateTime64(9),
-		Name LowCardinality(String),
-		Attributes %%MAP_OR_JSON%%
-	) CODEC(ZSTD(1)),
-	Links Nested (
-		TraceId String,
-		SpanId String,
-		TraceState String,
-		Attributes %%MAP_OR_JSON%%
-	) CODEC(ZSTD(1)),
-	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-
-    %%MAP_INDICES%%
-
-	INDEX idx_duration Duration TYPE minmax GRANULARITY 1
-) ENGINE = %%ENGINE%%
-PARTITION BY toDate(Timestamp)
-ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
-%%TTL_EXPR%%
-SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
-;
-"#;
-
-const TRACES_TABLE_MAP_INDICES_SQL: &str = r#"
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-"#;
-
-const TRACES_TABLE_ID_TS_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
-     TraceId String CODEC(ZSTD(1)),
-     Start DateTime CODEC(Delta, ZSTD(1)),
-     End DateTime CODEC(Delta, ZSTD(1)),
-     INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = %%ENGINE%%
-PARTITION BY toDate(Start)
-ORDER BY (TraceId, Start)
-%%TTL_EXPR%%
-SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-"#;
-
-const TRACES_TABLE_ID_TS_MV_SQL: &str = r#"
-CREATE MATERIALIZED VIEW IF NOT EXISTS %%TABLE%% %%CLUSTER%%
-TO %%TABLE_ID_TS%%
-AS SELECT
-	TraceId,
-	min(Timestamp) as Start,
-	max(Timestamp) as End
-FROM
-%%TABLE_TRACES%%
-WHERE TraceId != ''
-GROUP BY TraceId;
-"#;
-
-const LOGS_TABLE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
-	Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TimestampTime DateTime DEFAULT toDateTime(Timestamp),
-	TraceId String CODEC(ZSTD(1)),
-	SpanId String CODEC(ZSTD(1)),
-	TraceFlags UInt8,
-	SeverityText LowCardinality(String) CODEC(ZSTD(1)),
-	SeverityNumber UInt8,
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	Body String CODEC(ZSTD(1)),
-	ResourceSchemaUrl LowCardinality(String) CODEC(ZSTD(1)),
-	ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
-	ScopeSchemaUrl LowCardinality(String) CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion LowCardinality(String) CODEC(ZSTD(1)),
-	ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
-	LogAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
-
-	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-	
-    %%MAP_INDICES%%
-	
-	INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
-) ENGINE = %%ENGINE%%
-PARTITION BY toDate(TimestampTime)
-PRIMARY KEY (ServiceName, TimestampTime)
-ORDER BY (ServiceName, TimestampTime, Timestamp)
-%%TTL_EXPR%%
-SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
-;
-"#;
-
-const LOGS_TABLE_MAP_INDICES_SQL: &str = r#"
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-"#;
-
-fn build_table_name(database: &String, table_prefix: &String, table_name: &str) -> String {
+    table_name: &str,
+) -> String {
     format!("{}.{}_{}", database, table_prefix, table_name)
 }
 
-fn build_cluster_string(cluster: &Option<String>) -> String {
+pub(crate) fn build_cluster_string(cluster: &Option<String>) -> String {
     match cluster {
         None => "".to_string(),
         Some(name) => format!("ON CLUSTER {}", name),
     }
 }
 
-fn build_ttl_string(ttl: &Duration, time_field: &str) -> String {
+pub(crate) fn build_ttl_string(ttl: &Duration, time_field: &str) -> String {
     let ttl_secs = ttl.as_secs();
     if ttl_secs == 0 {
         return "".to_string();
@@ -257,7 +35,7 @@ fn build_ttl_string(ttl: &Duration, time_field: &str) -> String {
     format!("TTL {} + toIntervalSecond({})", time_field, ttl_secs)
 }
 
-fn replace_placeholders(template: &str, replacements: &HashMap<&str, &str>) -> String {
+pub(crate) fn replace_placeholders(template: &str, replacements: &HashMap<&str, &str>) -> String {
     let mut result = template.to_string();
 
     for (key, value) in replacements {
@@ -268,7 +46,7 @@ fn replace_placeholders(template: &str, replacements: &HashMap<&str, &str>) -> S
     result
 }
 
-fn get_json_col_type<'a>(use_json: bool) -> &'a str {
+pub(crate) fn get_json_col_type<'a>(use_json: bool) -> &'a str {
     match use_json {
         true => "JSON",
         false => "Map(LowCardinality(String), String)",

--- a/src/bin/clickhouse-ddl/ddl_logs.rs
+++ b/src/bin/clickhouse-ddl/ddl_logs.rs
@@ -1,0 +1,84 @@
+use crate::ddl::{
+    build_cluster_string, build_table_name, build_ttl_string, get_json_col_type,
+    replace_placeholders,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+
+pub(crate) fn get_logs_ddl(
+    cluster: &Option<String>,
+    database: &String,
+    table_prefix: &String,
+    engine: &str,
+    ttl: &Duration,
+    use_json: bool,
+) -> Vec<String> {
+    let map_or_json = get_json_col_type(use_json);
+    let mut map_indices = "";
+    let mut json_setting = "";
+    if !use_json {
+        map_indices = LOGS_TABLE_MAP_INDICES_SQL;
+    } else {
+        json_setting = ", allow_experimental_json_type = 1";
+    }
+
+    let table_sql = replace_placeholders(
+        LOGS_TABLE_SQL,
+        &HashMap::from([
+            (
+                "TABLE",
+                build_table_name(database, table_prefix, "logs").as_str(),
+            ),
+            ("CLUSTER", build_cluster_string(cluster).as_str()),
+            ("MAP_OR_JSON", map_or_json),
+            ("ENGINE", engine),
+            ("MAP_INDICES", map_indices),
+            ("TTL_EXPR", build_ttl_string(ttl, "TimestampTime").as_str()),
+            ("JSON_SETTING", json_setting),
+        ]),
+    );
+
+    vec![table_sql]
+}
+
+const LOGS_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+	Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TimestampTime DateTime DEFAULT toDateTime(Timestamp),
+	TraceId String CODEC(ZSTD(1)),
+	SpanId String CODEC(ZSTD(1)),
+	TraceFlags UInt8,
+	SeverityText LowCardinality(String) CODEC(ZSTD(1)),
+	SeverityNumber UInt8,
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	Body String CODEC(ZSTD(1)),
+	ResourceSchemaUrl LowCardinality(String) CODEC(ZSTD(1)),
+	ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	ScopeSchemaUrl LowCardinality(String) CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion LowCardinality(String) CODEC(ZSTD(1)),
+	ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	LogAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+
+	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+
+    %%MAP_INDICES%%
+
+	INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
+) ENGINE = %%ENGINE%%
+PARTITION BY toDate(TimestampTime)
+PRIMARY KEY (ServiceName, TimestampTime)
+ORDER BY (ServiceName, TimestampTime, Timestamp)
+%%TTL_EXPR%%
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const LOGS_TABLE_MAP_INDICES_SQL: &str = r#"
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+"#;

--- a/src/bin/clickhouse-ddl/ddl_metrics.rs
+++ b/src/bin/clickhouse-ddl/ddl_metrics.rs
@@ -1,0 +1,263 @@
+use crate::ddl::{
+    build_cluster_string, build_table_name, build_ttl_string, get_json_col_type,
+    replace_placeholders,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+
+pub(crate) fn get_metrics_ddl(
+    cluster: &Option<String>,
+    database: &String,
+    table_prefix: &String,
+    engine: &str,
+    ttl: &Duration,
+    use_json: bool,
+) -> Vec<String> {
+    let map_or_json = get_json_col_type(use_json);
+    let mut map_indices = "";
+    let mut json_setting = "";
+    if !use_json {
+        map_indices = METRICS_TABLE_MAP_INDICES_SQL;
+    } else {
+        json_setting = ", allow_experimental_json_type = 1";
+    }
+
+    let sqls = [
+        (METRICS_SUM_TABLE_SQL, "metrics_sum"),
+        (METRICS_GAUGE_TABLE_SQL, "metrics_gauge"),
+        (METRICS_HISTOGRAM_TABLE_SQL, "metrics_histogram"),
+        (
+            METRICS_EXP_HISTOGRAM_TABLE_SQL,
+            "metrics_exponential_histogram",
+        ),
+        (METRICS_SUMMARY_TABLE_SQL, "metrics_summary"),
+    ];
+
+    sqls.iter()
+        .map(|(table_sql, table_name)| {
+            replace_placeholders(
+                table_sql,
+                &HashMap::from([
+                    (
+                        "TABLE",
+                        build_table_name(database, table_prefix, table_name).as_str(),
+                    ),
+                    ("CLUSTER", build_cluster_string(cluster).as_str()),
+                    ("MAP_OR_JSON", map_or_json),
+                    ("ENGINE", engine),
+                    ("MAP_INDICES", map_indices),
+                    (
+                        "TTL_EXPR",
+                        build_ttl_string(ttl, "toDateTime(TimeUnix)").as_str(),
+                    ),
+                    ("JSON_SETTING", json_setting),
+                ]),
+            )
+        })
+        .collect()
+}
+
+const METRICS_SUM_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+    ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+	Value Float64 CODEC(ZSTD(1)),
+	Flags UInt32  CODEC(ZSTD(1)),
+    Exemplars Nested (
+		FilteredAttributes %%MAP_OR_JSON%%,
+		TimeUnix DateTime64(9),
+		Value Float64,
+		SpanId String,
+		TraceId String
+    ) CODEC(ZSTD(1)),
+    AggregationTemporality Int32 CODEC(ZSTD(1)),
+	IsMonotonic Boolean CODEC(Delta, ZSTD(1)),
+
+    %%MAP_INDICES%%
+
+) ENGINE = %%ENGINE%%
+%%TTL_EXPR%%
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const METRICS_GAUGE_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+    ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Value Float64 CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1)),
+    Exemplars Nested (
+		FilteredAttributes %%MAP_OR_JSON%%,
+		TimeUnix DateTime64(9),
+		Value Float64,
+		SpanId String,
+		TraceId String
+    ) CODEC(ZSTD(1)),
+
+    %%MAP_INDICES%%
+
+) ENGINE = %%ENGINE%%
+%%TTL_EXPR%%
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const METRICS_HISTOGRAM_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+    ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Count UInt64 CODEC(Delta, ZSTD(1)),
+    Sum Float64 CODEC(ZSTD(1)),
+    BucketCounts Array(UInt64) CODEC(ZSTD(1)),
+    ExplicitBounds Array(Float64) CODEC(ZSTD(1)),
+	Exemplars Nested (
+		FilteredAttributes %%MAP_OR_JSON%%,
+		TimeUnix DateTime64(9),
+		Value Float64,
+		SpanId String,
+		TraceId String
+    ) CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1)),
+    Min Float64 CODEC(ZSTD(1)),
+    Max Float64 CODEC(ZSTD(1)),
+		AggregationTemporality Int32 CODEC(ZSTD(1)),
+
+    %%MAP_INDICES%%
+
+) ENGINE = %%ENGINE%%
+%%TTL_EXPR%%
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const METRICS_EXP_HISTOGRAM_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+    ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Count UInt64 CODEC(Delta, ZSTD(1)),
+    Sum Float64 CODEC(ZSTD(1)),
+    Scale Int32 CODEC(ZSTD(1)),
+    ZeroCount UInt64 CODEC(ZSTD(1)),
+	PositiveOffset Int32 CODEC(ZSTD(1)),
+	PositiveBucketCounts Array(UInt64) CODEC(ZSTD(1)),
+	NegativeOffset Int32 CODEC(ZSTD(1)),
+	NegativeBucketCounts Array(UInt64) CODEC(ZSTD(1)),
+	Exemplars Nested (
+		FilteredAttributes %%MAP_OR_JSON%%,
+		TimeUnix DateTime64(9),
+		Value Float64,
+		SpanId String,
+		TraceId String
+    ) CODEC(ZSTD(1)),
+    Flags UInt32  CODEC(ZSTD(1)),
+    Min Float64 CODEC(ZSTD(1)),
+    Max Float64 CODEC(ZSTD(1)),
+		AggregationTemporality Int32 CODEC(ZSTD(1)),
+
+    %%MAP_INDICES%%
+
+) ENGINE = %%ENGINE%%
+%%TTL_EXPR%%
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const METRICS_SUMMARY_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+    ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ResourceSchemaUrl String CODEC(ZSTD(1)),
+    ScopeName String CODEC(ZSTD(1)),
+    ScopeVersion String CODEC(ZSTD(1)),
+    ScopeAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+    ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+    ScopeSchemaUrl String CODEC(ZSTD(1)),
+    ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+    MetricName String CODEC(ZSTD(1)),
+    MetricDescription String CODEC(ZSTD(1)),
+    MetricUnit String CODEC(ZSTD(1)),
+    Attributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta, ZSTD(1)),
+    Count UInt64 CODEC(Delta, ZSTD(1)),
+    Sum Float64 CODEC(ZSTD(1)),
+    ValueAtQuantiles Nested(
+		Quantile Float64,
+		Value Float64
+	) CODEC(ZSTD(1)),
+    Flags UInt32  CODEC(ZSTD(1)),
+
+    %%MAP_INDICES%%
+
+) ENGINE = %%ENGINE%%
+%%TTL_EXPR%%
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const METRICS_TABLE_MAP_INDICES_SQL: &str = r#"
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+"#;

--- a/src/bin/clickhouse-ddl/ddl_metrics.rs
+++ b/src/bin/clickhouse-ddl/ddl_metrics.rs
@@ -14,10 +14,12 @@ pub(crate) fn get_metrics_ddl(
     use_json: bool,
 ) -> Vec<String> {
     let map_or_json = get_json_col_type(use_json);
+    let mut attributes_ordered = "";
     let mut map_indices = "";
     let mut json_setting = "";
     if !use_json {
         map_indices = METRICS_TABLE_MAP_INDICES_SQL;
+        attributes_ordered = " , Attributes ";
     } else {
         json_setting = ", allow_experimental_json_type = 1";
     }
@@ -45,6 +47,7 @@ pub(crate) fn get_metrics_ddl(
                     ("CLUSTER", build_cluster_string(cluster).as_str()),
                     ("MAP_OR_JSON", map_or_json),
                     ("ENGINE", engine),
+                    ("ATTRIBUTES_ORDERED", attributes_ordered),
                     ("MAP_INDICES", map_indices),
                     (
                         "TTL_EXPR",
@@ -90,7 +93,7 @@ CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
 ) ENGINE = %%ENGINE%%
 %%TTL_EXPR%%
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+ORDER BY (ServiceName, MetricName %%ATTRIBUTES_ORDERED%% , toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
 ;
 "#;
@@ -126,7 +129,7 @@ CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
 ) ENGINE = %%ENGINE%%
 %%TTL_EXPR%%
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+ORDER BY (ServiceName, MetricName %%ATTRIBUTES_ORDERED%% , toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
 ;
 "#;
@@ -168,7 +171,7 @@ CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
 ) ENGINE = %%ENGINE%%
 %%TTL_EXPR%%
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+ORDER BY (ServiceName, MetricName %%ATTRIBUTES_ORDERED%% , toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
 ;
 "#;
@@ -214,7 +217,7 @@ CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
 ) ENGINE = %%ENGINE%%
 %%TTL_EXPR%%
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+ORDER BY (ServiceName, MetricName %%ATTRIBUTES_ORDERED%% , toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
 ;
 "#;
@@ -248,7 +251,7 @@ CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
 ) ENGINE = %%ENGINE%%
 %%TTL_EXPR%%
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+ORDER BY (ServiceName, MetricName %%ATTRIBUTES_ORDERED%% , toUnixTimestamp64Nano(TimeUnix))
 SETTINGS index_granularity=8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
 ;
 "#;

--- a/src/bin/clickhouse-ddl/ddl_traces.rs
+++ b/src/bin/clickhouse-ddl/ddl_traces.rs
@@ -1,0 +1,154 @@
+use crate::ddl::{
+    build_cluster_string, build_table_name, build_ttl_string, get_json_col_type,
+    replace_placeholders,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+
+pub(crate) fn get_traces_ddl(
+    cluster: &Option<String>,
+    database: &String,
+    table_prefix: &String,
+    engine: &str,
+    ttl: &Duration,
+    use_json: bool,
+) -> Vec<String> {
+    let map_or_json = get_json_col_type(use_json);
+    let mut map_indices = "";
+    let mut json_setting = "";
+    if !use_json {
+        map_indices = TRACES_TABLE_MAP_INDICES_SQL;
+    } else {
+        json_setting = ", allow_experimental_json_type = 1";
+    }
+
+    let table_sql = replace_placeholders(
+        TRACES_TABLE_SQL,
+        &HashMap::from([
+            (
+                "TABLE",
+                build_table_name(database, table_prefix, "traces").as_str(),
+            ),
+            ("CLUSTER", build_cluster_string(cluster).as_str()),
+            ("MAP_OR_JSON", map_or_json),
+            ("ENGINE", engine),
+            ("MAP_INDICES", map_indices),
+            (
+                "TTL_EXPR",
+                build_ttl_string(ttl, "toDateTime(Timestamp)").as_str(),
+            ),
+            ("JSON_SETTING", json_setting),
+        ]),
+    );
+
+    let table_id_ts_sql = replace_placeholders(
+        TRACES_TABLE_ID_TS_SQL,
+        &HashMap::from([
+            (
+                "TABLE",
+                build_table_name(database, table_prefix, "traces_trace_id_ts").as_str(),
+            ),
+            ("CLUSTER", build_cluster_string(cluster).as_str()),
+            ("ENGINE", engine),
+            (
+                "TTL_EXPR",
+                build_ttl_string(ttl, "toDateTime(Start)").as_str(),
+            ),
+        ]),
+    );
+
+    let table_id_ts_mv_sql = replace_placeholders(
+        TRACES_TABLE_ID_TS_MV_SQL,
+        &HashMap::from([
+            (
+                "TABLE",
+                build_table_name(database, table_prefix, "traces_trace_id_ts_mv").as_str(),
+            ),
+            ("CLUSTER", build_cluster_string(cluster).as_str()),
+            (
+                "TABLE_ID_TS",
+                build_table_name(database, table_prefix, "traces_trace_id_ts").as_str(),
+            ),
+            (
+                "TABLE_TRACES",
+                build_table_name(database, table_prefix, "traces").as_str(),
+            ),
+        ]),
+    );
+
+    vec![table_sql, table_id_ts_sql, table_id_ts_mv_sql]
+}
+
+const TRACES_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+	Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
+	TraceId String CODEC(ZSTD(1)),
+	SpanId String CODEC(ZSTD(1)),
+	ParentSpanId String CODEC(ZSTD(1)),
+	TraceState String CODEC(ZSTD(1)),
+	SpanName LowCardinality(String) CODEC(ZSTD(1)),
+	SpanKind LowCardinality(String) CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	ResourceAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	SpanAttributes %%MAP_OR_JSON%% CODEC(ZSTD(1)),
+	Duration UInt64 CODEC(ZSTD(1)),
+	StatusCode LowCardinality(String) CODEC(ZSTD(1)),
+	StatusMessage String CODEC(ZSTD(1)),
+	Events Nested (
+		Timestamp DateTime64(9),
+		Name LowCardinality(String),
+		Attributes %%MAP_OR_JSON%%
+	) CODEC(ZSTD(1)),
+	Links Nested (
+		TraceId String,
+		SpanId String,
+		TraceState String,
+		Attributes %%MAP_OR_JSON%%
+	) CODEC(ZSTD(1)),
+	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+
+    %%MAP_INDICES%%
+
+	INDEX idx_duration Duration TYPE minmax GRANULARITY 1
+) ENGINE = %%ENGINE%%
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+%%TTL_EXPR%%
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
+;
+"#;
+
+const TRACES_TABLE_MAP_INDICES_SQL: &str = r#"
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+"#;
+
+const TRACES_TABLE_ID_TS_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
+     TraceId String CODEC(ZSTD(1)),
+     Start DateTime CODEC(Delta, ZSTD(1)),
+     End DateTime CODEC(Delta, ZSTD(1)),
+     INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = %%ENGINE%%
+PARTITION BY toDate(Start)
+ORDER BY (TraceId, Start)
+%%TTL_EXPR%%
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+"#;
+
+const TRACES_TABLE_ID_TS_MV_SQL: &str = r#"
+CREATE MATERIALIZED VIEW IF NOT EXISTS %%TABLE%% %%CLUSTER%%
+TO %%TABLE_ID_TS%%
+AS SELECT
+	TraceId,
+	min(Timestamp) as Start,
+	max(Timestamp) as End
+FROM
+%%TABLE_TRACES%%
+WHERE TraceId != ''
+GROUP BY TraceId;
+"#;

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -4,6 +4,7 @@ mod compression;
 mod exception;
 mod payload;
 mod request_builder;
+mod request_mapper;
 mod rowbinary;
 mod schema;
 mod transformer;
@@ -231,25 +232,6 @@ impl ClickhouseExporterBuilder {
 
         Ok(exp)
     }
-}
-
-fn get_traces_sql(table_prefix: String) -> String {
-    build_insert_sql(
-        get_table_name(table_prefix, "traces"),
-        get_span_row_col_keys(),
-    )
-}
-
-fn get_logs_sql(table_prefix: String) -> String {
-    build_insert_sql(get_table_name(table_prefix, "logs"), get_log_row_col_keys())
-}
-
-fn build_insert_sql(table: String, cols: String) -> String {
-    format!("INSERT INTO {} ({}) FORMAT RowBinary", table, cols,)
-}
-
-fn get_table_name(table_prefix: String, table: &str) -> String {
-    format!("{}_{}", table_prefix, table)
 }
 
 #[derive(Default, Clone)]

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -7,14 +7,16 @@ mod request_builder;
 mod request_mapper;
 mod rowbinary;
 mod schema;
+mod transform_logs;
+mod transform_traces;
 mod transformer;
 
 use crate::bounded_channel::BoundedReceiver;
-use crate::exporters::clickhouse::api_request::ApiRequestBuilder;
+use crate::exporters::clickhouse::api_request::ConnectionConfig;
 use crate::exporters::clickhouse::exception::extract_exception;
 use crate::exporters::clickhouse::payload::ClickhousePayload;
 use crate::exporters::clickhouse::request_builder::RequestBuilder;
-use crate::exporters::clickhouse::schema::{get_log_row_col_keys, get_span_row_col_keys};
+use crate::exporters::clickhouse::request_mapper::RequestMapper;
 use crate::exporters::clickhouse::transformer::Transformer;
 use crate::exporters::http::client::ResponseDecode;
 use crate::exporters::http::exporter::{Exporter, ResultLogger};
@@ -31,6 +33,7 @@ use flume::r#async::RecvStream;
 use http::Request;
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+use std::sync::Arc;
 use std::time::Duration;
 use tower::retry::Retry as TowerRetry;
 use tower::timeout::Timeout;
@@ -51,7 +54,7 @@ pub enum Compression {
 }
 
 #[derive(Default)]
-pub struct ClickhouseExporterBuilder {
+pub struct ClickhouseExporterConfigBuilder {
     retry_config: RetryConfig,
     compression: Compression,
     endpoint: String,
@@ -83,13 +86,13 @@ type ExporterType<'a, Resource> = Exporter<
     ClickhouseResultLogger,
 >;
 
-impl ClickhouseExporterBuilder {
+impl ClickhouseExporterConfigBuilder {
     pub fn new(
         endpoint: String,
         database: String,
         table_prefix: String,
-    ) -> ClickhouseExporterBuilder {
-        ClickhouseExporterBuilder {
+    ) -> ClickhouseExporterConfigBuilder {
+        ClickhouseExporterConfigBuilder {
             endpoint,
             database,
             table_prefix,
@@ -127,6 +130,35 @@ impl ClickhouseExporterBuilder {
         self
     }
 
+    pub fn build(self) -> Result<ClickhouseExporterBuilder, BoxError> {
+        let config = ConnectionConfig {
+            endpoint: self.endpoint,
+            database: self.database,
+            compression: self.compression,
+            auth_user: self.auth_user,
+            auth_password: self.auth_password,
+            async_insert: self.async_insert,
+            use_json: self.use_json,
+            use_json_underscore: self.use_json_underscore,
+        };
+
+        let mapper = Arc::new(RequestMapper::new(&config, self.table_prefix)?);
+
+        Ok(ClickhouseExporterBuilder {
+            config,
+            request_mapper: mapper,
+            retry_config: self.retry_config,
+        })
+    }
+}
+
+pub struct ClickhouseExporterBuilder {
+    config: ConnectionConfig,
+    retry_config: RetryConfig,
+    request_mapper: Arc<RequestMapper>,
+}
+
+impl ClickhouseExporterBuilder {
     pub fn build_traces_exporter<'a>(
         &self,
         rx: BoundedReceiver<Vec<ResourceSpans>>,
@@ -135,24 +167,12 @@ impl ClickhouseExporterBuilder {
         let client = HttpClient::build(tls::Config::default(), Default::default())?;
 
         let transformer = Transformer::new(
-            self.compression.clone(),
-            self.use_json,
-            self.use_json_underscore,
+            self.config.compression.clone(),
+            self.config.use_json,
+            self.config.use_json_underscore,
         );
 
-        let traces_sql = get_traces_sql(self.table_prefix.clone());
-        let api_req_builder = ApiRequestBuilder::new(
-            self.endpoint.clone(),
-            self.database.clone(),
-            traces_sql,
-            self.compression.clone(),
-            self.auth_user.clone(),
-            self.auth_password.clone(),
-            self.async_insert,
-            self.use_json,
-        )?;
-
-        let req_builder = RequestBuilder::new(transformer, api_req_builder)?;
+        let req_builder = RequestBuilder::new(transformer, self.request_mapper.clone())?;
 
         let retry_layer = RetryPolicy::new(self.retry_config.clone(), None);
 
@@ -188,24 +208,12 @@ impl ClickhouseExporterBuilder {
         let client = HttpClient::build(tls::Config::default(), Default::default())?;
 
         let transformer = Transformer::new(
-            self.compression.clone(),
-            self.use_json,
-            self.use_json_underscore,
+            self.config.compression.clone(),
+            self.config.use_json,
+            self.config.use_json_underscore,
         );
 
-        let logs_sql = get_logs_sql(self.table_prefix.clone());
-        let api_req_builder = ApiRequestBuilder::new(
-            self.endpoint.clone(),
-            self.database.clone(),
-            logs_sql,
-            self.compression.clone(),
-            self.auth_user.clone(),
-            self.auth_password.clone(),
-            self.async_insert,
-            self.use_json,
-        )?;
-
-        let req_builder = RequestBuilder::new(transformer, api_req_builder)?;
+        let req_builder = RequestBuilder::new(transformer, self.request_mapper.clone())?;
 
         let retry_layer = RetryPolicy::new(self.retry_config.clone(), None);
 
@@ -371,17 +379,23 @@ mod tests {
         addr: String,
         brx: BoundedReceiver<Vec<ResourceSpans>>,
     ) -> ExporterType<'a, ResourceSpans> {
-        ClickhouseExporterBuilder::new(addr, "otel".to_string(), "otel".to_string())
-            .build_traces_exporter(brx, None)
-            .unwrap()
+        let builder =
+            ClickhouseExporterConfigBuilder::new(addr, "otel".to_string(), "otel".to_string())
+                .build()
+                .unwrap();
+
+        builder.build_traces_exporter(brx, None).unwrap()
     }
 
     fn new_logs_exporter<'a>(
         addr: String,
         brx: BoundedReceiver<Vec<ResourceLogs>>,
     ) -> ExporterType<'a, ResourceLogs> {
-        ClickhouseExporterBuilder::new(addr, "otel".to_string(), "otel".to_string())
-            .build_logs_exporter(brx, None)
-            .unwrap()
+        let builder =
+            ClickhouseExporterConfigBuilder::new(addr, "otel".to_string(), "otel".to_string())
+                .build()
+                .unwrap();
+
+        builder.build_logs_exporter(brx, None).unwrap()
     }
 }

--- a/src/exporters/clickhouse/payload.rs
+++ b/src/exporters/clickhouse/payload.rs
@@ -41,6 +41,10 @@ impl ClickhousePayloadBuilder {
         Ok(written)
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.curr_chunk.is_empty() && self.closed.is_empty()
+    }
+
     pub(crate) fn finish(mut self) -> Result<ClickhousePayload, BoxError> {
         if !self.curr_chunk.is_empty() {
             let new_chunk = self.take_and_close_current()?;

--- a/src/exporters/clickhouse/request_mapper.rs
+++ b/src/exporters/clickhouse/request_mapper.rs
@@ -1,0 +1,119 @@
+use crate::exporters::clickhouse::api_request::{ApiRequestBuilder, ConnectionConfig};
+use crate::exporters::clickhouse::payload::ClickhousePayload;
+use crate::exporters::clickhouse::schema::{
+    get_log_row_col_keys, get_metrics_exp_histogram_row_col_keys, get_metrics_gauge_row_col_keys,
+    get_metrics_histogram_row_col_keys, get_metrics_sum_row_col_keys,
+    get_metrics_summary_row_col_keys, get_span_row_col_keys,
+};
+use http::Request;
+use std::collections::HashMap;
+use tower::BoxError;
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum RequestType {
+    Traces,
+    Logs,
+    MetricsSum,
+    MetricsGauge,
+    MetricsHistogram,
+    MetricsExponentialHistogram,
+    MetricsSummary,
+}
+
+pub struct RequestMapper {
+    mapper: HashMap<RequestType, ApiRequestBuilder>,
+}
+
+impl RequestMapper {
+    fn new(config: &ConnectionConfig, table_prefix: String) -> Result<Self, BoxError> {
+        let mut mapper = HashMap::new();
+
+        mapper.insert(
+            RequestType::Traces,
+            new_api_req_builder(config, &table_prefix, "traces", get_span_row_col_keys())?,
+        );
+        mapper.insert(
+            RequestType::Logs,
+            new_api_req_builder(config, &table_prefix, "logs", get_log_row_col_keys())?,
+        );
+        mapper.insert(
+            RequestType::MetricsSum,
+            new_api_req_builder(
+                config,
+                &table_prefix,
+                "metrics_sum",
+                get_metrics_sum_row_col_keys(),
+            )?,
+        );
+        mapper.insert(
+            RequestType::MetricsGauge,
+            new_api_req_builder(
+                config,
+                &table_prefix,
+                "metrics_gauge",
+                get_metrics_gauge_row_col_keys(),
+            )?,
+        );
+        mapper.insert(
+            RequestType::MetricsHistogram,
+            new_api_req_builder(
+                config,
+                &table_prefix,
+                "metrics_histogram",
+                get_metrics_histogram_row_col_keys(),
+            )?,
+        );
+        mapper.insert(
+            RequestType::MetricsExponentialHistogram,
+            new_api_req_builder(
+                config,
+                &table_prefix,
+                "metrics_exponential_histogram",
+                get_metrics_exp_histogram_row_col_keys(),
+            )?,
+        );
+        mapper.insert(
+            RequestType::MetricsSummary,
+            new_api_req_builder(
+                config,
+                &table_prefix,
+                "metrics_summary",
+                get_metrics_summary_row_col_keys(),
+            )?,
+        );
+
+        Ok(Self { mapper })
+    }
+
+    fn build(
+        &self,
+        req_type: RequestType,
+        payload: ClickhousePayload,
+    ) -> Result<Request<ClickhousePayload>, BoxError> {
+        let req_builder = self
+            .mapper
+            .get(&req_type)
+            .expect("unknown request type in mapper");
+
+        req_builder.build(payload)
+    }
+}
+
+fn new_api_req_builder(
+    config: &ConnectionConfig,
+    table_prefix: &String,
+    table_name: &str,
+    col_keys: String,
+) -> Result<ApiRequestBuilder, BoxError> {
+    let query = build_insert_sql(get_table_name(table_prefix, table_name), col_keys);
+
+    ApiRequestBuilder::new(config, query)
+}
+
+fn build_insert_sql(table: String, cols: String) -> String {
+    format!("INSERT INTO {} ({}) FORMAT RowBinary", table, cols,)
+}
+
+fn get_table_name(table_prefix: &String, table: &str) -> String {
+    format!("{}_{}", table_prefix, table)
+}

--- a/src/exporters/clickhouse/request_mapper.rs
+++ b/src/exporters/clickhouse/request_mapper.rs
@@ -9,7 +9,7 @@ use http::Request;
 use std::collections::HashMap;
 use tower::BoxError;
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash, Clone)]
 pub enum RequestType {
     Traces,
     Logs,
@@ -20,12 +20,13 @@ pub enum RequestType {
     MetricsSummary,
 }
 
+#[derive(Clone)]
 pub struct RequestMapper {
     mapper: HashMap<RequestType, ApiRequestBuilder>,
 }
 
 impl RequestMapper {
-    fn new(config: &ConnectionConfig, table_prefix: String) -> Result<Self, BoxError> {
+    pub(crate) fn new(config: &ConnectionConfig, table_prefix: String) -> Result<Self, BoxError> {
         let mut mapper = HashMap::new();
 
         mapper.insert(
@@ -85,7 +86,7 @@ impl RequestMapper {
         Ok(Self { mapper })
     }
 
-    fn build(
+    pub(crate) fn build(
         &self,
         req_type: RequestType,
         payload: ClickhousePayload,

--- a/src/exporters/clickhouse/schema.rs
+++ b/src/exporters/clickhouse/schema.rs
@@ -124,7 +124,7 @@ pub fn get_log_row_col_keys() -> String {
     fields.join(",")
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsMeta {
     pub(crate) resource_attributes: MapOrJson,
@@ -162,7 +162,7 @@ pub fn get_metrics_meta_col_keys<'a>() -> Vec<&'a str> {
     ]
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsExemplars {
     #[serde(rename = "Exemplars.FilteredAttributes")]
@@ -187,7 +187,7 @@ pub fn get_metrics_exemplars_col_keys<'a>() -> Vec<&'a str> {
     ]
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsSumRow<'a> {
     #[serde(flatten)]

--- a/src/exporters/clickhouse/schema.rs
+++ b/src/exporters/clickhouse/schema.rs
@@ -216,37 +216,22 @@ pub fn get_metrics_sum_row_col_keys() -> String {
 
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct MetricsGaugeRow {
+pub struct MetricsGaugeRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta,
 
     pub(crate) value: f64,
     pub(crate) flags: u32,
 
-    #[serde(rename = "Exemplars.FilteredAttributes")]
-    pub(crate) exemplars_filtered_attributes: MapOrJson,
-    #[serde(rename = "Exemplars.TimeUnix")]
-    pub(crate) exemplars_time_unix: u64,
-    #[serde(rename = "Exemplars.Value")]
-    pub(crate) exemplars_value: f64,
-    #[serde(rename = "Exemplars.SpanId")]
-    pub(crate) exemplars_span_id: String,
-    #[serde(rename = "Exemplars.TraceId")]
-    pub(crate) exemplars_trace_id: String,
+    #[serde(flatten)]
+    pub(crate) exemplars: MetricsExemplars,
 }
 
 pub fn get_metrics_gauge_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
-        vec![
-            "Value",
-            "Flags",
-            "Exemplars.FilteredAttributes",
-            "Exemplars.TimeUnix",
-            "Exemplars.Value",
-            "Exemplars.SpanId",
-            "Exemplars.TraceId",
-        ],
+        vec!["Value", "Flags"],
+        get_metrics_exemplars_col_keys(),
     ]
     .concat();
 
@@ -255,30 +240,22 @@ pub fn get_metrics_gauge_row_col_keys() -> String {
 
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct MetricsHistogramRow {
+pub struct MetricsHistogramRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta,
 
     pub(crate) count: u64,
     pub(crate) sum: f64,
     pub(crate) bucket_counts: Vec<u64>,
     pub(crate) explicit_bounds: Vec<f64>,
 
-    #[serde(rename = "Exemplars.FilteredAttributes")]
-    pub(crate) exemplars_filtered_attributes: MapOrJson,
-    #[serde(rename = "Exemplars.TimeUnix")]
-    pub(crate) exemplars_time_unix: u64,
-    #[serde(rename = "Exemplars.Value")]
-    pub(crate) exemplars_value: f64,
-    #[serde(rename = "Exemplars.SpanId")]
-    pub(crate) exemplars_span_id: String,
-    #[serde(rename = "Exemplars.TraceId")]
-    pub(crate) exemplars_trace_id: String,
-
     pub(crate) flags: u32,
     pub(crate) min: f64,
     pub(crate) max: f64,
     pub(crate) aggregation_temporality: i32,
+
+    #[serde(flatten)]
+    pub(crate) exemplars: MetricsExemplars,
 }
 
 pub fn get_metrics_histogram_row_col_keys() -> String {
@@ -289,16 +266,12 @@ pub fn get_metrics_histogram_row_col_keys() -> String {
             "Sum",
             "BucketCounts",
             "ExplicitBounds",
-            "Exemplars.FilteredAttributes",
-            "Exemplars.TimeUnix",
-            "Exemplars.Value",
-            "Exemplars.SpanId",
-            "Exemplars.TraceId",
             "Flags",
             "Min",
             "Max",
             "AggregationTemporality",
         ],
+        get_metrics_exemplars_col_keys(),
     ]
     .concat();
 
@@ -307,9 +280,9 @@ pub fn get_metrics_histogram_row_col_keys() -> String {
 
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct MetricsExpHistogramRow {
+pub struct MetricsExpHistogramRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta,
 
     pub(crate) count: u64,
     pub(crate) sum: f64,
@@ -321,21 +294,13 @@ pub struct MetricsExpHistogramRow {
     pub(crate) negative_offset: i32,
     pub(crate) negative_bucket_counts: Vec<u64>,
 
-    #[serde(rename = "Exemplars.FilteredAttributes")]
-    pub(crate) exemplars_filtered_attributes: MapOrJson,
-    #[serde(rename = "Exemplars.TimeUnix")]
-    pub(crate) exemplars_time_unix: u64,
-    #[serde(rename = "Exemplars.Value")]
-    pub(crate) exemplars_value: f64,
-    #[serde(rename = "Exemplars.SpanId")]
-    pub(crate) exemplars_span_id: String,
-    #[serde(rename = "Exemplars.TraceId")]
-    pub(crate) exemplars_trace_id: String,
-
     pub(crate) flags: u32,
     pub(crate) min: f64,
     pub(crate) max: f64,
     pub(crate) aggregation_temporality: i32,
+
+    #[serde(flatten)]
+    pub(crate) exemplars: MetricsExemplars,
 }
 
 pub fn get_metrics_exp_histogram_row_col_keys() -> String {
@@ -350,16 +315,12 @@ pub fn get_metrics_exp_histogram_row_col_keys() -> String {
             "PositiveBucketCounts",
             "NegativeOffset",
             "NegativeBucketCounts",
-            "Exemplars.FilteredAttributes",
-            "Exemplars.TimeUnix",
-            "Exemplars.Value",
-            "Exemplars.SpanId",
-            "Exemplars.TraceId",
             "Flags",
             "Min",
             "Max",
             "AggregationTemporality",
         ],
+        get_metrics_exemplars_col_keys(),
     ]
     .concat();
 
@@ -368,28 +329,18 @@ pub fn get_metrics_exp_histogram_row_col_keys() -> String {
 
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct MetricsSummaryRow {
+pub struct MetricsSummaryRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta,
 
     pub(crate) count: u64,
     pub(crate) sum: f64,
 
     #[serde(rename = "ValueAtQuantiles.Quantile")]
-    pub(crate) value_at_quantiles_quantile: f64,
+    pub(crate) value_at_quantiles_quantile: Vec<f64>,
     #[serde(rename = "ValueAtQuantiles.Value")]
-    pub(crate) value_at_quantiles_value: f64,
-    //
-    // #[serde(rename = "Exemplars.FilteredAttributes")]
-    // pub(crate) exemplars_filtered_attributes: MapOrJson,
-    // #[serde(rename = "Exemplars.TimeUnix")]
-    // pub(crate) exemplars_time_unix: u64,
-    // #[serde(rename = "Exemplars.Value")]
-    // pub(crate) exemplars_value: f64,
-    // #[serde(rename = "Exemplars.SpanId")]
-    // pub(crate) exemplars_span_id: String,
-    // #[serde(rename = "Exemplars.TraceId")]
-    // pub(crate) exemplars_trace_id: String,
+    pub(crate) value_at_quantiles_value: Vec<f64>,
+
     pub(crate) flags: u32,
 }
 
@@ -401,11 +352,6 @@ pub fn get_metrics_summary_row_col_keys() -> String {
             "Sum",
             "ValueAtQuantiles.Quantile",
             "ValueAtQauntiles.Value",
-            // "Exemplars.FilteredAttributes",
-            // "Exemplars.TimeUnix",
-            // "Exemplars.Value",
-            // "Exemplars.SpanId",
-            // "Exemplars.TraceId",
             "Flags",
         ],
     ]

--- a/src/exporters/clickhouse/schema.rs
+++ b/src/exporters/clickhouse/schema.rs
@@ -124,6 +124,288 @@ pub fn get_log_row_col_keys() -> String {
     fields.join(",")
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsMeta {
+    pub(crate) resource_attributes: MapOrJson,
+    pub(crate) resource_schema_url: String,
+    pub(crate) scope_name: String,
+    pub(crate) scope_version: String,
+    pub(crate) scope_attributes: MapOrJson,
+    pub(crate) scope_dropped_attr_count: u32,
+    pub(crate) scope_schema_url: String,
+    pub(crate) service_name: String,
+    pub(crate) metric_name: String,
+    pub(crate) metric_description: String,
+    pub(crate) metric_unit: String,
+    pub(crate) attributes: MapOrJson,
+    pub(crate) start_time_unix: u64,
+    pub(crate) time_unix: u64,
+}
+
+pub fn get_metrics_meta_col_keys<'a>() -> Vec<&'a str> {
+    vec![
+        "ResourceAttributes",
+        "ResourceSchemaUrl",
+        "ScopeName",
+        "ScopeVersion",
+        "ScopeAttributes",
+        "ScopeDroppedAttrCount",
+        "ScopeSchemaUrl",
+        "ServiceName",
+        "MetricName",
+        "MetricDescription",
+        "MetricUnit",
+        "Attributes",
+        "StartTimeUnix",
+        "TimeUnix",
+    ]
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsSumRow {
+    #[serde(flatten)]
+    pub(crate) meta: MetricsMeta,
+
+    pub(crate) value: f64,
+    pub(crate) flags: u32,
+
+    #[serde(rename = "Exemplars.FilteredAttributes")]
+    pub(crate) exemplars_filtered_attributes: MapOrJson,
+    #[serde(rename = "Exemplars.TimeUnix")]
+    pub(crate) exemplars_time_unix: u64,
+    #[serde(rename = "Exemplars.Value")]
+    pub(crate) exemplars_value: f64,
+    #[serde(rename = "Exemplars.SpanId")]
+    pub(crate) exemplars_span_id: String,
+    #[serde(rename = "Exemplars.TraceId")]
+    pub(crate) exemplars_trace_id: String,
+
+    pub(crate) aggregation_temporality: i32,
+    pub(crate) is_monotonic: bool,
+}
+
+pub fn get_metrics_sum_row_col_keys() -> String {
+    let fields = [
+        get_metrics_meta_col_keys(),
+        vec![
+            "Value",
+            "Flags",
+            "Exemplars.FilteredAttributes",
+            "Exemplars.TimeUnix",
+            "Exemplars.Value",
+            "Exemplars.SpanId",
+            "Exemplars.TraceId",
+            "AggregationTemporality",
+            "IsMonotonic",
+        ],
+    ]
+    .concat();
+
+    fields.join(",")
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsGaugeRow {
+    #[serde(flatten)]
+    pub(crate) meta: MetricsMeta,
+
+    pub(crate) value: f64,
+    pub(crate) flags: u32,
+
+    #[serde(rename = "Exemplars.FilteredAttributes")]
+    pub(crate) exemplars_filtered_attributes: MapOrJson,
+    #[serde(rename = "Exemplars.TimeUnix")]
+    pub(crate) exemplars_time_unix: u64,
+    #[serde(rename = "Exemplars.Value")]
+    pub(crate) exemplars_value: f64,
+    #[serde(rename = "Exemplars.SpanId")]
+    pub(crate) exemplars_span_id: String,
+    #[serde(rename = "Exemplars.TraceId")]
+    pub(crate) exemplars_trace_id: String,
+}
+
+pub fn get_metrics_gauge_row_col_keys() -> String {
+    let fields = [
+        get_metrics_meta_col_keys(),
+        vec![
+            "Value",
+            "Flags",
+            "Exemplars.FilteredAttributes",
+            "Exemplars.TimeUnix",
+            "Exemplars.Value",
+            "Exemplars.SpanId",
+            "Exemplars.TraceId",
+        ],
+    ]
+    .concat();
+
+    fields.join(",")
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsHistogramRow {
+    #[serde(flatten)]
+    pub(crate) meta: MetricsMeta,
+
+    pub(crate) count: u64,
+    pub(crate) sum: f64,
+    pub(crate) bucket_counts: Vec<u64>,
+    pub(crate) explicit_bounds: Vec<f64>,
+
+    #[serde(rename = "Exemplars.FilteredAttributes")]
+    pub(crate) exemplars_filtered_attributes: MapOrJson,
+    #[serde(rename = "Exemplars.TimeUnix")]
+    pub(crate) exemplars_time_unix: u64,
+    #[serde(rename = "Exemplars.Value")]
+    pub(crate) exemplars_value: f64,
+    #[serde(rename = "Exemplars.SpanId")]
+    pub(crate) exemplars_span_id: String,
+    #[serde(rename = "Exemplars.TraceId")]
+    pub(crate) exemplars_trace_id: String,
+
+    pub(crate) flags: u32,
+    pub(crate) min: f64,
+    pub(crate) max: f64,
+    pub(crate) aggregation_temporality: i32,
+}
+
+pub fn get_metrics_histogram_row_col_keys() -> String {
+    let fields = [
+        get_metrics_meta_col_keys(),
+        vec![
+            "Count",
+            "Sum",
+            "BucketCounts",
+            "ExplicitBounds",
+            "Exemplars.FilteredAttributes",
+            "Exemplars.TimeUnix",
+            "Exemplars.Value",
+            "Exemplars.SpanId",
+            "Exemplars.TraceId",
+            "Flags",
+            "Min",
+            "Max",
+            "AggregationTemporality",
+        ],
+    ]
+    .concat();
+
+    fields.join(",")
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsExpHistogramRow {
+    #[serde(flatten)]
+    pub(crate) meta: MetricsMeta,
+
+    pub(crate) count: u64,
+    pub(crate) sum: f64,
+    pub(crate) scale: i32,
+    pub(crate) zero_count: u64,
+
+    pub(crate) positive_offset: i32,
+    pub(crate) positive_bucket_counts: Vec<u64>,
+    pub(crate) negative_offset: i32,
+    pub(crate) negative_bucket_counts: Vec<u64>,
+
+    #[serde(rename = "Exemplars.FilteredAttributes")]
+    pub(crate) exemplars_filtered_attributes: MapOrJson,
+    #[serde(rename = "Exemplars.TimeUnix")]
+    pub(crate) exemplars_time_unix: u64,
+    #[serde(rename = "Exemplars.Value")]
+    pub(crate) exemplars_value: f64,
+    #[serde(rename = "Exemplars.SpanId")]
+    pub(crate) exemplars_span_id: String,
+    #[serde(rename = "Exemplars.TraceId")]
+    pub(crate) exemplars_trace_id: String,
+
+    pub(crate) flags: u32,
+    pub(crate) min: f64,
+    pub(crate) max: f64,
+    pub(crate) aggregation_temporality: i32,
+}
+
+pub fn get_metrics_exp_histogram_row_col_keys() -> String {
+    let fields = [
+        get_metrics_meta_col_keys(),
+        vec![
+            "Count",
+            "Sum",
+            "Scale",
+            "ZeroCount",
+            "PositiveOffset",
+            "PositiveBucketCounts",
+            "NegativeOffset",
+            "NegativeBucketCounts",
+            "Exemplars.FilteredAttributes",
+            "Exemplars.TimeUnix",
+            "Exemplars.Value",
+            "Exemplars.SpanId",
+            "Exemplars.TraceId",
+            "Flags",
+            "Min",
+            "Max",
+            "AggregationTemporality",
+        ],
+    ]
+    .concat();
+
+    fields.join(",")
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsSummaryRow {
+    #[serde(flatten)]
+    pub(crate) meta: MetricsMeta,
+
+    pub(crate) count: u64,
+    pub(crate) sum: f64,
+
+    #[serde(rename = "ValueAtQuantiles.Quantile")]
+    pub(crate) value_at_quantiles_quantile: f64,
+    #[serde(rename = "ValueAtQuantiles.Value")]
+    pub(crate) value_at_quantiles_value: f64,
+    //
+    // #[serde(rename = "Exemplars.FilteredAttributes")]
+    // pub(crate) exemplars_filtered_attributes: MapOrJson,
+    // #[serde(rename = "Exemplars.TimeUnix")]
+    // pub(crate) exemplars_time_unix: u64,
+    // #[serde(rename = "Exemplars.Value")]
+    // pub(crate) exemplars_value: f64,
+    // #[serde(rename = "Exemplars.SpanId")]
+    // pub(crate) exemplars_span_id: String,
+    // #[serde(rename = "Exemplars.TraceId")]
+    // pub(crate) exemplars_trace_id: String,
+    pub(crate) flags: u32,
+}
+
+pub fn get_metrics_summary_row_col_keys() -> String {
+    let fields = [
+        get_metrics_meta_col_keys(),
+        vec![
+            "Count",
+            "Sum",
+            "ValueAtQuantiles.Quantile",
+            "ValueAtQauntiles.Value",
+            // "Exemplars.FilteredAttributes",
+            // "Exemplars.TimeUnix",
+            // "Exemplars.Value",
+            // "Exemplars.SpanId",
+            // "Exemplars.TraceId",
+            "Flags",
+        ],
+    ]
+    .concat();
+
+    fields.join(",")
+}
+
 #[derive(Debug)]
 pub enum MapOrJson {
     Map(Vec<(String, String)>),

--- a/src/exporters/clickhouse/schema.rs
+++ b/src/exporters/clickhouse/schema.rs
@@ -164,42 +164,50 @@ pub fn get_metrics_meta_col_keys<'a>() -> Vec<&'a str> {
 
 #[derive(Serialize)]
 #[serde(rename_all = "PascalCase")]
-pub struct MetricsSumRow {
+pub struct MetricsExemplars {
+    #[serde(rename = "Exemplars.FilteredAttributes")]
+    pub(crate) exemplars_filtered_attributes: Vec<MapOrJson>,
+    #[serde(rename = "Exemplars.TimeUnix")]
+    pub(crate) exemplars_time_unix: Vec<u64>,
+    #[serde(rename = "Exemplars.Value")]
+    pub(crate) exemplars_value: Vec<f64>,
+    #[serde(rename = "Exemplars.SpanId")]
+    pub(crate) exemplars_span_id: Vec<String>,
+    #[serde(rename = "Exemplars.TraceId")]
+    pub(crate) exemplars_trace_id: Vec<String>,
+}
+
+pub fn get_metrics_exemplars_col_keys<'a>() -> Vec<&'a str> {
+    vec![
+        "Exemplars.FilteredAttributes",
+        "Exemplars.TimeUnix",
+        "Exemplars.Value",
+        "Exemplars.SpanId",
+        "Exemplars.TraceId",
+    ]
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct MetricsSumRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta,
 
     pub(crate) value: f64,
     pub(crate) flags: u32,
 
-    #[serde(rename = "Exemplars.FilteredAttributes")]
-    pub(crate) exemplars_filtered_attributes: MapOrJson,
-    #[serde(rename = "Exemplars.TimeUnix")]
-    pub(crate) exemplars_time_unix: u64,
-    #[serde(rename = "Exemplars.Value")]
-    pub(crate) exemplars_value: f64,
-    #[serde(rename = "Exemplars.SpanId")]
-    pub(crate) exemplars_span_id: String,
-    #[serde(rename = "Exemplars.TraceId")]
-    pub(crate) exemplars_trace_id: String,
-
     pub(crate) aggregation_temporality: i32,
     pub(crate) is_monotonic: bool,
+
+    #[serde(flatten)]
+    pub(crate) exemplars: MetricsExemplars,
 }
 
 pub fn get_metrics_sum_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
-        vec![
-            "Value",
-            "Flags",
-            "Exemplars.FilteredAttributes",
-            "Exemplars.TimeUnix",
-            "Exemplars.Value",
-            "Exemplars.SpanId",
-            "Exemplars.TraceId",
-            "AggregationTemporality",
-            "IsMonotonic",
-        ],
+        vec!["Value", "Flags", "AggregationTemporality", "IsMonotonic"],
+        get_metrics_exemplars_col_keys(),
     ]
     .concat();
 

--- a/src/exporters/clickhouse/transform_logs.rs
+++ b/src/exporters/clickhouse/transform_logs.rs
@@ -1,0 +1,69 @@
+use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayloadBuilder};
+use crate::exporters::clickhouse::request_builder::TransformPayload;
+use crate::exporters::clickhouse::request_mapper::RequestType;
+use crate::exporters::clickhouse::schema::LogRecordRow;
+use crate::exporters::clickhouse::transformer::{
+    Transformer, find_attribute, get_scope_properties,
+};
+use crate::otlp::cvattr;
+use crate::otlp::cvattr::ConvertedAttrValue;
+use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use tower::BoxError;
+
+impl TransformPayload<ResourceLogs> for Transformer {
+    fn transform(
+        &self,
+        input: Vec<ResourceLogs>,
+    ) -> Result<Vec<(RequestType, ClickhousePayload)>, BoxError> {
+        let mut payload_builder = ClickhousePayloadBuilder::new(self.compression.clone());
+        for rl in input {
+            let res_attrs = rl.resource.unwrap_or_default().attributes;
+            let res_attrs = cvattr::convert(&res_attrs);
+            let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+            let res_schema_url = rl.schema_url;
+
+            for sl in rl.scope_logs {
+                let (scope_name, scope_version) = get_scope_properties(sl.scope.as_ref());
+
+                let scope_attrs = match sl.scope.as_ref() {
+                    None => Vec::new(),
+                    Some(scope) => cvattr::convert(&scope.attributes),
+                };
+
+                for log in sl.log_records {
+                    let log_attrs = cvattr::convert(&log.attributes);
+
+                    let body_conv: Option<ConvertedAttrValue> = match log.body {
+                        None => None,
+                        Some(av) => av.value.map(|v| v.into()),
+                    };
+
+                    let row = LogRecordRow {
+                        timestamp: log.time_unix_nano,
+                        trace_id: hex::encode(log.trace_id),
+                        span_id: hex::encode(log.span_id),
+                        trace_flags: (log.flags & 0x000000FF) as u8,
+                        severity_text: log.severity_text,
+                        severity_number: (log.severity_number & 0x000000FF) as u8,
+                        service_name: service_name.clone(),
+                        body: body_conv.map(|av| av.to_string()).unwrap_or_default(),
+                        resource_schema_url: res_schema_url.clone(),
+                        resource_attributes: self.transform_attrs(&res_attrs),
+                        scope_schema_url: sl.schema_url.clone(),
+                        scope_name: scope_name.clone(),
+                        scope_version: scope_version.clone(),
+                        scope_attributes: self.transform_attrs(&scope_attrs),
+                        log_attributes: self.transform_attrs(&log_attrs),
+                    };
+
+                    payload_builder.add_row(&row)?;
+                }
+            }
+        }
+
+        payload_builder
+            .finish()
+            .map(|payload| vec![(RequestType::Logs, payload)])
+    }
+}

--- a/src/exporters/clickhouse/transform_metrics.rs
+++ b/src/exporters/clickhouse/transform_metrics.rs
@@ -1,0 +1,144 @@
+use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayloadBuilder};
+use crate::exporters::clickhouse::request_builder::TransformPayload;
+use crate::exporters::clickhouse::request_mapper::RequestType;
+use crate::exporters::clickhouse::schema::{
+    MapOrJson, MetricsExemplars, MetricsMeta, MetricsSumRow,
+};
+use crate::exporters::clickhouse::transformer::{
+    Transformer, find_attribute, get_scope_properties,
+};
+use crate::otlp::cvattr;
+use opentelemetry_proto::tonic::metrics::v1::exemplar::Value;
+use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+use opentelemetry_proto::tonic::metrics::v1::number_data_point::Value as DataPointValue;
+use opentelemetry_proto::tonic::metrics::v1::{Exemplar, ResourceMetrics};
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use std::collections::HashMap;
+use tower::BoxError;
+
+impl TransformPayload<ResourceMetrics> for Transformer {
+    fn transform(
+        &self,
+        input: Vec<ResourceMetrics>,
+    ) -> Result<Vec<(RequestType, ClickhousePayload)>, BoxError> {
+        let mut payloads = HashMap::new();
+
+        for rm in input {
+            let res_attrs = rm.resource.unwrap_or_default().attributes;
+            let res_attrs = cvattr::convert(&res_attrs);
+            let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+
+            for sm in rm.scope_metrics {
+                let (scope_name, scope_version) = get_scope_properties(sm.scope.as_ref());
+                let scope_attrs = match &sm.scope {
+                    None => Vec::new(),
+                    Some(scope) => cvattr::convert(&scope.attributes),
+                };
+
+                let droppped_attr_count = sm.scope.map(|s| s.dropped_attributes_count).unwrap_or(0);
+
+                for metric in sm.metrics {
+                    if let Some(data) = metric.data {
+                        let mut meta = MetricsMeta {
+                            resource_attributes: self.transform_attrs(&res_attrs),
+                            resource_schema_url: rm.schema_url.clone(),
+                            scope_name: scope_name.clone(),
+                            scope_version: scope_version.clone(),
+                            scope_attributes: self.transform_attrs(&scope_attrs),
+                            scope_dropped_attr_count: droppped_attr_count,
+                            scope_schema_url: sm.schema_url.clone(),
+                            service_name: service_name.clone(),
+                            metric_name: metric.name,
+                            metric_description: metric.description,
+                            metric_unit: metric.unit,
+                            // Placeholder values that will be replaced per data point
+                            attributes: MapOrJson::Json("".to_string()),
+                            start_time_unix: 0,
+                            time_unix: 0,
+                        };
+
+                        match data {
+                            Data::Sum(s) => {
+                                for dp in s.data_points {
+                                    let attrs = cvattr::convert(&dp.attributes);
+
+                                    meta.attributes = self.transform_attrs(&attrs);
+                                    meta.start_time_unix = dp.start_time_unix_nano;
+                                    meta.time_unix = dp.time_unix_nano;
+
+                                    let row = MetricsSumRow {
+                                        meta: &meta,
+
+                                        value: get_metric_value(dp.value),
+                                        flags: dp.flags,
+                                        aggregation_temporality: s.aggregation_temporality,
+                                        is_monotonic: s.is_monotonic,
+                                        exemplars: self.parse_exemplars(&dp.exemplars),
+                                    };
+
+                                    let e = payloads.entry(RequestType::MetricsSum).or_insert(
+                                        ClickhousePayloadBuilder::new(self.compression.clone()),
+                                    );
+
+                                    e.add_row(&row)?;
+                                }
+                            }
+                            Data::Gauge(_) => {}
+                            Data::Histogram(_) => {}
+                            Data::ExponentialHistogram(_) => {}
+                            Data::Summary(_) => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        payloads
+            .into_iter()
+            .filter_map(|(typ, builder)| match builder.is_empty() {
+                true => None,
+                false => match builder.finish() {
+                    Ok(payload) => Some(Ok((typ, payload))),
+                    Err(e) => Some(Err(e)),
+                },
+            })
+            .collect()
+    }
+}
+
+impl Transformer {
+    fn parse_exemplars(&self, exemplars: &[Exemplar]) -> MetricsExemplars {
+        MetricsExemplars {
+            exemplars_filtered_attributes: exemplars
+                .iter()
+                .map(|e| {
+                    let event_attrs = cvattr::convert(&e.filtered_attributes);
+                    self.transform_attrs(&event_attrs)
+                })
+                .collect(),
+            exemplars_time_unix: exemplars.iter().map(|e| e.time_unix_nano).collect(),
+            exemplars_value: exemplars
+                .iter()
+                .map(|e| match e.value {
+                    None => 0.0,
+                    Some(value) => match value {
+                        Value::AsDouble(f) => f,
+                        Value::AsInt(i) => i as f64,
+                    },
+                })
+                .collect(),
+            exemplars_span_id: exemplars.iter().map(|e| hex::encode(&e.span_id)).collect(),
+            exemplars_trace_id: exemplars.iter().map(|e| hex::encode(&e.trace_id)).collect(),
+        }
+    }
+}
+
+fn get_metric_value(dp: Option<DataPointValue>) -> f64 {
+    match dp {
+        None => 0.0,
+        Some(value) => match value {
+            DataPointValue::AsDouble(f) => f,
+            DataPointValue::AsInt(i) => i as f64,
+        },
+    }
+}

--- a/src/exporters/clickhouse/transform_traces.rs
+++ b/src/exporters/clickhouse/transform_traces.rs
@@ -59,13 +59,9 @@ impl TransformPayload<ResourceSpans> for Transformer {
                         links_trace_id: span
                             .links
                             .iter()
-                            .map(|l| hex::encode(l.trace_id.clone()))
+                            .map(|l| hex::encode(&l.trace_id))
                             .collect(),
-                        links_span_id: span
-                            .links
-                            .iter()
-                            .map(|l| hex::encode(l.span_id.clone()))
-                            .collect(),
+                        links_span_id: span.links.iter().map(|l| hex::encode(&l.span_id)).collect(),
                         links_trace_state: span
                             .links
                             .iter()

--- a/src/exporters/clickhouse/transform_traces.rs
+++ b/src/exporters/clickhouse/transform_traces.rs
@@ -1,0 +1,127 @@
+use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayloadBuilder};
+use crate::exporters::clickhouse::request_builder::TransformPayload;
+use crate::exporters::clickhouse::request_mapper::RequestType;
+use crate::exporters::clickhouse::schema::SpanRow;
+use crate::exporters::clickhouse::transformer::{
+    Transformer, find_attribute, get_scope_properties,
+};
+use crate::otlp::cvattr;
+use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, Span};
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use tower::BoxError;
+
+impl TransformPayload<ResourceSpans> for Transformer {
+    fn transform(
+        &self,
+        input: Vec<ResourceSpans>,
+    ) -> Result<Vec<(RequestType, ClickhousePayload)>, BoxError> {
+        let mut payload_builder = ClickhousePayloadBuilder::new(self.compression.clone());
+        for rs in input {
+            let res_attrs = rs.resource.unwrap_or_default().attributes;
+            let res_attrs = cvattr::convert(&res_attrs);
+            let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+
+            for ss in rs.scope_spans {
+                let (scope_name, scope_version) = get_scope_properties(ss.scope.as_ref());
+
+                for span in ss.spans {
+                    let span_attrs = cvattr::convert(&span.attributes);
+                    let status_code = status_code(&span);
+                    let status_message = status_message(&span);
+
+                    let row = SpanRow {
+                        timestamp: span.start_time_unix_nano,
+                        trace_id: hex::encode(span.trace_id),
+                        span_id: hex::encode(span.span_id),
+                        parent_span_id: hex::encode(span.parent_span_id),
+                        trace_state: span.trace_state,
+                        span_name: span.name,
+                        span_kind: span_kind_to_string(span.kind),
+                        service_name: service_name.clone(),
+                        resource_attributes: self.transform_attrs(&res_attrs),
+                        scope_name: scope_name.clone(),
+                        scope_version: scope_version.clone(),
+                        span_attributes: self.transform_attrs(&span_attrs),
+                        duration: (span.end_time_unix_nano - span.start_time_unix_nano) as i64,
+                        status_code,
+                        status_message,
+                        events_timestamp: span.events.iter().map(|e| e.time_unix_nano).collect(),
+                        events_name: span.events.iter().map(|e| e.name.clone()).collect(),
+                        events_attributes: span
+                            .events
+                            .iter()
+                            .map(|e| {
+                                let event_attrs = cvattr::convert(&e.attributes);
+                                self.transform_attrs(&event_attrs)
+                            })
+                            .collect(),
+                        links_trace_id: span
+                            .links
+                            .iter()
+                            .map(|l| hex::encode(l.trace_id.clone()))
+                            .collect(),
+                        links_span_id: span
+                            .links
+                            .iter()
+                            .map(|l| hex::encode(l.span_id.clone()))
+                            .collect(),
+                        links_trace_state: span
+                            .links
+                            .iter()
+                            .map(|l| l.trace_state.clone())
+                            .collect(),
+                        links_attributes: span
+                            .links
+                            .iter()
+                            .map(|l| {
+                                let link_attrs = cvattr::convert(&l.attributes);
+                                self.transform_attrs(&link_attrs)
+                            })
+                            .collect(),
+                    };
+
+                    payload_builder.add_row(&row)?;
+                }
+            }
+        }
+
+        payload_builder
+            .finish()
+            .map(|payload| vec![(RequestType::Traces, payload)])
+    }
+}
+
+fn span_kind_to_string(kind: i32) -> String {
+    if kind == SpanKind::Internal as i32 {
+        "Internal".to_string()
+    } else if kind == SpanKind::Server as i32 {
+        "Server".to_string()
+    } else if kind == SpanKind::Client as i32 {
+        "Client".to_string()
+    } else if kind == SpanKind::Producer as i32 {
+        "Producer".to_string()
+    } else if kind == SpanKind::Consumer as i32 {
+        "client".to_string()
+    } else {
+        "Unspecified".to_string()
+    }
+}
+
+fn status_message(span: &Span) -> String {
+    match &span.status {
+        None => "".to_string(),
+        Some(s) => s.message.clone(),
+    }
+}
+
+fn status_code(span: &Span) -> String {
+    match &span.status {
+        None => "Unset".to_string(),
+        Some(s) => match s.code {
+            1 => "Ok".to_string(),
+            2 => "Error".to_string(),
+            _ => "Unset".to_string(),
+        },
+    }
+}

--- a/src/exporters/clickhouse/transformer.rs
+++ b/src/exporters/clickhouse/transformer.rs
@@ -1,21 +1,13 @@
 use crate::exporters::clickhouse::Compression;
-use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayloadBuilder};
-use crate::exporters::clickhouse::request_builder::TransformPayload;
-use crate::exporters::clickhouse::schema::{LogRecordRow, MapOrJson, SpanRow};
-use crate::otlp::cvattr;
-use crate::otlp::cvattr::{ConvertedAttrKeyValue, ConvertedAttrValue};
+use crate::exporters::clickhouse::schema::MapOrJson;
+use crate::otlp::cvattr::ConvertedAttrKeyValue;
 use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
-use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
-use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
-use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, Span};
-use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use serde_json::json;
 use std::collections::HashMap;
-use tower::BoxError;
 
 #[derive(Clone)]
 pub struct Transformer {
-    compression: Compression,
+    pub(crate) compression: Compression,
     use_json: bool,
     use_json_underscore: bool,
 }
@@ -30,135 +22,7 @@ impl Transformer {
     }
 }
 
-impl TransformPayload<ResourceSpans> for Transformer {
-    fn transform(&self, input: Vec<ResourceSpans>) -> Result<ClickhousePayload, BoxError> {
-        let mut payload_builder = ClickhousePayloadBuilder::new(self.compression.clone());
-        for rs in input {
-            let res_attrs = rs.resource.unwrap_or_default().attributes;
-            let res_attrs = cvattr::convert(&res_attrs);
-            let service_name = find_attribute(SERVICE_NAME, &res_attrs);
-
-            for ss in rs.scope_spans {
-                let (scope_name, scope_version) = get_scope_properties(ss.scope.as_ref());
-
-                for span in ss.spans {
-                    let span_attrs = cvattr::convert(&span.attributes);
-                    let status_code = status_code(&span);
-                    let status_message = status_message(&span);
-
-                    let row = SpanRow {
-                        timestamp: span.start_time_unix_nano,
-                        trace_id: hex::encode(span.trace_id),
-                        span_id: hex::encode(span.span_id),
-                        parent_span_id: hex::encode(span.parent_span_id),
-                        trace_state: span.trace_state,
-                        span_name: span.name,
-                        span_kind: span_kind_to_string(span.kind),
-                        service_name: service_name.clone(),
-                        resource_attributes: self.transform_attrs(&res_attrs),
-                        scope_name: scope_name.clone(),
-                        scope_version: scope_version.clone(),
-                        span_attributes: self.transform_attrs(&span_attrs),
-                        duration: (span.end_time_unix_nano - span.start_time_unix_nano) as i64,
-                        status_code,
-                        status_message,
-                        events_timestamp: span.events.iter().map(|e| e.time_unix_nano).collect(),
-                        events_name: span.events.iter().map(|e| e.name.clone()).collect(),
-                        events_attributes: span
-                            .events
-                            .iter()
-                            .map(|e| {
-                                let event_attrs = cvattr::convert(&e.attributes);
-                                self.transform_attrs(&event_attrs)
-                            })
-                            .collect(),
-                        links_trace_id: span
-                            .links
-                            .iter()
-                            .map(|l| hex::encode(l.trace_id.clone()))
-                            .collect(),
-                        links_span_id: span
-                            .links
-                            .iter()
-                            .map(|l| hex::encode(l.span_id.clone()))
-                            .collect(),
-                        links_trace_state: span
-                            .links
-                            .iter()
-                            .map(|l| l.trace_state.clone())
-                            .collect(),
-                        links_attributes: span
-                            .links
-                            .iter()
-                            .map(|l| {
-                                let link_attrs = cvattr::convert(&l.attributes);
-                                self.transform_attrs(&link_attrs)
-                            })
-                            .collect(),
-                    };
-
-                    payload_builder.add_row(&row)?;
-                }
-            }
-        }
-
-        payload_builder.finish()
-    }
-}
-
-impl TransformPayload<ResourceLogs> for Transformer {
-    fn transform(&self, input: Vec<ResourceLogs>) -> Result<ClickhousePayload, BoxError> {
-        let mut payload_builder = ClickhousePayloadBuilder::new(self.compression.clone());
-        for rl in input {
-            let res_attrs = rl.resource.unwrap_or_default().attributes;
-            let res_attrs = cvattr::convert(&res_attrs);
-            let service_name = find_attribute(SERVICE_NAME, &res_attrs);
-            let res_schema_url = rl.schema_url;
-
-            for sl in rl.scope_logs {
-                let (scope_name, scope_version) = get_scope_properties(sl.scope.as_ref());
-
-                let scope_attrs = match sl.scope.as_ref() {
-                    None => Vec::new(),
-                    Some(scope) => cvattr::convert(&scope.attributes),
-                };
-
-                for log in sl.log_records {
-                    let log_attrs = cvattr::convert(&log.attributes);
-
-                    let body_conv: Option<ConvertedAttrValue> = match log.body {
-                        None => None,
-                        Some(av) => av.value.map(|v| v.into()),
-                    };
-
-                    let row = LogRecordRow {
-                        timestamp: log.time_unix_nano,
-                        trace_id: hex::encode(log.trace_id),
-                        span_id: hex::encode(log.span_id),
-                        trace_flags: (log.flags & 0x000000FF) as u8,
-                        severity_text: log.severity_text,
-                        severity_number: (log.severity_number & 0x000000FF) as u8,
-                        service_name: service_name.clone(),
-                        body: body_conv.map(|av| av.to_string()).unwrap_or_default(),
-                        resource_schema_url: res_schema_url.clone(),
-                        resource_attributes: self.transform_attrs(&res_attrs),
-                        scope_schema_url: sl.schema_url.clone(),
-                        scope_name: scope_name.clone(),
-                        scope_version: scope_version.clone(),
-                        scope_attributes: self.transform_attrs(&scope_attrs),
-                        log_attributes: self.transform_attrs(&log_attrs),
-                    };
-
-                    payload_builder.add_row(&row)?;
-                }
-            }
-        }
-
-        payload_builder.finish()
-    }
-}
-
-fn get_scope_properties(scope: Option<&InstrumentationScope>) -> (String, String) {
+pub(crate) fn get_scope_properties(scope: Option<&InstrumentationScope>) -> (String, String) {
     match scope {
         None => ("".to_string(), "".to_string()),
         Some(scope) => (scope.name.clone(), scope.version.clone()),
@@ -166,7 +30,7 @@ fn get_scope_properties(scope: Option<&InstrumentationScope>) -> (String, String
 }
 
 impl Transformer {
-    fn transform_attrs(&self, attrs: &[ConvertedAttrKeyValue]) -> MapOrJson {
+    pub(crate) fn transform_attrs(&self, attrs: &[ConvertedAttrKeyValue]) -> MapOrJson {
         match self.use_json {
             true => {
                 let hm: HashMap<String, String> = attrs
@@ -194,44 +58,10 @@ impl Transformer {
     }
 }
 
-fn status_code(span: &Span) -> String {
-    match &span.status {
-        None => "Unset".to_string(),
-        Some(s) => match s.code {
-            1 => "Ok".to_string(),
-            2 => "Error".to_string(),
-            _ => "Unset".to_string(),
-        },
-    }
-}
-
-fn status_message(span: &Span) -> String {
-    match &span.status {
-        None => "".to_string(),
-        Some(s) => s.message.clone(),
-    }
-}
-
-fn find_attribute(attr: &str, attributes: &[ConvertedAttrKeyValue]) -> String {
+pub(crate) fn find_attribute(attr: &str, attributes: &[ConvertedAttrKeyValue]) -> String {
     attributes
         .iter()
         .find(|kv| kv.0 == attr)
         .map(|kv| kv.1.to_string())
         .unwrap_or("".to_string())
-}
-
-fn span_kind_to_string(kind: i32) -> String {
-    if kind == SpanKind::Internal as i32 {
-        "Internal".to_string()
-    } else if kind == SpanKind::Server as i32 {
-        "Server".to_string()
-    } else if kind == SpanKind::Client as i32 {
-        "Client".to_string()
-    } else if kind == SpanKind::Producer as i32 {
-        "Producer".to_string()
-    } else if kind == SpanKind::Consumer as i32 {
-        "client".to_string()
-    } else {
-        "Unspecified".to_string()
-    }
 }

--- a/src/init/activation.rs
+++ b/src/init/activation.rs
@@ -53,7 +53,7 @@ impl TelemetryActivation {
             Exporter::Clickhouse => TelemetryActivation {
                 logs: TelemetryState::Active,
                 traces: TelemetryState::Active,
-                metrics: TelemetryState::NoListeners,
+                metrics: TelemetryState::Active,
             },
             Exporter::AwsXray => TelemetryActivation {
                 logs: TelemetryState::NoListeners,

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -2,7 +2,7 @@ use crate::aws_api::config::AwsConfig;
 use crate::bounded_channel::{BoundedReceiver, bounded};
 use crate::crypto::init_crypto_provider;
 use crate::exporters::blackhole::BlackholeExporter;
-use crate::exporters::clickhouse::ClickhouseExporterBuilder;
+use crate::exporters::clickhouse::ClickhouseExporterConfigBuilder;
 use crate::exporters::datadog::{DatadogTraceExporterBuilder, Region};
 use crate::exporters::otlp;
 use crate::exporters::xray::XRayTraceExporterBuilder;
@@ -429,7 +429,7 @@ impl Agent {
                 let async_insert =
                     parse_bool_value(config.clickhouse_exporter.clickhouse_exporter_async_insert)?;
 
-                let mut builder = ClickhouseExporterBuilder::new(
+                let mut cfg_builder = ClickhouseExporterConfigBuilder::new(
                     config
                         .clickhouse_exporter
                         .clickhouse_exporter_endpoint
@@ -447,12 +447,14 @@ impl Agent {
                 );
 
                 if let Some(user) = config.clickhouse_exporter.clickhouse_exporter_user {
-                    builder = builder.with_user(user);
+                    cfg_builder = cfg_builder.with_user(user);
                 }
 
                 if let Some(password) = config.clickhouse_exporter.clickhouse_exporter_password {
-                    builder = builder.with_password(password);
+                    cfg_builder = cfg_builder.with_password(password);
                 }
+
+                let builder = cfg_builder.build()?;
 
                 // Trace spans
                 let exp = builder.build_traces_exporter(

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -493,6 +493,25 @@ impl Agent {
 
                     Ok(())
                 });
+
+                // Metrics
+                let exp = builder.build_metrics_exporter(
+                    metrics_pipeline_out_rx,
+                    self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                )?;
+
+                let token = exporters_cancel.clone();
+                exporters_task_set.spawn(async move {
+                    let res = exp.start(token).await;
+                    if let Err(e) = res {
+                        error!(
+                            error = e,
+                            "Clickhouse metrics exporter returned from run loop with error."
+                        );
+                    }
+
+                    Ok(())
+                });
             }
         }
 


### PR DESCRIPTION
This brings in support for OTLP metrics for the Clickhouse exporter. The implementation is a bit different from traces and logs as metrics are split across 5 table tables, one per data type.

This completes the telemetry support for the Clickhouse exporter.

I've tested sum, gauge and histogram types so far. The exponential histogram and summary types are not exposed in the Golang SDK nor telemetrygen, so I'll need to find some alternative ways of testing.

Overview of changes here:

* DDL support for creating the breakout metric tables (DDL now split across files)
* Transforms for ResourceMetrics
* Refactors transforms out to separate files by telemetry type
* Implemented value serialization for the RowBinary map types in order to support flattened serde types
* DRY's out exporter creation logic
* Adds a RequestMapper that maps the table type to the API request builder for it (mostly varies the insert query SQL)
* Split out a ConfigBuilder to allow us to build a single RequestMapper used across exporters
* Pulls up all the connection config info into a struct to reduce parameter length on request builder
* Attributes column is dropped from the ORDERBY when using JSON types because it is not comparable (TBD what the best option is here)

Fixes: #71 