### PR TITLE
Refactor AWS API

### DIFF
--- a/src/aws_api/arn.rs
+++ b/src/aws_api/arn.rs
@@ -91,6 +91,23 @@ impl Display for AwsArn {
 }
 
 impl AwsArn {
+    pub fn service(&self) -> &String {
+        &self.service
+    }
+
+    pub fn region(&self) -> &String {
+        &self.region
+    }
+
+    pub fn resource_field(&self) -> &String {
+        &self.resource_field
+    }
+
+    pub fn set_resource_field(mut self, new_value: String) -> Self {
+        self.resource_field = new_value;
+        self
+    }
+
     pub fn get_endpoint(&self) -> String {
         let domain = if self.region.starts_with("cn-") {
             "amazonaws.com.cn"

--- a/src/aws_api/config.rs
+++ b/src/aws_api/config.rs
@@ -8,6 +8,20 @@ pub struct AwsConfig {
 }
 
 impl AwsConfig {
+    pub fn new(
+        region: String,
+        aws_access_key_id: String,
+        aws_secret_access_key: String,
+        aws_session_token: Option<String>,
+    ) -> Self {
+        AwsConfig {
+            region,
+            aws_access_key_id,
+            aws_secret_access_key,
+            aws_session_token,
+        }
+    }
+
     pub fn from_env() -> Self {
         Self {
             region: std::env::var("AWS_DEFAULT_REGION").unwrap_or("us-east-1".to_string()),

--- a/src/aws_api/error.rs
+++ b/src/aws_api/error.rs
@@ -1,19 +1,10 @@
-use http::uri::InvalidUri;
 use std::fmt;
-use tower::BoxError;
 
 #[derive(Debug)]
 pub enum Error {
     ArnParseError(String),
-    UriParseError(InvalidUri),
     RequestBuildError(http::Error),
-    HttpError(hyper_util::client::legacy::Error),
-    HttpResponseError(hyper::Error),
-    HttpResponseErrorParse(BoxError),
     SignatureError(String),
-    SerdeError(serde_json::Error),
-    AwsError { code: String, message: String },
-    InvalidSecrets(Vec<String>),
 }
 
 impl fmt::Display for Error {
@@ -21,48 +12,9 @@ impl fmt::Display for Error {
         match self {
             Error::RequestBuildError(e) => write!(f, "HTTP request build error: {}", e),
             Error::SignatureError(msg) => write!(f, "AWS signature error: {}", msg),
-            Error::SerdeError(e) => write!(f, "Serialization error: {}", e),
-            Error::AwsError { code, message } => write!(f, "AWS error [{}]: {}", code, message),
             Error::ArnParseError(arn) => write!(f, "Invalid ARN: {}", arn),
-            Error::HttpError(e) => write!(f, "HTTP error: {}", e),
-            Error::HttpResponseError(e) => write!(f, "Failed to parse HTTP response: {}", e),
-            Error::HttpResponseErrorParse(e) => write!(f, "Failed to parse HTTP response: {}", e),
-            Error::UriParseError(e) => write!(f, "Unable to parse endpoint url: {}", e),
-            Error::InvalidSecrets(params) => {
-                write!(f, "Unable to lookup secret values: {:?}", params)
-            }
         }
     }
 }
 
 impl std::error::Error for Error {}
-
-impl From<InvalidUri> for Error {
-    fn from(err: InvalidUri) -> Self {
-        Error::UriParseError(err)
-    }
-}
-
-impl From<BoxError> for Error {
-    fn from(err: BoxError) -> Self {
-        Error::HttpResponseErrorParse(err)
-    }
-}
-
-impl From<hyper_util::client::legacy::Error> for Error {
-    fn from(err: hyper_util::client::legacy::Error) -> Self {
-        Error::HttpError(err)
-    }
-}
-
-impl From<hyper::Error> for Error {
-    fn from(err: hyper::Error) -> Self {
-        Error::HttpResponseError(err)
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Error::SerdeError(err)
-    }
-}

--- a/src/aws_api/mod.rs
+++ b/src/aws_api/mod.rs
@@ -1,7 +1,7 @@
 pub mod arn;
-pub(crate) mod auth;
+pub mod auth;
 pub mod config;
-mod error;
+pub mod error;
 pub mod host;
 
 pub const SECRETS_MANAGER_SERVICE: &str = "secretsmanager";

--- a/src/exporters/otlp/signer.rs
+++ b/src/exporters/otlp/signer.rs
@@ -53,16 +53,10 @@ impl RequestSignerBuilder for AwsSigv4RequestSignerBuilder {
             Some(svc) => svc,
         };
 
-        // XXX: leak these so that we can elide the lifetime of signer
-        let svc = Box::leak(Box::new(svc));
-        let config = Box::leak(Box::new(self.config.clone()));
-
         let signer = AwsRequestSigner::new(
             &svc.service,
             &svc.region,
-            &config.aws_access_key_id,
-            &config.aws_secret_access_key,
-            config.aws_session_token.as_deref(),
+            self.config.clone(),
             SystemClock {},
         );
 
@@ -72,12 +66,12 @@ impl RequestSignerBuilder for AwsSigv4RequestSignerBuilder {
 
 #[derive(Clone)]
 pub struct AwsSigv4RequestSigner {
-    signer: AwsRequestSigner<'static, SystemClock>,
+    signer: AwsRequestSigner<SystemClock>,
     uri: Uri,
 }
 
 impl AwsSigv4RequestSigner {
-    pub fn new(signer: AwsRequestSigner<'static, SystemClock>, uri: Uri) -> Self {
+    pub fn new(signer: AwsRequestSigner<SystemClock>, uri: Uri) -> Self {
         Self { signer, uri }
     }
 }

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -296,7 +296,6 @@ mod tests {
         });
 
         let (btx, brx) = bounded::<Vec<ResourceSpans>>(100);
-        // Create a true 'static reference using Box::leak
         let config = AwsConfig::from_env();
         let exporter = new_exporter(addr, brx, config);
 

--- a/src/exporters/xray/xray_request.rs
+++ b/src/exporters/xray/xray_request.rs
@@ -18,7 +18,7 @@ fn build_url(endpoint: &url::Url, path: &str) -> url::Url {
 
 #[derive(Clone)]
 pub struct XRayRequestBuilder {
-    signer: AwsRequestSigner<'static, SystemClock>,
+    signer: AwsRequestSigner<SystemClock>,
     pub base_headers: HeaderMap,
     pub uri: Uri,
 }
@@ -43,17 +43,8 @@ impl XRayRequestBuilder {
             HeaderValue::from_static("application/x-amz-json-1.1"),
         );
 
-        // leak for now to ease lifetimes
-        let config = Box::leak(Box::new(config));
-
-        let signer = AwsRequestSigner::new(
-            "xray",
-            config.region.as_str(),
-            config.aws_access_key_id.as_str(),
-            config.aws_secret_access_key.as_str(),
-            config.aws_session_token.as_deref(),
-            SystemClock,
-        );
+        let signer =
+            AwsRequestSigner::new("xray", config.region.clone().as_str(), config, SystemClock);
 
         let s = Self {
             uri,


### PR DESCRIPTION
Cleans up the AWS API so that it can be shared with the lambda extension (PR coming), including adding accessor methods to private fields. Removed the lifetimes's on the parameters to AwsConfig to make it easier to work with (we were just leaking it to make it static).

STR-3378