### PR TITLE
Python processor SDK: Metrics Support

### DIFF
--- a/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
+++ b/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
@@ -1,15 +1,15 @@
 # read_and_write_metrics_test.py
 
 from rotel_sdk.open_telemetry.metrics.v1 import (
-    Metric,
     MetricData,
-    Sum,
-    Histogram,
+    ExponentialHistogramBuckets,
     NumberDataPoint,
     HistogramDataPoint,
+    ExponentialHistogramDataPoint,
+    SummaryDataPoint,
+    ValueAtQuantile,
     Exemplar,
     AggregationTemporality,
-    DataPointFlags,
     NumberDataPointValue,
     ExemplarValue
 )
@@ -19,189 +19,498 @@ from rotel_sdk.open_telemetry.common.v1 import KeyValue
 
 def process_metrics(resource_metrics):
     """
-    Processes and mutates a ResourceMetrics object received from Rust.
-    This function asserts initial states and then modifies the metrics data.
+    1. Verifies ALL initial metric values created by Rust
+    2. Mutates ALL metric types and their properties
+    3. Verifies all mutations were successful
     """
 
-    # Assert initial state of ResourceMetrics (similar to how it would come from Rust)
+    print("=== STEP 1: VERIFY ALL INITIAL VALUES FROM RUST ===")
+
+    # --- Verify ResourceMetrics initial state ---
     assert resource_metrics.schema_url == "initial_schema_url_resource"
     assert resource_metrics.resource is not None
-    assert resource_metrics.resource.dropped_attributes_count == 0
-    assert len(resource_metrics.scope_metrics) == 1
+    assert resource_metrics.resource.dropped_attributes_count == 10
+    assert len(resource_metrics.resource.attributes) == 1
+    assert resource_metrics.resource.attributes[0].key == "initial_resource_key"
+    assert resource_metrics.resource.attributes[0].value.value == "initial_resource_value"
 
+    # --- Verify ScopeMetrics initial state ---
+    assert len(resource_metrics.scope_metrics) == 1
     scope_metrics = resource_metrics.scope_metrics[0]
     assert scope_metrics.schema_url == "initial_schema_url_scope"
     assert scope_metrics.scope is not None
     assert scope_metrics.scope.name == "initial_scope_name"
-    assert len(scope_metrics.metrics) == 1
+    assert scope_metrics.scope.version == "1.0.0"
+    assert scope_metrics.scope.dropped_attributes_count == 5
+    assert len(scope_metrics.scope.attributes) == 1
+    assert scope_metrics.scope.attributes[0].key == "initial_scope_key"
+    assert scope_metrics.scope.attributes[0].value.value is True
 
-    metric = scope_metrics.metrics[0]
-    assert metric.name == "initial_metric_name"
-    assert metric.description == "initial_description"
-    assert metric.unit == "initial_unit"
-    assert len(metric.metadata) == 1
-    assert metric.metadata[0].key == "initial_metadata_key"
-    assert metric.metadata[0].value.value == "initial_metadata_value"
-    assert metric.data is not None
+    # Should have 5 metrics: Gauge, Sum, Histogram, ExponentialHistogram, Summary
+    assert len(scope_metrics.metrics) == 5
 
-    # Assume it's a Gauge for initial state
-    assert isinstance(metric.data, MetricData.Gauge)
-    gauge = metric.data[0]
-    assert len(gauge.data_points) == 1
+    # --- Verify Gauge metric initial state ---
+    gauge_metric = scope_metrics.metrics[0]
+    assert gauge_metric.name == "initial_gauge_metric"
+    assert gauge_metric.description == "initial_gauge_description"
+    assert gauge_metric.unit == "initial_gauge_unit"
+    assert len(gauge_metric.metadata) == 1
+    assert gauge_metric.metadata[0].key == "gauge_metadata_key"
+    assert gauge_metric.metadata[0].value.value == "gauge_metadata_value"
+    assert isinstance(gauge_metric.data, MetricData.Gauge)
 
-    num_dp = gauge.data_points[0]
-    assert num_dp.start_time_unix_nano == 1000
-    assert num_dp.time_unix_nano == 2000
-    assert num_dp.value[0] == 123.45
-    assert len(num_dp.attributes) == 1
-    assert num_dp.attributes[0].key == "dp_key"
-    assert num_dp.attributes[0].value.value == "dp_value"
-    assert num_dp.flags == 0
-    assert len(num_dp.exemplars) == 0
+    gauge_data = gauge_metric.data[0]
+    assert len(gauge_data.data_points) == 1
+    gauge_dp = gauge_data.data_points[0]
+    assert gauge_dp.start_time_unix_nano == 1000
+    assert gauge_dp.time_unix_nano == 2000
+    assert gauge_dp.flags == 0
+    assert gauge_dp.value[0] == 123.45
+    assert len(gauge_dp.attributes) == 1
+    assert gauge_dp.attributes[0].key == "gauge_dp_key"
+    assert gauge_dp.attributes[0].value.value == "gauge_dp_value"
+    assert len(gauge_dp.exemplars) == 1
+    assert gauge_dp.exemplars[0].time_unix_nano == 1500
+    assert gauge_dp.exemplars[0].value[0] == 15.5
+    assert len(gauge_dp.exemplars[0].filtered_attributes) == 1
+    assert gauge_dp.exemplars[0].filtered_attributes[0].key == "gauge_exemplar_key"
 
-    # let's change the start_time_unix_nano
-    num_dp.start_time_unix_nano = 2000
-    num_dp.time_unix_nano = 3000
-    num_dp.attributes.append(KeyValue.new_string_value("dp_key2", "dp_value2"))
-    exemplar = Exemplar()
-    exemplar.time_unix_nano = 3500
-    exemplar.span_id = b"\x01\x02\x03\x04\x05\x06\x07\x08"
-    exemplar.trace_id = b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01"
-    exemplar.value = ExemplarValue.AsDouble(10.5)
-    exemplar.filtered_attributes.append(KeyValue.new_string_value("filtered_key", "filtered_value"))
-    num_dp.exemplars.append(exemplar)
-    num_dp = gauge.data_points[0]
-    num_dp.flags = 1
-    num_dp.value = NumberDataPointValue.AsInt(111)
-    assert num_dp.start_time_unix_nano == 2000
-    assert num_dp.time_unix_nano == 3000
-    assert len(num_dp.attributes) == 2
-    del (num_dp.attributes[0])
-    assert len(num_dp.attributes) == 1
-    assert num_dp.attributes[0].key == "dp_key2"
-    assert num_dp.attributes[0].value.value == "dp_value2"
-    assert len(num_dp.exemplars) == 1
-    assert num_dp.flags == 1
-    assert num_dp.value[0] == 111
+    # --- Verify Sum metric initial state ---
+    sum_metric = scope_metrics.metrics[1]
+    assert sum_metric.name == "initial_sum_metric"
+    assert sum_metric.description == "initial_sum_description"
+    assert sum_metric.unit == "initial_sum_unit"
+    assert len(sum_metric.metadata) == 1
+    assert sum_metric.metadata[0].key == "sum_metadata_key"
+    assert sum_metric.metadata[0].value.value == 42
+    assert isinstance(sum_metric.data, MetricData.Sum)
 
-    # --- Mutate the metrics data ---
+    sum_data = sum_metric.data[0]
+    assert int(sum_data.aggregation_temporality) == int(AggregationTemporality.Delta)
+    assert sum_data.is_monotonic is True
+    assert len(sum_data.data_points) == 1
+    sum_dp = sum_data.data_points[0]
+    assert sum_dp.start_time_unix_nano == 3000
+    assert sum_dp.time_unix_nano == 4000
+    assert sum_dp.flags == 0
+    assert sum_dp.value[0] == 100
+    assert len(sum_dp.attributes) == 1
+    assert sum_dp.attributes[0].key == "sum_dp_key"
+    assert len(sum_dp.exemplars) == 0
 
-    # Mutate ResourceMetrics
-    resource_metrics.schema_url = "py_processed_schema_url_resource"
-    resource_metrics.resource.dropped_attributes_count = 5
+    # --- Verify Histogram metric initial state ---
+    hist_metric = scope_metrics.metrics[2]
+    assert hist_metric.name == "initial_histogram_metric"
+    assert hist_metric.description == "initial_histogram_description"
+    assert hist_metric.unit == "initial_histogram_unit"
+    assert len(hist_metric.metadata) == 1
+    assert hist_metric.metadata[0].key == "histogram_metadata_key"
+    assert hist_metric.metadata[0].value.value is False
+    assert isinstance(hist_metric.data, MetricData.Histogram)
 
-    # Mutate ScopeMetrics
-    scope_metrics.schema_url = "py_processed_schema_url_scope"
-    scope_metrics.scope.name = "py_processed_scope_name"
-    scope_metrics.scope.version = "py_processed_scope_version"
-    scope_metrics.scope.attributes.append(KeyValue.new_bool_value("scope_attr_py", True))
-    scope_metrics.scope.dropped_attributes_count = 1
+    hist_data = hist_metric.data[0]
+    assert int(hist_data.aggregation_temporality) == int(AggregationTemporality.Cumulative)
+    assert len(hist_data.data_points) == 1
+    hist_dp = hist_data.data_points[0]
+    assert hist_dp.start_time_unix_nano == 5000
+    assert hist_dp.time_unix_nano == 6000
+    assert hist_dp.count == 50
+    assert hist_dp.sum == 500.0
+    assert hist_dp.bucket_counts == [5, 10, 15, 20]
+    assert hist_dp.explicit_bounds == [1.0, 5.0, 10.0]
+    assert hist_dp.flags == 1
+    assert hist_dp.min == 0.1
+    assert hist_dp.max == 20.0
+    assert len(hist_dp.attributes) == 1
+    assert hist_dp.attributes[0].key == "histogram_dp_key"
+    assert len(hist_dp.exemplars) == 1
+    assert hist_dp.exemplars[0].time_unix_nano == 5500
+    assert hist_dp.exemplars[0].value[0] == 25
 
-    # Mutate Metric
-    metric.name = "py_processed_metric_name"
-    metric.description = "py_processed_description"
-    metric.unit = "py_processed_unit"
-    metric.metadata.append(KeyValue.new_int_value("metadata_py", 999))
+    # --- Verify ExponentialHistogram metric initial state ---
+    exp_hist_metric = scope_metrics.metrics[3]
+    assert exp_hist_metric.name == "initial_exp_histogram_metric"
+    assert exp_hist_metric.description == "initial_exp_histogram_description"
+    assert exp_hist_metric.unit == "initial_exp_histogram_unit"
+    assert len(exp_hist_metric.metadata) == 1
+    assert exp_hist_metric.metadata[0].key == "exp_histogram_metadata_key"
+    assert exp_hist_metric.metadata[0].value.value == 3.14
+    assert isinstance(exp_hist_metric.data, MetricData.ExponentialHistogram)
 
-    # Change metric type to Sum and add new data points
-    new_sum = Sum()
-    new_sum.aggregation_temporality = AggregationTemporality.Cumulative
-    new_sum.is_monotonic = True
+    exp_hist_data = exp_hist_metric.data[0]
+    assert int(exp_hist_data.aggregation_temporality) == int(AggregationTemporality.Delta)
+    assert len(exp_hist_data.data_points) == 1
+    exp_hist_dp = exp_hist_data.data_points[0]
+    assert exp_hist_dp.start_time_unix_nano == 7000
+    assert exp_hist_dp.time_unix_nano == 8000
+    assert exp_hist_dp.count == 75
+    assert exp_hist_dp.sum == 750.0
+    assert exp_hist_dp.scale == 1
+    assert exp_hist_dp.zero_count == 3
+    assert exp_hist_dp.zero_threshold == 0.01
+    assert exp_hist_dp.flags == 0
+    assert exp_hist_dp.min == 0.5
+    assert exp_hist_dp.max == 50.0
+    assert len(exp_hist_dp.attributes) == 1
+    assert exp_hist_dp.attributes[0].key == "exp_histogram_dp_key"
+    assert len(exp_hist_dp.exemplars) == 1
+    assert exp_hist_dp.exemplars[0].time_unix_nano == 7500
+    assert exp_hist_dp.exemplars[0].value[0] == 37.5
 
-    sum_dp1 = NumberDataPoint()
-    sum_dp1.start_time_unix_nano = 3000
-    sum_dp1.time_unix_nano = 4000
-    sum_dp1.value = NumberDataPointValue.AsInt(10)
-    sum_dp1.attributes.append(KeyValue.new_string_value("sum_dp_key", "sum_dp_value"))
+    # Verify positive buckets
+    assert exp_hist_dp.positive is not None
+    assert exp_hist_dp.positive.offset == 2
+    assert exp_hist_dp.positive.bucket_counts == [2, 4, 6, 8]
 
-    sum_dp2 = NumberDataPoint()
-    sum_dp2.start_time_unix_nano = 5000
-    sum_dp2.time_unix_nano = 6000
-    sum_dp2.value = NumberDataPointValue.AsInt(20)
-    sum_dp2.flags = DataPointFlags.NoRecordedValueMask.value
+    # Verify negative buckets
+    assert exp_hist_dp.negative is not None
+    assert exp_hist_dp.negative.offset == -1
+    assert exp_hist_dp.negative.bucket_counts == [1, 2, 3]
 
-    new_sum.data_points.append(sum_dp1)
-    new_sum.data_points.append(sum_dp2)
+    # --- Verify Summary metric initial state ---
+    summary_metric = scope_metrics.metrics[4]
+    assert summary_metric.name == "initial_summary_metric"
+    assert summary_metric.description == "initial_summary_description"
+    assert summary_metric.unit == "initial_summary_unit"
+    assert len(summary_metric.metadata) == 1
+    assert summary_metric.metadata[0].key == "summary_metadata_key"
+    assert bytes(summary_metric.metadata[0].value.value) == b"summary_bytes"
+    assert isinstance(summary_metric.data, MetricData.Summary)
 
-    # Add an exemplar to sum_dp1
-    exemplar_sum = Exemplar()
-    exemplar_sum.time_unix_nano = 3500
-    exemplar_sum.span_id = b"\x01\x02\x03\x04\x05\x06\x07\x08"
-    exemplar_sum.trace_id = b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01"
-    exemplar_sum.value = ExemplarValue.AsDouble(10.5)
-    exemplar_sum.filtered_attributes.append(KeyValue.new_string_value("filtered_key", "filtered_value"))
-    sum_dp1.exemplars.append(exemplar_sum)
+    summary_data = summary_metric.data[0]
+    assert len(summary_data.data_points) == 1
+    summary_dp = summary_data.data_points[0]
+    assert summary_dp.start_time_unix_nano == 9000
+    assert summary_dp.time_unix_nano == 10000
+    assert summary_dp.count == 25
+    assert summary_dp.sum == 250.0
+    assert summary_dp.flags == 1
+    assert len(summary_dp.attributes) == 1
+    assert summary_dp.attributes[0].key == "summary_dp_key"
+    assert len(summary_dp.quantile_values) == 3
+    assert summary_dp.quantile_values[0].quantile == 0.5
+    assert summary_dp.quantile_values[0].value == 10.0
+    assert summary_dp.quantile_values[1].quantile == 0.95
+    assert summary_dp.quantile_values[1].value == 19.0
+    assert summary_dp.quantile_values[2].quantile == 0.99
+    assert summary_dp.quantile_values[2].value == 19.8
 
-    metric.data = MetricData.Sum(new_sum)
+    print("✓ All initial values verified successfully!")
 
-    # Add a new metric (Histogram) to the scope_metrics list
-    new_metric_histogram = Metric()
-    new_metric_histogram.name = "py_processed_histogram"
-    new_metric_histogram.description = "A histogram from Python"
-    new_metric_histogram.unit = "ms"
+    print("\n=== STEP 2: MUTATE ALL METRIC TYPES ===")
 
-    hist_data = Histogram()
+    # --- Mutate ResourceMetrics ---
+    resource_metrics.schema_url = "python_modified_schema_url_resource"
+    resource_metrics.resource.dropped_attributes_count = 25
+    resource_metrics.resource.attributes.append(
+        KeyValue.new_string_value("python_added_resource_key", "python_added_resource_value"))
+
+    # --- Mutate ScopeMetrics ---
+    scope_metrics.schema_url = "python_modified_schema_url_scope"
+    scope_metrics.scope.name = "python_modified_scope_name"
+    scope_metrics.scope.version = "python_modified_scope_version"
+    scope_metrics.scope.dropped_attributes_count = 15
+    scope_metrics.scope.attributes.append(KeyValue.new_bool_value("python_added_scope_key", False))
+
+    # --- Mutate Gauge metric ---
+    gauge_metric.name = "python_modified_gauge_metric"
+    gauge_metric.description = "python_modified_gauge_description"
+    gauge_metric.unit = "python_modified_gauge_unit"
+    gauge_metric.metadata.append(KeyValue.new_double_value("python_added_gauge_metadata", 99.99))
+
+    # Mutate existing gauge data point
+    gauge_dp.start_time_unix_nano = 1100
+    gauge_dp.time_unix_nano = 2200
+    gauge_dp.flags = 1
+    gauge_dp.value = NumberDataPointValue.AsInt(200)
+    gauge_dp.attributes.append(KeyValue.new_string_value("python_added_gauge_dp_attr", "python_value"))
+
+    # Add exemplar to gauge
+    new_gauge_exemplar = Exemplar()
+    new_gauge_exemplar.time_unix_nano = 1750
+    new_gauge_exemplar.span_id = b"\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10"
+    new_gauge_exemplar.trace_id = b"\x10\x0f\x0e\x0d\x0c\x0b\x0a\x09\x10\x0f\x0e\x0d\x0c\x0b\x0a\x09"
+    new_gauge_exemplar.value = ExemplarValue.AsInt(175)
+    new_gauge_exemplar.filtered_attributes.append(
+        KeyValue.new_string_value("new_gauge_exemplar_key", "new_gauge_exemplar_value"))
+    gauge_dp.exemplars.append(new_gauge_exemplar)
+
+    # Add new gauge data point
+    new_gauge_dp = NumberDataPoint()
+    new_gauge_dp.start_time_unix_nano = 2000
+    new_gauge_dp.time_unix_nano = 3000
+    new_gauge_dp.value = NumberDataPointValue.AsDouble(300.0)
+    new_gauge_dp.flags = 0
+    new_gauge_dp.attributes.append(KeyValue.new_string_value("new_gauge_dp_key", "new_gauge_dp_value"))
+    gauge_data.data_points.append(new_gauge_dp)
+
+    # --- Mutate Sum metric ---
+    sum_metric.name = "python_modified_sum_metric"
+    sum_metric.description = "python_modified_sum_description"
+    sum_metric.unit = "python_modified_sum_unit"
+    sum_metric.metadata.append(KeyValue.new_int_value("python_added_sum_metadata", 777))
+
+    # Change sum properties
+    sum_data.aggregation_temporality = AggregationTemporality.Cumulative
+    sum_data.is_monotonic = False
+
+    # Mutate existing sum data point
+    sum_dp.start_time_unix_nano = 3300
+    sum_dp.time_unix_nano = 4400
+    sum_dp.value = NumberDataPointValue.AsInt(150)
+    sum_dp.flags = 1
+    sum_dp.attributes.append(KeyValue.new_string_value("python_added_sum_dp_attr", "python_sum_value"))
+
+    # Add exemplar to sum
+    sum_exemplar = Exemplar()
+    sum_exemplar.time_unix_nano = 3700
+    sum_exemplar.value = ExemplarValue.AsDouble(125.5)
+    sum_exemplar.span_id = b"\x31\x32\x33\x34\x35\x36\x37\x38"
+    sum_exemplar.trace_id = b"\x38\x37\x36\x35\x34\x33\x32\x31\x38\x37\x36\x35\x34\x33\x32\x31"
+    sum_exemplar.filtered_attributes.append(KeyValue.new_string_value("sum_exemplar_key", "sum_exemplar_value"))
+    sum_dp.exemplars.append(sum_exemplar)
+
+    # Add new sum data point
+    new_sum_dp = NumberDataPoint()
+    new_sum_dp.start_time_unix_nano = 4000
+    new_sum_dp.time_unix_nano = 5000
+    new_sum_dp.value = NumberDataPointValue.AsDouble(250.5)
+    new_sum_dp.flags = 0
+    new_sum_dp.attributes.append(KeyValue.new_string_value("new_sum_dp_key", "new_sum_dp_value"))
+    sum_data.data_points.append(new_sum_dp)
+
+    # --- Mutate Histogram metric ---
+    hist_metric.name = "python_modified_histogram_metric"
+    hist_metric.description = "python_modified_histogram_description"
+    hist_metric.unit = "python_modified_histogram_unit"
+    hist_metric.metadata.append(KeyValue.new_bool_value("python_added_histogram_metadata", True))
+
+    # Change histogram properties
     hist_data.aggregation_temporality = AggregationTemporality.Delta
 
-    hist_dp = HistogramDataPoint()
-    hist_dp.start_time_unix_nano = 7000
-    hist_dp.time_unix_nano = 8000
-    hist_dp.count = 100
-    hist_dp.sum = 1000.0
+    # Mutate existing histogram data point
+    hist_dp.start_time_unix_nano = 5500
+    hist_dp.time_unix_nano = 6600
+    hist_dp.count = 75
+    hist_dp.sum = 750.0
     hist_dp.bucket_counts = [10, 20, 30, 40]
-    hist_dp.explicit_bounds = [1.0, 5.0, 10.0]
-    hist_dp.min = 0.5
-    hist_dp.max = 12.0
-    hist_dp.attributes.append(KeyValue.new_string_value("hist_attr", "hist_value"))
+    hist_dp.explicit_bounds = [2.0, 10.0, 20.0]
+    hist_dp.flags = 0
+    hist_dp.min = 0.2
+    hist_dp.max = 25.0
+    hist_dp.attributes.append(KeyValue.new_string_value("python_added_histogram_dp_attr", "python_hist_value"))
 
+    # Add exemplar to histogram
     hist_exemplar = Exemplar()
-    hist_exemplar.time_unix_nano = 7500
-    hist_exemplar.value = ExemplarValue.AsInt(75)
+    hist_exemplar.time_unix_nano = 6000
+    hist_exemplar.value = ExemplarValue.AsInt(30)
+    hist_exemplar.span_id = b"\x41\x42\x43\x44\x45\x46\x47\x48"
+    hist_exemplar.trace_id = b"\x48\x47\x46\x45\x44\x43\x42\x41\x48\x47\x46\x45\x44\x43\x42\x41"
+    hist_exemplar.filtered_attributes.append(KeyValue.new_string_value("hist_exemplar_key", "hist_exemplar_value"))
     hist_dp.exemplars.append(hist_exemplar)
 
-    hist_data.data_points.append(hist_dp)
-    new_metric_histogram.data = MetricData.Histogram(hist_data)
-    scope_metrics.metrics.append(new_metric_histogram)
+    # Add new histogram data point
+    new_hist_dp = HistogramDataPoint()
+    new_hist_dp.start_time_unix_nano = 6000
+    new_hist_dp.time_unix_nano = 7000
+    new_hist_dp.count = 100
+    new_hist_dp.sum = 1000.0
+    new_hist_dp.bucket_counts = [15, 25, 35, 45]
+    new_hist_dp.explicit_bounds = [3.0, 15.0, 30.0]
+    new_hist_dp.flags = 1
+    new_hist_dp.min = 0.3
+    new_hist_dp.max = 35.0
+    new_hist_dp.attributes.append(KeyValue.new_string_value("new_hist_dp_key", "new_hist_dp_value"))
+    hist_data.data_points.append(new_hist_dp)
 
-    # Verify mutations
-    assert resource_metrics.schema_url == "py_processed_schema_url_resource"
-    assert resource_metrics.resource.dropped_attributes_count == 5
-    assert scope_metrics.schema_url == "py_processed_schema_url_scope"
-    assert scope_metrics.scope.name == "py_processed_scope_name"
-    assert scope_metrics.scope.version == "py_processed_scope_version"
+    # --- Mutate ExponentialHistogram metric ---
+    exp_hist_metric.name = "python_modified_exp_histogram_metric"
+    exp_hist_metric.description = "python_modified_exp_histogram_description"
+    exp_hist_metric.unit = "python_modified_exp_histogram_unit"
+    exp_hist_metric.metadata.append(KeyValue.new_bytes_value("python_added_exp_histogram_metadata", b"exp_hist_bytes"))
+
+    # Change exp histogram properties
+    exp_hist_data.aggregation_temporality = AggregationTemporality.Cumulative
+
+    # Mutate existing exp histogram data point
+    exp_hist_dp.start_time_unix_nano = 7700
+    exp_hist_dp.time_unix_nano = 8800
+    exp_hist_dp.count = 100
+    exp_hist_dp.sum = 1000.0
+    exp_hist_dp.scale = 2
+    exp_hist_dp.zero_count = 5
+    exp_hist_dp.zero_threshold = 0.02
+    exp_hist_dp.flags = 1
+    exp_hist_dp.min = 0.6
+    exp_hist_dp.max = 60.0
+    exp_hist_dp.attributes.append(
+        KeyValue.new_string_value("python_added_exp_histogram_dp_attr", "python_exp_hist_value"))
+
+    # Mutate positive buckets
+    exp_hist_dp.positive.offset = 3
+    exp_hist_dp.positive.bucket_counts = [4, 8, 12, 16]
+
+    # Mutate negative buckets
+    exp_hist_dp.negative.offset = -2
+    exp_hist_dp.negative.bucket_counts = [2, 4, 6]
+
+    # Add exemplar to exp histogram
+    exp_hist_exemplar = Exemplar()
+    exp_hist_exemplar.time_unix_nano = 8000
+    exp_hist_exemplar.value = ExemplarValue.AsDouble(50.0)
+    exp_hist_exemplar.span_id = b"\x51\x52\x53\x54\x55\x56\x57\x58"
+    exp_hist_exemplar.trace_id = b"\x58\x57\x56\x55\x54\x53\x52\x51\x58\x57\x56\x55\x54\x53\x52\x51"
+    exp_hist_exemplar.filtered_attributes.append(
+        KeyValue.new_string_value("exp_hist_exemplar_key", "exp_hist_exemplar_value"))
+    exp_hist_dp.exemplars.append(exp_hist_exemplar)
+
+    # Add new exp histogram data point
+    new_exp_hist_dp = ExponentialHistogramDataPoint()
+    new_exp_hist_dp.start_time_unix_nano = 8000
+    new_exp_hist_dp.time_unix_nano = 9000
+    new_exp_hist_dp.count = 125
+    new_exp_hist_dp.sum = 1250.0
+    new_exp_hist_dp.scale = 3
+    new_exp_hist_dp.zero_count = 7
+    new_exp_hist_dp.zero_threshold = 0.03
+    new_exp_hist_dp.flags = 0
+    new_exp_hist_dp.min = 0.7
+    new_exp_hist_dp.max = 70.0
+    new_exp_hist_dp.attributes.append(KeyValue.new_string_value("new_exp_hist_dp_key", "new_exp_hist_dp_value"))
+
+    # Create new buckets for new data point
+    new_positive_buckets = ExponentialHistogramBuckets()
+    new_positive_buckets.offset = 4
+    new_positive_buckets.bucket_counts = [5, 10, 15, 20, 25]
+    new_exp_hist_dp.positive = new_positive_buckets
+
+    new_negative_buckets = ExponentialHistogramBuckets()
+    new_negative_buckets.offset = -3
+    new_negative_buckets.bucket_counts = [3, 6, 9, 12]
+    new_exp_hist_dp.negative = new_negative_buckets
+
+    exp_hist_data.data_points.append(new_exp_hist_dp)
+
+    # --- Mutate Summary metric ---
+    summary_metric.name = "python_modified_summary_metric"
+    summary_metric.description = "python_modified_summary_description"
+    summary_metric.unit = "python_modified_summary_unit"
+    summary_metric.metadata.append(KeyValue.new_string_value("python_added_summary_metadata", "summary_metadata_value"))
+
+    # Mutate existing summary data point
+    summary_dp.start_time_unix_nano = 9900
+    summary_dp.time_unix_nano = 11000
+    summary_dp.count = 50
+    summary_dp.sum = 500.0
+    summary_dp.flags = 0
+    summary_dp.attributes.append(KeyValue.new_string_value("python_added_summary_dp_attr", "python_summary_value"))
+
+    # Mutate quantile values
+    summary_dp.quantile_values[0].value = 20.0  # Changed from 10.0
+    summary_dp.quantile_values[1].value = 38.0  # Changed from 19.0
+    summary_dp.quantile_values[2].value = 39.6  # Changed from 19.8
+
+    # Add new quantile
+    new_quantile = ValueAtQuantile()
+    new_quantile.quantile = 0.999
+    new_quantile.value = 39.96
+    summary_dp.quantile_values.append(new_quantile)
+
+    # Add new summary data point
+    new_summary_dp = SummaryDataPoint()
+    new_summary_dp.start_time_unix_nano = 10000
+    new_summary_dp.time_unix_nano = 11000
+    new_summary_dp.count = 75
+    new_summary_dp.sum = 750.0
+    new_summary_dp.flags = 1
+    new_summary_dp.attributes.append(KeyValue.new_string_value("new_summary_dp_key", "new_summary_dp_value"))
+
+    # Add quantiles for new data point
+    q50 = ValueAtQuantile()
+    q50.quantile = 0.5
+    q50.value = 30.0
+
+    q95 = ValueAtQuantile()
+    q95.quantile = 0.95
+    q95.value = 57.0
+
+    new_summary_dp.quantile_values = [q50, q95]
+    summary_data.data_points.append(new_summary_dp)
+
+    print("✓ All metrics mutated successfully!")
+
+    print("\n=== STEP 3: VERIFY ALL MUTATIONS ===")
+
+    # --- Verify ResourceMetrics mutations ---
+    assert resource_metrics.schema_url == "python_modified_schema_url_resource"
+    assert resource_metrics.resource.dropped_attributes_count == 25
+    assert len(resource_metrics.resource.attributes) == 2
+    assert resource_metrics.resource.attributes[1].key == "python_added_resource_key"
+
+    # --- Verify ScopeMetrics mutations ---
+    assert scope_metrics.schema_url == "python_modified_schema_url_scope"
+    assert scope_metrics.scope.name == "python_modified_scope_name"
+    assert scope_metrics.scope.version == "python_modified_scope_version"
+    assert scope_metrics.scope.dropped_attributes_count == 15
     assert len(scope_metrics.scope.attributes) == 2
-    assert scope_metrics.scope.attributes[1].key == "scope_attr_py"
-    assert scope_metrics.scope.attributes[1].value.value is True
-    assert scope_metrics.scope.dropped_attributes_count == 1
+    assert scope_metrics.scope.attributes[1].key == "python_added_scope_key"
 
-    assert metric.name == "py_processed_metric_name"
-    assert metric.description == "py_processed_description"
-    assert metric.unit == "py_processed_unit"
-    assert len(metric.metadata) == 2
-    assert metric.metadata[1].key == "metadata_py"
-    assert metric.metadata[1].value.value == 999
+    # --- Verify Gauge mutations ---
+    assert gauge_metric.name == "python_modified_gauge_metric"
+    assert len(gauge_metric.metadata) == 2
+    assert len(gauge_data.data_points) == 2
+    assert gauge_data.data_points[0].start_time_unix_nano == 1100
+    assert gauge_data.data_points[0].time_unix_nano == 2200
+    assert gauge_data.data_points[0].flags == 1
+    assert gauge_data.data_points[0].value[0] == 200
+    assert len(gauge_data.data_points[0].attributes) == 2
+    assert len(gauge_data.data_points[0].exemplars) == 2
 
-    assert isinstance(metric.data, MetricData.Sum)
-    processed_sum = metric.data[0]
-    assert int(processed_sum.aggregation_temporality) == int(AggregationTemporality.Cumulative)
-    assert processed_sum.is_monotonic is True
-    assert len(processed_sum.data_points) == 2
-    assert processed_sum.data_points[0].value[0] == 10
-    assert processed_sum.data_points[1].value[0] == 20
-    assert processed_sum.data_points[0].exemplars[0].value[0] == 10.5
-    assert processed_sum.data_points[0].exemplars[0].filtered_attributes[0].value.value == "filtered_value"
+    # --- Verify Sum mutations ---
+    assert sum_metric.name == "python_modified_sum_metric"
+    assert int(sum_data.aggregation_temporality) == int(AggregationTemporality.Cumulative)
+    assert sum_data.is_monotonic is False
+    assert len(sum_data.data_points) == 2
+    assert sum_data.data_points[0].start_time_unix_nano == 3300
+    assert sum_data.data_points[0].time_unix_nano == 4400
+    assert len(sum_data.data_points[0].exemplars) == 1
 
-    assert len(scope_metrics.metrics) == 2
-    processed_hist_metric = scope_metrics.metrics[1]
-    assert processed_hist_metric.name == "py_processed_histogram"
-    assert isinstance(processed_hist_metric.data, MetricData.Histogram)
-    processed_hist_data = processed_hist_metric.data[0]
-    assert int(processed_hist_data.aggregation_temporality) == int(AggregationTemporality.Delta)
-    assert len(processed_hist_data.data_points) == 1
-    assert processed_hist_data.data_points[0].count == 100
-    assert processed_hist_data.data_points[0].sum == 1000.0
-    assert processed_hist_data.data_points[0].bucket_counts == [10, 20, 30, 40]
-    assert processed_hist_data.data_points[0].explicit_bounds == [1.0, 5.0, 10.0]
-    assert processed_hist_data.data_points[0].min == 0.5
-    assert processed_hist_data.data_points[0].max == 12.0
-    assert processed_hist_data.data_points[0].exemplars[0].value[0] == 75
+    # --- Verify Histogram mutations ---
+    assert hist_metric.name == "python_modified_histogram_metric"
+    assert int(hist_data.aggregation_temporality) == int(AggregationTemporality.Delta)
+    assert len(hist_data.data_points) == 2
+    assert hist_data.data_points[0].count == 75
+    assert hist_data.data_points[0].sum == 750.0
+    assert hist_data.data_points[0].bucket_counts == [10, 20, 30, 40]
+    assert hist_data.data_points[0].explicit_bounds == [2.0, 10.0, 20.0]
+    assert len(hist_data.data_points[0].exemplars) == 2
+
+    # --- Verify ExponentialHistogram mutations ---
+    assert exp_hist_metric.name == "python_modified_exp_histogram_metric"
+    assert int(exp_hist_data.aggregation_temporality) == int(AggregationTemporality.Cumulative)
+    assert len(exp_hist_data.data_points) == 2
+    assert exp_hist_data.data_points[0].count == 100
+    assert exp_hist_data.data_points[0].sum == 1000.0
+    assert exp_hist_data.data_points[0].scale == 2
+    assert exp_hist_data.data_points[0].zero_count == 5
+    assert exp_hist_data.data_points[0].positive.offset == 3
+    assert exp_hist_data.data_points[0].positive.bucket_counts == [4, 8, 12, 16]
+    assert exp_hist_data.data_points[0].negative.offset == -2
+    assert exp_hist_data.data_points[0].negative.bucket_counts == [2, 4, 6]
+    assert len(exp_hist_data.data_points[0].exemplars) == 2
+
+    # --- Verify Summary mutations ---
+    assert summary_metric.name == "python_modified_summary_metric"
+    assert len(summary_data.data_points) == 2
+    assert summary_data.data_points[0].count == 50
+    assert summary_data.data_points[0].sum == 500.0
+    assert summary_data.data_points[0].flags == 0
+    assert len(summary_data.data_points[0].quantile_values) == 4
+    assert summary_data.data_points[0].quantile_values[0].value == 20.0
+    assert summary_data.data_points[0].quantile_values[1].value == 38.0
+    assert summary_data.data_points[0].quantile_values[2].value == 39.6
+    assert summary_data.data_points[0].quantile_values[3].quantile == 0.999
+
+    print("✓ All mutations verified successfully!")
+    print("\n=== PYTHON PROCESSING COMPLETE ===")
+    print("Rust will now verify all mutations...")

--- a/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
+++ b/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
@@ -59,6 +59,11 @@ def process_metrics(resource_metrics):
     assert num_dp.flags == 0
     assert len(num_dp.exemplars) == 0
 
+    # let's change the start_time_unix_nano
+    num_dp.start_time_unix_nano = 2000
+    num_dp = gauge.data_points[0]
+    assert num_dp.start_time_unix_nano == 2000
+
     # --- Mutate the metrics data ---
 
     # Mutate ResourceMetrics

--- a/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
+++ b/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
@@ -1,0 +1,182 @@
+# read_and_write_metrics_test.py
+
+from rotel_sdk.open_telemetry.metrics.v1 import (
+    Metric,
+    MetricData,
+    Sum,
+    Histogram,
+    NumberDataPoint,
+    HistogramDataPoint,
+    Exemplar,
+    AggregationTemporality,
+    DataPointFlags,
+    NumberDataPointValue,
+    ExemplarValue
+)
+
+from rotel_sdk.open_telemetry.common.v1 import KeyValue
+
+
+def process_metrics(resource_metrics):
+    """
+    Processes and mutates a ResourceMetrics object received from Rust.
+    This function asserts initial states and then modifies the metrics data.
+    """
+
+    # Assert initial state of ResourceMetrics (similar to how it would come from Rust)
+    assert resource_metrics.schema_url == "initial_schema_url_resource"
+    assert resource_metrics.resource is not None
+    assert resource_metrics.resource.dropped_attributes_count == 0
+    assert len(resource_metrics.scope_metrics) == 1
+
+    scope_metrics = resource_metrics.scope_metrics[0]
+    assert scope_metrics.schema_url == "initial_schema_url_scope"
+    assert scope_metrics.scope is not None
+    assert scope_metrics.scope.name == "initial_scope_name"
+    assert len(scope_metrics.metrics) == 1
+
+    metric = scope_metrics.metrics[0]
+    assert metric.name == "initial_metric_name"
+    assert metric.description == "initial_description"
+    assert metric.unit == "initial_unit"
+    assert len(metric.metadata) == 1
+    assert metric.metadata[0].key == "initial_metadata_key"
+    assert metric.metadata[0].value.value == "initial_metadata_value"
+    assert metric.data is not None
+
+    # Assume it's a Gauge for initial state
+    assert isinstance(metric.data, MetricData.Gauge)
+    gauge = metric.data[0]
+    assert len(gauge.data_points) == 1
+
+    num_dp = gauge.data_points[0]
+    assert num_dp.start_time_unix_nano == 1000
+    assert num_dp.time_unix_nano == 2000
+    assert num_dp.value[0] == 123.45
+    assert len(num_dp.attributes) == 1
+    assert num_dp.attributes[0].key == "dp_key"
+    assert num_dp.attributes[0].value.value == "dp_value"
+    assert num_dp.flags == 0
+    assert len(num_dp.exemplars) == 0
+
+    # --- Mutate the metrics data ---
+
+    # Mutate ResourceMetrics
+    resource_metrics.schema_url = "py_processed_schema_url_resource"
+    resource_metrics.resource.dropped_attributes_count = 5
+
+    # Mutate ScopeMetrics
+    scope_metrics.schema_url = "py_processed_schema_url_scope"
+    scope_metrics.scope.name = "py_processed_scope_name"
+    scope_metrics.scope.version = "py_processed_scope_version"
+    scope_metrics.scope.attributes.append(KeyValue.new_bool_value("scope_attr_py", True))
+    scope_metrics.scope.dropped_attributes_count = 1
+
+    # Mutate Metric
+    metric.name = "py_processed_metric_name"
+    metric.description = "py_processed_description"
+    metric.unit = "py_processed_unit"
+    metric.metadata.append(KeyValue.new_int_value("metadata_py", 999))
+
+    # Change metric type to Sum and add new data points
+    new_sum = Sum()
+    new_sum.aggregation_temporality = AggregationTemporality.Cumulative
+    new_sum.is_monotonic = True
+
+    sum_dp1 = NumberDataPoint()
+    sum_dp1.start_time_unix_nano = 3000
+    sum_dp1.time_unix_nano = 4000
+    sum_dp1.value = NumberDataPointValue.AsInt(10)
+    sum_dp1.attributes.append(KeyValue.new_string_value("sum_dp_key", "sum_dp_value"))
+
+    sum_dp2 = NumberDataPoint()
+    sum_dp2.start_time_unix_nano = 5000
+    sum_dp2.time_unix_nano = 6000
+    sum_dp2.value = NumberDataPointValue.AsInt(20)
+    sum_dp2.flags = DataPointFlags.NoRecordedValueMask.value
+
+    new_sum.data_points.append(sum_dp1)
+    new_sum.data_points.append(sum_dp2)
+
+    # Add an exemplar to sum_dp1
+    exemplar_sum = Exemplar()
+    exemplar_sum.time_unix_nano = 3500
+    exemplar_sum.span_id = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+    exemplar_sum.trace_id = b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01"
+    exemplar_sum.value = ExemplarValue.AsDouble(10.5)
+    exemplar_sum.filtered_attributes.append(KeyValue.new_string_value("filtered_key", "filtered_value"))
+    sum_dp1.exemplars.append(exemplar_sum)
+
+    metric.data = MetricData.Sum(new_sum)
+
+    # Add a new metric (Histogram) to the scope_metrics list
+    new_metric_histogram = Metric()
+    new_metric_histogram.name = "py_processed_histogram"
+    new_metric_histogram.description = "A histogram from Python"
+    new_metric_histogram.unit = "ms"
+
+    hist_data = Histogram()
+    hist_data.aggregation_temporality = AggregationTemporality.Delta
+
+    hist_dp = HistogramDataPoint()
+    hist_dp.start_time_unix_nano = 7000
+    hist_dp.time_unix_nano = 8000
+    hist_dp.count = 100
+    hist_dp.sum = 1000.0
+    hist_dp.bucket_counts = [10, 20, 30, 40]
+    hist_dp.explicit_bounds = [1.0, 5.0, 10.0]
+    hist_dp.min = 0.5
+    hist_dp.max = 12.0
+    hist_dp.attributes.append(KeyValue.new_string_value("hist_attr", "hist_value"))
+
+    hist_exemplar = Exemplar()
+    hist_exemplar.time_unix_nano = 7500
+    hist_exemplar.value = ExemplarValue.AsInt(75)
+    hist_dp.exemplars.append(hist_exemplar)
+
+    hist_data.data_points.append(hist_dp)
+    new_metric_histogram.data = MetricData.Histogram(hist_data)
+    scope_metrics.metrics.append(new_metric_histogram)
+
+    # Verify mutations
+    assert resource_metrics.schema_url == "py_processed_schema_url_resource"
+    assert resource_metrics.resource.dropped_attributes_count == 5
+    assert scope_metrics.schema_url == "py_processed_schema_url_scope"
+    assert scope_metrics.scope.name == "py_processed_scope_name"
+    assert scope_metrics.scope.version == "py_processed_scope_version"
+    assert len(scope_metrics.scope.attributes) == 2
+    assert scope_metrics.scope.attributes[1].key == "scope_attr_py"
+    assert scope_metrics.scope.attributes[1].value.value is True
+    assert scope_metrics.scope.dropped_attributes_count == 1
+
+    assert metric.name == "py_processed_metric_name"
+    assert metric.description == "py_processed_description"
+    assert metric.unit == "py_processed_unit"
+    assert len(metric.metadata) == 2
+    assert metric.metadata[1].key == "metadata_py"
+    assert metric.metadata[1].value.value == 999
+
+    assert isinstance(metric.data, MetricData.Sum)
+    processed_sum = metric.data[0]
+    assert int(processed_sum.aggregation_temporality) == int(AggregationTemporality.Cumulative)
+    assert processed_sum.is_monotonic is True
+    assert len(processed_sum.data_points) == 2
+    assert processed_sum.data_points[0].value[0] == 10
+    assert processed_sum.data_points[1].value[0] == 20
+    assert processed_sum.data_points[0].exemplars[0].value[0] == 10.5
+    assert processed_sum.data_points[0].exemplars[0].filtered_attributes[0].value.value == "filtered_value"
+
+    assert len(scope_metrics.metrics) == 2
+    processed_hist_metric = scope_metrics.metrics[1]
+    assert processed_hist_metric.name == "py_processed_histogram"
+    assert isinstance(processed_hist_metric.data, MetricData.Histogram)
+    processed_hist_data = processed_hist_metric.data[0]
+    assert int(processed_hist_data.aggregation_temporality) == int(AggregationTemporality.Delta)
+    assert len(processed_hist_data.data_points) == 1
+    assert processed_hist_data.data_points[0].count == 100
+    assert processed_hist_data.data_points[0].sum == 1000.0
+    assert processed_hist_data.data_points[0].bucket_counts == [10, 20, 30, 40]
+    assert processed_hist_data.data_points[0].explicit_bounds == [1.0, 5.0, 10.0]
+    assert processed_hist_data.data_points[0].min == 0.5
+    assert processed_hist_data.data_points[0].max == 12.0
+    assert processed_hist_data.data_points[0].exemplars[0].value[0] == 75

--- a/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
+++ b/rotel_python_processor_sdk/python_tests/read_and_write_metrics_test.py
@@ -61,8 +61,28 @@ def process_metrics(resource_metrics):
 
     # let's change the start_time_unix_nano
     num_dp.start_time_unix_nano = 2000
+    num_dp.time_unix_nano = 3000
+    num_dp.attributes.append(KeyValue.new_string_value("dp_key2", "dp_value2"))
+    exemplar = Exemplar()
+    exemplar.time_unix_nano = 3500
+    exemplar.span_id = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+    exemplar.trace_id = b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01"
+    exemplar.value = ExemplarValue.AsDouble(10.5)
+    exemplar.filtered_attributes.append(KeyValue.new_string_value("filtered_key", "filtered_value"))
+    num_dp.exemplars.append(exemplar)
     num_dp = gauge.data_points[0]
+    num_dp.flags = 1
+    num_dp.value = NumberDataPointValue.AsInt(111)
     assert num_dp.start_time_unix_nano == 2000
+    assert num_dp.time_unix_nano == 3000
+    assert len(num_dp.attributes) == 2
+    del (num_dp.attributes[0])
+    assert len(num_dp.attributes) == 1
+    assert num_dp.attributes[0].key == "dp_key2"
+    assert num_dp.attributes[0].value.value == "dp_value2"
+    assert len(num_dp.exemplars) == 1
+    assert num_dp.flags == 1
+    assert num_dp.value[0] == 111
 
     # --- Mutate the metrics data ---
 

--- a/rotel_python_processor_sdk/src/model/metrics.rs
+++ b/rotel_python_processor_sdk/src/model/metrics.rs
@@ -27,17 +27,17 @@ pub struct RMetric {
     pub description: String,
     pub unit: String,
     pub metadata: Arc<Mutex<Vec<RKeyValue>>>,
-    pub data: Arc<Mutex<Option<RMetricData>>>,
+    pub data: Arc<Mutex<Option<Arc<Mutex<RMetricData>>>>>,
 }
 
-/// RMetricData determines the aggregation type (if any) of the metric.
+// Alternative approach - change your RMetricData to hold Arcs
 #[derive(Debug, Clone)]
 pub enum RMetricData {
-    Gauge(RGauge),
-    Sum(RSum),
-    Histogram(RHistogram),
-    ExponentialHistogram(RExponentialHistogram),
-    Summary(RSummary),
+    Gauge(Arc<Mutex<RGauge>>),
+    Sum(Arc<Mutex<RSum>>),
+    Histogram(Arc<Mutex<RHistogram>>),
+    ExponentialHistogram(Arc<Mutex<RExponentialHistogram>>),
+    Summary(Arc<Mutex<RSummary>>),
 }
 
 /// RGauge represents the type of a scalar metric that always exports the
@@ -151,7 +151,7 @@ pub struct RSummaryDataPoint {
     pub time_unix_nano: u64,
     pub count: u64,
     pub sum: f64,
-    pub quantile_values: Vec<RValueAtQuantile>,
+    pub quantile_values: Arc<Mutex<Vec<Arc<Mutex<RValueAtQuantile>>>>>,
     pub flags: u32,
 }
 

--- a/rotel_python_processor_sdk/src/model/metrics.rs
+++ b/rotel_python_processor_sdk/src/model/metrics.rs
@@ -106,6 +106,7 @@ pub struct RHistogramDataPoint {
     pub time_unix_nano: u64,
     pub count: u64,
     pub sum: Option<f64>,
+    // TODO these should be an ARC?
     pub bucket_counts: Vec<u64>,
     pub explicit_bounds: Vec<f64>,
     pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
@@ -125,8 +126,8 @@ pub struct RExponentialHistogramDataPoint {
     pub sum: Option<f64>,
     pub scale: i32,
     pub zero_count: u64,
-    pub positive: Option<RExponentialHistogramBuckets>,
-    pub negative: Option<RExponentialHistogramBuckets>,
+    pub positive: Arc<Mutex<Option<Arc<Mutex<RExponentialHistogramBuckets>>>>>,
+    pub negative: Arc<Mutex<Option<Arc<Mutex<RExponentialHistogramBuckets>>>>>,
     pub flags: u32,
     pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
     pub min: Option<f64>,

--- a/rotel_python_processor_sdk/src/model/metrics.rs
+++ b/rotel_python_processor_sdk/src/model/metrics.rs
@@ -1,0 +1,197 @@
+// metrics.rs
+
+use crate::model::common::*;
+use crate::model::resource::RResource;
+use std::sync::{Arc, Mutex};
+
+/// A collection of RScopeMetrics from a RResource.
+#[derive(Debug, Clone)]
+pub struct RResourceMetrics {
+    pub resource: Arc<Mutex<Option<RResource>>>,
+    pub scope_metrics: Arc<Mutex<Vec<Arc<Mutex<RScopeMetrics>>>>>,
+    pub schema_url: String,
+}
+
+/// A collection of Metrics produced by an RInstrumentationScope.
+#[derive(Debug, Clone)]
+pub struct RScopeMetrics {
+    pub scope: Arc<Mutex<Option<RInstrumentationScope>>>,
+    pub metrics: Arc<Mutex<Vec<Arc<Mutex<RMetric>>>>>,
+    pub schema_url: String,
+}
+
+/// Defines a RMetric which has one or more timeseries.
+#[derive(Debug, Clone)]
+pub struct RMetric {
+    pub name: String,
+    pub description: String,
+    pub unit: String,
+    pub metadata: Arc<Mutex<Vec<RKeyValue>>>,
+    pub data: Option<RMetricData>,
+}
+
+/// RMetricData determines the aggregation type (if any) of the metric.
+#[derive(Debug, Clone)]
+pub enum RMetricData {
+    Gauge(RGauge),
+    Sum(RSum),
+    Histogram(RHistogram),
+    ExponentialHistogram(RExponentialHistogram),
+    Summary(RSummary),
+}
+
+/// RGauge represents the type of a scalar metric that always exports the
+/// "current value" for every data point.
+#[derive(Debug, Clone)]
+pub struct RGauge {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RNumberDataPoint>>>>>,
+}
+
+/// RSum represents the type of a scalar metric that is calculated as a sum of all
+/// reported measurements over a time interval.
+#[derive(Debug, Clone)]
+pub struct RSum {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RNumberDataPoint>>>>>,
+    pub aggregation_temporality: i32,
+    pub is_monotonic: bool,
+}
+
+/// RHistogram represents the type of a metric that is calculated by aggregating
+/// as a Histogram of all reported measurements over a time interval.
+#[derive(Debug, Clone)]
+pub struct RHistogram {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RHistogramDataPoint>>>>>,
+    pub aggregation_temporality: i32,
+}
+
+/// RExponentialHistogram represents the type of a metric that is calculated by aggregating
+/// as a ExponentialHistogram of all reported double measurements over a time interval.
+#[derive(Debug, Clone)]
+pub struct RExponentialHistogram {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RExponentialHistogramDataPoint>>>>>,
+    pub aggregation_temporality: i32,
+}
+
+/// RSummary metric data are used to convey quantile summaries.
+#[derive(Debug, Clone)]
+pub struct RSummary {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RSummaryDataPoint>>>>>,
+}
+
+/// RNumberDataPoint is a single data point in a timeseries that describes the
+/// time-varying scalar value of a metric.
+#[derive(Debug, Clone)]
+pub struct RNumberDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
+    pub flags: u32,
+    pub value: Option<RNumberDataPointValue>,
+}
+
+/// RNumberDataPointValue is the value itself for a NumberDataPoint.
+#[derive(Debug, Clone)]
+pub enum RNumberDataPointValue {
+    AsDouble(f64),
+    AsInt(i64),
+}
+
+/// RHistogramDataPoint is a single data point in a timeseries that describes the
+/// time-varying values of a Histogram.
+#[derive(Debug, Clone)]
+pub struct RHistogramDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub count: u64,
+    pub sum: Option<f64>,
+    pub bucket_counts: Vec<u64>,
+    pub explicit_bounds: Vec<f64>,
+    pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
+    pub flags: u32,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+/// RExponentialHistogramDataPoint is a single data point in a timeseries that describes the
+/// time-varying values of a ExponentialHistogram of double values.
+#[derive(Debug, Clone)]
+pub struct RExponentialHistogramDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub count: u64,
+    pub sum: Option<f64>,
+    pub scale: i32,
+    pub zero_count: u64,
+    pub positive: Option<RExponentialHistogramBuckets>,
+    pub negative: Option<RExponentialHistogramBuckets>,
+    pub flags: u32,
+    pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    pub zero_threshold: f64,
+}
+
+/// RExtendedExponentialHistogramBuckets are a set of bucket counts.
+#[derive(Debug, Clone)]
+pub struct RExponentialHistogramBuckets {
+    pub offset: i32,
+    pub bucket_counts: Vec<u64>,
+}
+
+/// RSummaryDataPoint is a single data point in a timeseries that describes the
+/// time-varying values of a Summary metric.
+#[derive(Debug, Clone)]
+pub struct RSummaryDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub count: u64,
+    pub sum: f64,
+    pub quantile_values: Vec<RValueAtQuantile>,
+    pub flags: u32,
+}
+
+/// RValueAtQuantile represents the value at a given quantile of a distribution.
+#[derive(Debug, Clone)]
+pub struct RValueAtQuantile {
+    pub quantile: f64,
+    pub value: f64,
+}
+
+/// RExemplar is a representation of an exemplar, which is a sample input measurement.
+#[derive(Debug, Clone)]
+pub struct RExemplar {
+    pub filtered_attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub time_unix_nano: u64,
+    pub span_id: Vec<u8>,
+    pub trace_id: Vec<u8>,
+    pub value: Option<RExemplarValue>,
+}
+
+/// RExemplarValue is the value of the measurement that was recorded.
+#[derive(Debug, Clone)]
+pub enum RExemplarValue {
+    AsDouble(f64),
+    AsInt(i64),
+}
+
+/// RAggregationTemporality defines how a metric aggregator reports aggregated values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[allow(dead_code)]
+pub enum RAggregationTemporality {
+    Unspecified = 0,
+    Delta = 1,
+    Cumulative = 2,
+}
+
+/// RDataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
+/// bit-field representing 32 distinct boolean flags.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[allow(dead_code)]
+pub enum RDataPointFlags {
+    DoNotUse = 0,
+    NoRecordedValueMask = 1,
+}

--- a/rotel_python_processor_sdk/src/model/metrics.rs
+++ b/rotel_python_processor_sdk/src/model/metrics.rs
@@ -17,7 +17,7 @@ pub struct RResourceMetrics {
 pub struct RScopeMetrics {
     pub scope: Arc<Mutex<Option<RInstrumentationScope>>>,
     pub metrics: Arc<Mutex<Vec<Arc<Mutex<RMetric>>>>>,
-    pub schema_url: String,
+    pub schema_url: Arc<Mutex<String>>,
 }
 
 /// Defines a RMetric which has one or more timeseries.
@@ -27,7 +27,7 @@ pub struct RMetric {
     pub description: String,
     pub unit: String,
     pub metadata: Arc<Mutex<Vec<RKeyValue>>>,
-    pub data: Option<RMetricData>,
+    pub data: Arc<Mutex<Option<RMetricData>>>,
 }
 
 /// RMetricData determines the aggregation type (if any) of the metric.

--- a/rotel_python_processor_sdk/src/model/mod.rs
+++ b/rotel_python_processor_sdk/src/model/mod.rs
@@ -1,5 +1,6 @@
 pub mod common;
 pub mod logs;
+pub mod metrics;
 pub mod otel_transform;
 pub mod py_transform;
 pub mod resource;

--- a/rotel_python_processor_sdk/src/model/otel_transform.rs
+++ b/rotel_python_processor_sdk/src/model/otel_transform.rs
@@ -153,7 +153,7 @@ fn transform_log_record(lr: opentelemetry_proto::tonic::logs::v1::LogRecord) -> 
     }
 }
 
-pub fn transform_metrics_data(
+pub fn transform_resource_metrics(
     rm: opentelemetry_proto::tonic::metrics::v1::ResourceMetrics,
 ) -> RResourceMetrics {
     let mut resource_metrics = RResourceMetrics {
@@ -191,7 +191,7 @@ pub fn transform_metrics_data(
         let scope_metrics = RScopeMetrics {
             scope: Arc::new(Mutex::new(scope)),
             metrics: Arc::new(Mutex::new(metrics_vec)),
-            schema_url: sm.schema_url,
+            schema_url: Arc::new(Mutex::new(sm.schema_url)),
         };
         scope_metrics_vec.push(Arc::new(Mutex::new(scope_metrics)));
     }
@@ -226,7 +226,7 @@ fn transform_metric(m: opentelemetry_proto::tonic::metrics::v1::Metric) -> RMetr
         description: m.description,
         unit: m.unit,
         metadata: Arc::new(Mutex::new(convert_attributes(m.metadata))),
-        data,
+        data: Arc::new(Mutex::new(data)),
     }
 }
 

--- a/rotel_python_processor_sdk/src/model/otel_transform.rs
+++ b/rotel_python_processor_sdk/src/model/otel_transform.rs
@@ -3,6 +3,7 @@ use crate::model::common::RValue::{
 };
 use crate::model::common::*;
 use crate::model::logs::*;
+use crate::model::metrics::*;
 use crate::model::trace::*;
 use std::sync::{Arc, Mutex};
 
@@ -149,6 +150,276 @@ fn transform_log_record(lr: opentelemetry_proto::tonic::logs::v1::LogRecord) -> 
         trace_id: lr.trace_id,
         span_id: lr.span_id,
         event_name: lr.event_name,
+    }
+}
+
+pub fn transform_metrics_data(
+    rm: opentelemetry_proto::tonic::metrics::v1::ResourceMetrics,
+) -> RResourceMetrics {
+    let mut resource_metrics = RResourceMetrics {
+        resource: Arc::new(Mutex::new(None)),
+        scope_metrics: Arc::new(Mutex::new(vec![])),
+        schema_url: rm.schema_url,
+    };
+
+    if rm.resource.is_some() {
+        let resource = rm.resource.unwrap();
+        let dropped_attributes_count = resource.dropped_attributes_count;
+        let kvs = build_rotel_sdk_resource(resource);
+        let res = Arc::new(Mutex::new(Some(crate::model::resource::RResource {
+            attributes: Arc::new(Mutex::new(kvs.to_owned())),
+            dropped_attributes_count: Arc::new(Mutex::new(dropped_attributes_count)),
+        })));
+        resource_metrics.resource = res.clone();
+    }
+
+    let mut scope_metrics_vec = vec![];
+    for sm in rm.scope_metrics {
+        let scope = sm.scope.map(|s| RInstrumentationScope {
+            name: s.name,
+            version: s.version,
+            attributes_raw: s.attributes,
+            attributes_arc: None,
+            dropped_attributes_count: s.dropped_attributes_count,
+        });
+
+        let mut metrics_vec = vec![];
+        for m in sm.metrics {
+            metrics_vec.push(Arc::new(Mutex::new(transform_metric(m))));
+        }
+
+        let scope_metrics = RScopeMetrics {
+            scope: Arc::new(Mutex::new(scope)),
+            metrics: Arc::new(Mutex::new(metrics_vec)),
+            schema_url: sm.schema_url,
+        };
+        scope_metrics_vec.push(Arc::new(Mutex::new(scope_metrics)));
+    }
+    resource_metrics.scope_metrics = Arc::new(Mutex::new(scope_metrics_vec));
+    resource_metrics
+}
+
+fn transform_metric(m: opentelemetry_proto::tonic::metrics::v1::Metric) -> RMetric {
+    let data = match m.data {
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(g)) => {
+            Some(RMetricData::Gauge(transform_gauge(g)))
+        }
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(s)) => {
+            Some(RMetricData::Sum(transform_sum(s)))
+        }
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(h)) => {
+            Some(RMetricData::Histogram(transform_histogram(h)))
+        }
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::ExponentialHistogram(eh)) => {
+            Some(RMetricData::ExponentialHistogram(
+                transform_exponential_histogram(eh),
+            ))
+        }
+        Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Summary(s)) => {
+            Some(RMetricData::Summary(transform_summary(s)))
+        }
+        None => None,
+    };
+
+    RMetric {
+        name: m.name,
+        description: m.description,
+        unit: m.unit,
+        metadata: Arc::new(Mutex::new(convert_attributes(m.metadata))),
+        data,
+    }
+}
+
+fn transform_gauge(g: opentelemetry_proto::tonic::metrics::v1::Gauge) -> RGauge {
+    let data_points = g
+        .data_points
+        .into_iter()
+        .map(|dp| Arc::new(Mutex::new(transform_number_data_point(dp))))
+        .collect();
+    RGauge {
+        data_points: Arc::new(Mutex::new(data_points)),
+    }
+}
+
+fn transform_sum(s: opentelemetry_proto::tonic::metrics::v1::Sum) -> RSum {
+    let data_points = s
+        .data_points
+        .into_iter()
+        .map(|dp| Arc::new(Mutex::new(transform_number_data_point(dp))))
+        .collect();
+    RSum {
+        data_points: Arc::new(Mutex::new(data_points)),
+        aggregation_temporality: s.aggregation_temporality,
+        is_monotonic: s.is_monotonic,
+    }
+}
+
+fn transform_histogram(h: opentelemetry_proto::tonic::metrics::v1::Histogram) -> RHistogram {
+    let data_points = h
+        .data_points
+        .into_iter()
+        .map(|dp| Arc::new(Mutex::new(transform_histogram_data_point(dp))))
+        .collect();
+    RHistogram {
+        data_points: Arc::new(Mutex::new(data_points)),
+        aggregation_temporality: h.aggregation_temporality,
+    }
+}
+
+fn transform_exponential_histogram(
+    eh: opentelemetry_proto::tonic::metrics::v1::ExponentialHistogram,
+) -> RExponentialHistogram {
+    let data_points = eh
+        .data_points
+        .into_iter()
+        .map(|dp| Arc::new(Mutex::new(transform_exponential_histogram_data_point(dp))))
+        .collect();
+    RExponentialHistogram {
+        data_points: Arc::new(Mutex::new(data_points)),
+        aggregation_temporality: eh.aggregation_temporality,
+    }
+}
+
+fn transform_summary(s: opentelemetry_proto::tonic::metrics::v1::Summary) -> RSummary {
+    let data_points = s
+        .data_points
+        .into_iter()
+        .map(|dp| Arc::new(Mutex::new(transform_summary_data_point(dp))))
+        .collect();
+    RSummary {
+        data_points: Arc::new(Mutex::new(data_points)),
+    }
+}
+
+fn transform_number_data_point(
+    ndp: opentelemetry_proto::tonic::metrics::v1::NumberDataPoint,
+) -> RNumberDataPoint {
+    let value = match ndp.value {
+        Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsDouble(d)) => {
+            Some(RNumberDataPointValue::AsDouble(d))
+        }
+        Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(i)) => {
+            Some(RNumberDataPointValue::AsInt(i))
+        }
+        None => None,
+    };
+
+    let exemplars = ndp
+        .exemplars
+        .into_iter()
+        .map(|e| Arc::new(Mutex::new(transform_exemplar(e))))
+        .collect();
+
+    RNumberDataPoint {
+        attributes: Arc::new(Mutex::new(convert_attributes(ndp.attributes))),
+        start_time_unix_nano: ndp.start_time_unix_nano,
+        time_unix_nano: ndp.time_unix_nano,
+        exemplars: Arc::new(Mutex::new(exemplars)),
+        flags: ndp.flags,
+        value,
+    }
+}
+
+fn transform_histogram_data_point(
+    hdp: opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint,
+) -> RHistogramDataPoint {
+    let exemplars = hdp
+        .exemplars
+        .into_iter()
+        .map(|e| Arc::new(Mutex::new(transform_exemplar(e))))
+        .collect();
+
+    RHistogramDataPoint {
+        attributes: Arc::new(Mutex::new(convert_attributes(hdp.attributes))),
+        start_time_unix_nano: hdp.start_time_unix_nano,
+        time_unix_nano: hdp.time_unix_nano,
+        count: hdp.count,
+        sum: hdp.sum,
+        bucket_counts: hdp.bucket_counts,
+        explicit_bounds: hdp.explicit_bounds,
+        exemplars: Arc::new(Mutex::new(exemplars)),
+        flags: hdp.flags,
+        min: hdp.min,
+        max: hdp.max,
+    }
+}
+
+fn transform_exponential_histogram_data_point(
+    ehdp: opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint,
+) -> RExponentialHistogramDataPoint {
+    let positive_buckets = ehdp.positive.map(|b| RExponentialHistogramBuckets {
+        offset: b.offset,
+        bucket_counts: b.bucket_counts,
+    });
+    let negative_buckets = ehdp.negative.map(|b| RExponentialHistogramBuckets {
+        offset: b.offset,
+        bucket_counts: b.bucket_counts,
+    });
+
+    let exemplars = ehdp
+        .exemplars
+        .into_iter()
+        .map(|e| Arc::new(Mutex::new(transform_exemplar(e))))
+        .collect();
+
+    RExponentialHistogramDataPoint {
+        attributes: Arc::new(Mutex::new(convert_attributes(ehdp.attributes))),
+        start_time_unix_nano: ehdp.start_time_unix_nano,
+        time_unix_nano: ehdp.time_unix_nano,
+        count: ehdp.count,
+        sum: ehdp.sum,
+        scale: ehdp.scale,
+        zero_count: ehdp.zero_count,
+        positive: positive_buckets,
+        negative: negative_buckets,
+        flags: ehdp.flags,
+        exemplars: Arc::new(Mutex::new(exemplars)),
+        min: ehdp.min,
+        max: ehdp.max,
+        zero_threshold: ehdp.zero_threshold,
+    }
+}
+
+fn transform_summary_data_point(
+    sdp: opentelemetry_proto::tonic::metrics::v1::SummaryDataPoint,
+) -> RSummaryDataPoint {
+    let quantile_values = sdp
+        .quantile_values
+        .into_iter()
+        .map(|qv| RValueAtQuantile {
+            quantile: qv.quantile,
+            value: qv.value,
+        })
+        .collect();
+
+    RSummaryDataPoint {
+        attributes: Arc::new(Mutex::new(convert_attributes(sdp.attributes))),
+        start_time_unix_nano: sdp.start_time_unix_nano,
+        time_unix_nano: sdp.time_unix_nano,
+        count: sdp.count,
+        sum: sdp.sum,
+        quantile_values,
+        flags: sdp.flags,
+    }
+}
+
+fn transform_exemplar(e: opentelemetry_proto::tonic::metrics::v1::Exemplar) -> RExemplar {
+    let value = match e.value {
+        Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsDouble(d)) => {
+            Some(RExemplarValue::AsDouble(d))
+        }
+        Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsInt(i)) => {
+            Some(RExemplarValue::AsInt(i))
+        }
+        None => None,
+    };
+
+    RExemplar {
+        filtered_attributes: Arc::new(Mutex::new(convert_attributes(e.filtered_attributes))),
+        time_unix_nano: e.time_unix_nano,
+        span_id: e.span_id,
+        trace_id: e.trace_id,
+        value,
     }
 }
 

--- a/rotel_python_processor_sdk/src/model/otel_transform.rs
+++ b/rotel_python_processor_sdk/src/model/otel_transform.rs
@@ -347,13 +347,17 @@ fn transform_histogram_data_point(
 fn transform_exponential_histogram_data_point(
     ehdp: opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint,
 ) -> RExponentialHistogramDataPoint {
-    let positive_buckets = ehdp.positive.map(|b| RExponentialHistogramBuckets {
-        offset: b.offset,
-        bucket_counts: b.bucket_counts,
+    let positive_buckets = ehdp.positive.map(|b| {
+        Arc::new(Mutex::new(RExponentialHistogramBuckets {
+            offset: b.offset,
+            bucket_counts: b.bucket_counts,
+        }))
     });
-    let negative_buckets = ehdp.negative.map(|b| RExponentialHistogramBuckets {
-        offset: b.offset,
-        bucket_counts: b.bucket_counts,
+    let negative_buckets = ehdp.negative.map(|b| {
+        Arc::new(Mutex::new(RExponentialHistogramBuckets {
+            offset: b.offset,
+            bucket_counts: b.bucket_counts,
+        }))
     });
 
     let exemplars = ehdp
@@ -370,8 +374,8 @@ fn transform_exponential_histogram_data_point(
         sum: ehdp.sum,
         scale: ehdp.scale,
         zero_count: ehdp.zero_count,
-        positive: positive_buckets,
-        negative: negative_buckets,
+        positive: Arc::new(Mutex::new(positive_buckets)),
+        negative: Arc::new(Mutex::new(negative_buckets)),
         flags: ehdp.flags,
         exemplars: Arc::new(Mutex::new(exemplars)),
         min: ehdp.min,

--- a/rotel_python_processor_sdk/src/model/py_transform.rs
+++ b/rotel_python_processor_sdk/src/model/py_transform.rs
@@ -3,8 +3,15 @@ use crate::model::common::*;
 use crate::model::logs::*;
 use crate::model::trace::*;
 
+use crate::model::metrics::{
+    RExemplar, RExemplarValue, RExponentialHistogram, RExponentialHistogramBuckets,
+    RExponentialHistogramDataPoint, RGauge, RHistogram, RHistogramDataPoint, RMetric, RMetricData,
+    RNumberDataPoint, RNumberDataPointValue, RScopeMetrics, RSum, RSummary, RSummaryDataPoint,
+    RValueAtQuantile,
+};
 use crate::model::resource::RResource;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
+use opentelemetry_proto::tonic::metrics::v1;
 use std::mem;
 use std::sync::{Arc, Mutex};
 
@@ -140,6 +147,433 @@ pub fn transform_logs(
         });
     }
     new_scope_logs
+}
+
+// Renamed and re-typed based on your request
+pub fn transform_metrics(scope_metrics: Vec<Arc<Mutex<RScopeMetrics>>>) -> Vec<v1::ScopeMetrics> {
+    let mut new_scope_metrics = vec![];
+    for sm_arc in scope_metrics.into_iter() {
+        // Consume the outer Vec
+        new_scope_metrics.push(transform_scope_metrics(sm_arc));
+    }
+    new_scope_metrics
+}
+
+// transform_resource_metrics is no longer a direct part of this new entry point
+// and would only be needed if converting RResourceMetrics specifically.
+// If it's used elsewhere, keep it; otherwise, it can be removed.
+// For this response, I'm assuming its removal as it's not part of the requested chain.
+
+fn transform_scope_metrics(sm_arc: Arc<Mutex<RScopeMetrics>>) -> v1::ScopeMetrics {
+    let mut sm_guard = sm_arc.lock().unwrap();
+    let moved_scope_metrics = mem::replace(
+        &mut *sm_guard,
+        RScopeMetrics {
+            // Placeholder
+            scope: Arc::new(Mutex::new(None)),
+            metrics: Arc::new(Mutex::new(vec![])),
+            schema_url: Arc::new(Mutex::new("".to_string())),
+        },
+    );
+
+    let scope = moved_scope_metrics.scope.lock().unwrap().take().map(|s| {
+        opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+            name: s.name,
+            version: s.version,
+            attributes: convert_attributes(s.attributes_raw, s.attributes_arc), // This will consume internal Arcs
+            dropped_attributes_count: s.dropped_attributes_count,
+        }
+    });
+
+    let mut metrics_vec = moved_scope_metrics.metrics.lock().unwrap();
+    let metrics = metrics_vec
+        .drain(..) // Use drain
+        .map(|m_arc| transform_metric(m_arc))
+        .collect();
+
+    v1::ScopeMetrics {
+        scope,
+        metrics,
+        schema_url: Arc::into_inner(moved_scope_metrics.schema_url)
+            .unwrap()
+            .into_inner()
+            .unwrap(),
+    }
+}
+
+fn transform_metric(m_arc: Arc<Mutex<RMetric>>) -> v1::Metric {
+    let mut m_guard = m_arc.lock().unwrap();
+    let moved_metric = mem::replace(
+        &mut *m_guard,
+        RMetric {
+            // Placeholder
+            name: "".to_string(),
+            description: "".to_string(),
+            unit: "".to_string(),
+            metadata: Arc::new(Mutex::new(vec![])),
+            data: Arc::new(Mutex::new(None)),
+        },
+    );
+
+    let m_data = Arc::into_inner(moved_metric.data)
+        .unwrap()
+        .into_inner()
+        .unwrap();
+    let data = match m_data {
+        Some(RMetricData::Gauge(g)) => Some(v1::metric::Data::Gauge(transform_gauge(g))),
+        Some(RMetricData::Sum(s)) => Some(v1::metric::Data::Sum(transform_sum(s))),
+        Some(RMetricData::Histogram(h)) => {
+            Some(v1::metric::Data::Histogram(transform_histogram(h)))
+        }
+        Some(RMetricData::ExponentialHistogram(eh)) => Some(
+            v1::metric::Data::ExponentialHistogram(transform_exponential_histogram(eh)),
+        ),
+        Some(RMetricData::Summary(s)) => Some(v1::metric::Data::Summary(transform_summary(s))),
+        None => None,
+    };
+
+    let x = v1::Metric {
+        name: moved_metric.name,
+        description: moved_metric.description,
+        unit: moved_metric.unit,
+        metadata: moved_metric
+            .metadata
+            .lock()
+            .unwrap()
+            .drain(..)
+            .map(|kv| {
+                let key = Arc::into_inner(kv.key).unwrap().into_inner().unwrap();
+                let value = kv.value.lock().unwrap().take().map(convert_value);
+                KeyValue { key, value }
+            })
+            .collect(),
+        data,
+    };
+    x
+}
+
+fn transform_gauge(g: RGauge) -> v1::Gauge {
+    let mut data_points_vec = g.data_points.lock().unwrap();
+    let data_points = data_points_vec
+        .drain(..)
+        .map(|dp_arc| transform_number_data_point(dp_arc))
+        .collect();
+    v1::Gauge { data_points }
+}
+
+fn transform_sum(s: RSum) -> v1::Sum {
+    let mut data_points_vec = s.data_points.lock().unwrap();
+    let data_points = data_points_vec
+        .drain(..)
+        .map(|dp_arc| transform_number_data_point(dp_arc))
+        .collect();
+    v1::Sum {
+        data_points,
+        aggregation_temporality: s.aggregation_temporality,
+        is_monotonic: s.is_monotonic,
+    }
+}
+
+fn transform_histogram(h: RHistogram) -> v1::Histogram {
+    let mut data_points_vec = h.data_points.lock().unwrap();
+    let data_points = data_points_vec
+        .drain(..)
+        .map(|dp_arc| transform_histogram_data_point(dp_arc))
+        .collect();
+    v1::Histogram {
+        data_points,
+        aggregation_temporality: h.aggregation_temporality,
+    }
+}
+
+fn transform_exponential_histogram(eh: RExponentialHistogram) -> v1::ExponentialHistogram {
+    let mut data_points_vec = eh.data_points.lock().unwrap();
+    let data_points = data_points_vec
+        .drain(..)
+        .map(|dp_arc| transform_exponential_histogram_data_point(dp_arc))
+        .collect();
+    v1::ExponentialHistogram {
+        data_points,
+        aggregation_temporality: eh.aggregation_temporality,
+    }
+}
+
+fn transform_summary(s: RSummary) -> v1::Summary {
+    let mut data_points_vec = s.data_points.lock().unwrap();
+    let data_points = data_points_vec
+        .drain(..)
+        .map(|dp_arc| transform_summary_data_point(dp_arc))
+        .collect();
+    v1::Summary { data_points }
+}
+
+fn transform_number_data_point(ndp_arc: Arc<Mutex<RNumberDataPoint>>) -> v1::NumberDataPoint {
+    let mut ndp_guard = ndp_arc.lock().unwrap();
+    let moved_ndp = mem::replace(
+        &mut *ndp_guard,
+        RNumberDataPoint {
+            // Placeholder
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            exemplars: Arc::new(Mutex::new(vec![])),
+            flags: 0,
+            value: None,
+        },
+    );
+
+    let value = match moved_ndp.value {
+        Some(RNumberDataPointValue::AsDouble(d)) => Some(v1::number_data_point::Value::AsDouble(d)),
+        Some(RNumberDataPointValue::AsInt(i)) => Some(v1::number_data_point::Value::AsInt(i)),
+        None => None,
+    };
+
+    let mut exemplars_vec = moved_ndp.exemplars.lock().unwrap();
+    let exemplars = exemplars_vec
+        .drain(..)
+        .map(|e_arc| transform_exemplar(e_arc))
+        .collect();
+
+    let x = v1::NumberDataPoint {
+        attributes: moved_ndp
+            .attributes
+            .lock()
+            .unwrap()
+            .drain(..)
+            .map(|kv_arc| {
+                let key = Arc::into_inner(kv_arc.key).unwrap().into_inner().unwrap();
+                let value = kv_arc.value.lock().unwrap().take().map(convert_value);
+                KeyValue { key, value }
+            })
+            .collect(),
+        start_time_unix_nano: moved_ndp.start_time_unix_nano,
+        time_unix_nano: moved_ndp.time_unix_nano,
+        exemplars,
+        flags: moved_ndp.flags,
+        value,
+    };
+    x
+}
+
+fn transform_histogram_data_point(
+    hdp_arc: Arc<Mutex<RHistogramDataPoint>>,
+) -> v1::HistogramDataPoint {
+    let mut hdp_guard = hdp_arc.lock().unwrap();
+    let moved_hdp = mem::replace(
+        &mut *hdp_guard,
+        RHistogramDataPoint {
+            // Placeholder
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            count: 0,
+            sum: None,
+            bucket_counts: vec![],
+            explicit_bounds: vec![],
+            exemplars: Arc::new(Mutex::new(vec![])),
+            flags: 0,
+            min: None,
+            max: None,
+        },
+    );
+
+    let mut exemplars_vec = moved_hdp.exemplars.lock().unwrap();
+    let exemplars = exemplars_vec
+        .drain(..)
+        .map(|e_arc| transform_exemplar(e_arc))
+        .collect();
+
+    let x = v1::HistogramDataPoint {
+        attributes: moved_hdp
+            .attributes
+            .lock()
+            .unwrap()
+            .drain(..)
+            .map(|kv_arc| {
+                let key = Arc::into_inner(kv_arc.key).unwrap().into_inner().unwrap();
+                let value = kv_arc.value.lock().unwrap().take().map(convert_value);
+                KeyValue { key, value }
+            })
+            .collect(),
+        start_time_unix_nano: moved_hdp.start_time_unix_nano,
+        time_unix_nano: moved_hdp.time_unix_nano,
+        count: moved_hdp.count,
+        sum: moved_hdp.sum,
+        bucket_counts: moved_hdp.bucket_counts,
+        explicit_bounds: moved_hdp.explicit_bounds,
+        exemplars,
+        flags: moved_hdp.flags,
+        min: moved_hdp.min,
+        max: moved_hdp.max,
+    };
+    x
+}
+
+fn transform_exponential_histogram_data_point(
+    ehdp_arc: Arc<Mutex<RExponentialHistogramDataPoint>>,
+) -> v1::ExponentialHistogramDataPoint {
+    let mut ehdp_guard = ehdp_arc.lock().unwrap();
+    let moved_ehdp = mem::replace(
+        &mut *ehdp_guard,
+        RExponentialHistogramDataPoint {
+            // Placeholder
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            count: 0,
+            sum: None,
+            scale: 0,
+            zero_count: 0,
+            positive: None,
+            negative: None,
+            flags: 0,
+            exemplars: Arc::new(Mutex::new(vec![])),
+            min: None,
+            max: None,
+            zero_threshold: 0.0,
+        },
+    );
+
+    let positive_buckets = moved_ehdp
+        .positive
+        .map(transform_exponential_histogram_buckets);
+    let negative_buckets = moved_ehdp
+        .negative
+        .map(transform_exponential_histogram_buckets);
+
+    let mut exemplars_vec = moved_ehdp.exemplars.lock().unwrap();
+    let exemplars = exemplars_vec
+        .drain(..)
+        .map(|e_arc| transform_exemplar(e_arc))
+        .collect();
+
+    let x = v1::ExponentialHistogramDataPoint {
+        attributes: moved_ehdp
+            .attributes
+            .lock()
+            .unwrap()
+            .drain(..)
+            .map(|kv_arc| {
+                let key = Arc::into_inner(kv_arc.key).unwrap().into_inner().unwrap();
+                let value = kv_arc.value.lock().unwrap().take().map(convert_value);
+                KeyValue { key, value }
+            })
+            .collect(),
+        start_time_unix_nano: moved_ehdp.start_time_unix_nano,
+        time_unix_nano: moved_ehdp.time_unix_nano,
+        count: moved_ehdp.count,
+        sum: moved_ehdp.sum,
+        scale: moved_ehdp.scale,
+        zero_count: moved_ehdp.zero_count,
+        positive: positive_buckets,
+        negative: negative_buckets,
+        flags: moved_ehdp.flags,
+        exemplars,
+        min: moved_ehdp.min,
+        max: moved_ehdp.max,
+        zero_threshold: moved_ehdp.zero_threshold,
+    };
+    x
+}
+
+fn transform_exponential_histogram_buckets(
+    b: RExponentialHistogramBuckets,
+) -> v1::exponential_histogram_data_point::Buckets {
+    v1::exponential_histogram_data_point::Buckets {
+        offset: b.offset,
+        bucket_counts: b.bucket_counts,
+    }
+}
+
+fn transform_summary_data_point(sdp_arc: Arc<Mutex<RSummaryDataPoint>>) -> v1::SummaryDataPoint {
+    let mut sdp_guard = sdp_arc.lock().unwrap();
+    let moved_sdp = mem::replace(
+        &mut *sdp_guard,
+        RSummaryDataPoint {
+            // Placeholder
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            count: 0,
+            sum: 0.0,
+            quantile_values: vec![],
+            flags: 0,
+        },
+    );
+
+    let quantile_values = moved_sdp
+        .quantile_values
+        .into_iter()
+        .map(transform_value_at_quantile)
+        .collect();
+
+    let x = v1::SummaryDataPoint {
+        attributes: moved_sdp
+            .attributes
+            .lock()
+            .unwrap()
+            .drain(..)
+            .map(|kv_arc| {
+                let key = Arc::into_inner(kv_arc.key).unwrap().into_inner().unwrap();
+                let value = kv_arc.value.lock().unwrap().take().map(convert_value);
+                KeyValue { key, value }
+            })
+            .collect(),
+        start_time_unix_nano: moved_sdp.start_time_unix_nano,
+        time_unix_nano: moved_sdp.time_unix_nano,
+        count: moved_sdp.count,
+        sum: moved_sdp.sum,
+        quantile_values,
+        flags: moved_sdp.flags,
+    };
+    x
+}
+
+fn transform_value_at_quantile(qv: RValueAtQuantile) -> v1::summary_data_point::ValueAtQuantile {
+    v1::summary_data_point::ValueAtQuantile {
+        quantile: qv.quantile,
+        value: qv.value,
+    }
+}
+
+fn transform_exemplar(e_arc: Arc<Mutex<RExemplar>>) -> v1::Exemplar {
+    let mut e_guard = e_arc.lock().unwrap();
+    let moved_exemplar = mem::replace(
+        &mut *e_guard,
+        RExemplar {
+            // Placeholder
+            filtered_attributes: Arc::new(Mutex::new(vec![])),
+            time_unix_nano: 0,
+            span_id: vec![],
+            trace_id: vec![],
+            value: None,
+        },
+    );
+
+    let value = match moved_exemplar.value {
+        Some(RExemplarValue::AsDouble(d)) => Some(v1::exemplar::Value::AsDouble(d)),
+        Some(RExemplarValue::AsInt(i)) => Some(v1::exemplar::Value::AsInt(i)),
+        None => None,
+    };
+
+    let x = v1::Exemplar {
+        filtered_attributes: moved_exemplar
+            .filtered_attributes
+            .lock()
+            .unwrap()
+            .drain(..)
+            .map(|kv_arc| {
+                let key = Arc::into_inner(kv_arc.key).unwrap().into_inner().unwrap();
+                let value = kv_arc.value.lock().unwrap().take().map(convert_value);
+                KeyValue { key, value }
+            })
+            .collect(),
+        time_unix_nano: moved_exemplar.time_unix_nano,
+        span_id: moved_exemplar.span_id,
+        trace_id: moved_exemplar.trace_id,
+        value,
+    };
+    x
 }
 
 fn convert_events(
@@ -332,7 +766,7 @@ pub fn convert_value(v: RAnyValue) -> opentelemetry_proto::tonic::common::v1::An
                     value: new_value,
                 });
             }
-            opentelemetry_proto::tonic::common::v1::AnyValue {
+            AnyValue {
                 value: Some(
                     opentelemetry_proto::tonic::common::v1::any_value::Value::KvlistValue(
                         opentelemetry_proto::tonic::common::v1::KeyValueList { values },
@@ -340,7 +774,7 @@ pub fn convert_value(v: RAnyValue) -> opentelemetry_proto::tonic::common::v1::An
                 ),
             }
         }
-        BytesValue(b) => opentelemetry_proto::tonic::common::v1::AnyValue {
+        BytesValue(b) => AnyValue {
             value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(b)),
         },
     }

--- a/rotel_python_processor_sdk/src/py/metrics.rs
+++ b/rotel_python_processor_sdk/src/py/metrics.rs
@@ -1,0 +1,2298 @@
+// metrics.rs
+
+use crate::model::common::{RInstrumentationScope, RKeyValue};
+use crate::model::resource::RResource;
+use crate::py::common::KeyValue;
+use crate::py::{handle_poison_error, AttributesList, InstrumentationScope, Resource};
+use pyo3::{pyclass, pymethods, Py, PyErr, PyRef, PyRefMut, PyResult, Python};
+use std::sync::{Arc, Mutex};
+use std::vec;
+
+use crate::model::metrics::{
+    RExemplar, RExemplarValue, RExponentialHistogram, RExponentialHistogramBuckets,
+    RExponentialHistogramDataPoint, RGauge, RHistogram, RHistogramDataPoint, RMetric, RMetricData,
+    RNumberDataPoint, RNumberDataPointValue, RScopeMetrics, RSum, RSummary, RSummaryDataPoint,
+    RValueAtQuantile,
+};
+
+// --- PyO3 Bindings for RResourceMetrics ---
+#[pyclass]
+#[derive(Clone)]
+pub struct ResourceMetrics {
+    pub resource: Arc<Mutex<Option<RResource>>>,
+    pub scope_metrics: Arc<Mutex<Vec<Arc<Mutex<RScopeMetrics>>>>>,
+    pub schema_url: String,
+}
+
+#[pymethods]
+impl ResourceMetrics {
+    #[getter]
+    fn resource(&self) -> PyResult<Option<Resource>> {
+        let v = self.resource.lock().map_err(handle_poison_error)?;
+        if v.is_none() {
+            return Ok(None);
+        }
+        let inner_resource = v.clone().unwrap();
+        Ok(Some(Resource {
+            attributes: inner_resource.attributes.clone(),
+            dropped_attributes_count: inner_resource.dropped_attributes_count.clone(),
+        }))
+    }
+
+    #[setter]
+    fn set_resource(&mut self, resource: Resource) -> PyResult<()> {
+        let mut inner = self.resource.lock().map_err(handle_poison_error)?;
+        *inner = Some(RResource {
+            attributes: resource.attributes,
+            dropped_attributes_count: resource.dropped_attributes_count,
+        });
+        Ok(())
+    }
+
+    #[getter]
+    fn scope_metrics(&self) -> PyResult<ScopeMetricsList> {
+        Ok(ScopeMetricsList(self.scope_metrics.clone()))
+    }
+
+    #[setter]
+    fn set_scope_metrics(&mut self, metrics: Vec<ScopeMetrics>) -> PyResult<()> {
+        let mut inner = self.scope_metrics.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for sm in metrics {
+            inner.push(Arc::new(Mutex::new(RScopeMetrics {
+                scope: sm.scope.clone(),
+                metrics: sm.metrics.clone(),
+                schema_url: sm.schema_url.clone(),
+            })));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn schema_url(&self) -> PyResult<String> {
+        Ok(self.schema_url.clone())
+    }
+
+    #[setter]
+    fn set_schema_url(&mut self, schema_url: String) -> PyResult<()> {
+        self.schema_url = schema_url;
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for ScopeMetricsList (for iterating and accessing) ---
+#[pyclass]
+pub struct ScopeMetricsList(Arc<Mutex<Vec<Arc<Mutex<RScopeMetrics>>>>>);
+
+#[pymethods]
+impl ScopeMetricsList {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<ScopeMetricsListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = ScopeMetricsListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<ScopeMetrics> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item = item.lock().unwrap();
+                Ok(ScopeMetrics {
+                    scope: item.scope.clone(),
+                    metrics: item.metrics.clone(),
+                    schema_url: item.schema_url.clone(),
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &ScopeMetrics) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner[index] = Arc::new(Mutex::new(RScopeMetrics {
+            scope: value.scope.clone(),
+            metrics: value.metrics.clone(),
+            schema_url: value.schema_url.clone(),
+        }));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &ScopeMetrics) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(RScopeMetrics {
+            scope: item.scope.clone(),
+            metrics: item.metrics.clone(),
+            schema_url: item.schema_url.clone(),
+        })));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct ScopeMetricsListIter {
+    inner: vec::IntoIter<Arc<Mutex<RScopeMetrics>>>,
+}
+
+#[pymethods]
+impl ScopeMetricsListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<ScopeMetrics>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(ScopeMetrics {
+            scope: inner.scope.clone(),
+            metrics: inner.metrics.clone(),
+            schema_url: inner.schema_url.clone(),
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RScopeMetrics ---
+#[pyclass]
+#[derive(Clone)]
+pub struct ScopeMetrics {
+    pub scope: Arc<Mutex<Option<RInstrumentationScope>>>,
+    pub metrics: Arc<Mutex<Vec<Arc<Mutex<RMetric>>>>>,
+    pub schema_url: String,
+}
+
+#[pymethods]
+impl ScopeMetrics {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(ScopeMetrics {
+            scope: Arc::new(Mutex::new(None)),
+            metrics: Arc::new(Mutex::new(vec![])),
+            schema_url: String::new(),
+        })
+    }
+
+    #[getter]
+    fn scope(&self) -> PyResult<Option<InstrumentationScope>> {
+        let v = self.scope.lock().map_err(handle_poison_error)?;
+        if v.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(InstrumentationScope(self.scope.clone())))
+    }
+
+    #[setter]
+    fn set_scope(&mut self, scope: Option<InstrumentationScope>) -> PyResult<()> {
+        let mut v = self.scope.lock().map_err(handle_poison_error)?;
+        if let Some(s) = scope {
+            let inner_s = s.0.lock().map_err(handle_poison_error)?;
+            *v = inner_s.clone();
+        } else {
+            *v = None;
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn metrics(&self) -> PyResult<MetricsList> {
+        Ok(MetricsList(self.metrics.clone()))
+    }
+
+    #[setter]
+    fn set_metrics(&mut self, metrics: Vec<Metric>) -> PyResult<()> {
+        let mut inner = self.metrics.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for m in metrics {
+            inner.push(Arc::new(Mutex::new(RMetric {
+                name: m.name.clone(),
+                description: m.description.clone(),
+                unit: m.unit.clone(),
+                metadata: m.metadata.clone(),
+                data: m.data.clone().map(|data| match data {
+                    MetricData::Gauge(g) => RMetricData::Gauge(g.into()),
+                    MetricData::Sum(s) => RMetricData::Sum(s.into()),
+                    MetricData::Histogram(h) => RMetricData::Histogram(h.into()),
+                    MetricData::ExponentialHistogram(eh) => {
+                        RMetricData::ExponentialHistogram(eh.into())
+                    }
+                    MetricData::Summary(s) => RMetricData::Summary(s.into()),
+                }),
+            })));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn schema_url(&self) -> PyResult<String> {
+        Ok(self.schema_url.clone())
+    }
+
+    #[setter]
+    fn set_schema_url(&mut self, schema_url: String) -> PyResult<()> {
+        self.schema_url = schema_url;
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for MetricsList ---
+#[pyclass]
+pub struct MetricsList(Arc<Mutex<Vec<Arc<Mutex<RMetric>>>>>);
+
+#[pymethods]
+impl MetricsList {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<MetricsListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = MetricsListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<Metric> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item_lock = item.lock().unwrap();
+                Ok(Metric {
+                    name: item_lock.name.clone(),
+                    description: item_lock.description.clone(),
+                    unit: item_lock.unit.clone(),
+                    metadata: item_lock.metadata.clone(),
+                    data: item_lock.data.clone().map(|data| match data {
+                        RMetricData::Gauge(g) => MetricData::Gauge(Gauge {
+                            data_points: g.data_points.clone(),
+                        }),
+                        RMetricData::Sum(s) => MetricData::Sum(Sum {
+                            data_points: s.data_points.clone(),
+                            aggregation_temporality: s.aggregation_temporality.into(),
+                            is_monotonic: s.is_monotonic,
+                        }),
+                        RMetricData::Histogram(h) => MetricData::Histogram(Histogram {
+                            data_points: h.data_points.clone(),
+                            aggregation_temporality: h.aggregation_temporality.into(),
+                        }),
+                        RMetricData::ExponentialHistogram(eh) => {
+                            MetricData::ExponentialHistogram(ExponentialHistogram {
+                                data_points: eh.data_points.clone(),
+                                aggregation_temporality: eh.aggregation_temporality.into(),
+                            })
+                        }
+                        RMetricData::Summary(s) => MetricData::Summary(Summary {
+                            data_points: s.data_points.clone(),
+                        }),
+                    }),
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &Metric) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner[index] = Arc::new(Mutex::new(RMetric {
+            name: value.name.clone(),
+            description: value.description.clone(),
+            unit: value.unit.clone(),
+            metadata: value.metadata.clone(),
+            data: value.data.clone().map(|data| match data {
+                MetricData::Gauge(g) => RMetricData::Gauge(g.into()),
+                MetricData::Sum(s) => RMetricData::Sum(s.into()),
+                MetricData::Histogram(h) => RMetricData::Histogram(h.into()),
+                MetricData::ExponentialHistogram(eh) => {
+                    RMetricData::ExponentialHistogram(eh.into())
+                }
+                MetricData::Summary(s) => RMetricData::Summary(s.into()),
+            }),
+        }));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &Metric) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(RMetric {
+            name: item.name.clone(),
+            description: item.description.clone(),
+            unit: item.unit.clone(),
+            metadata: item.metadata.clone(),
+            data: item.data.clone().map(|data| match data {
+                MetricData::Gauge(g) => RMetricData::Gauge(g.into()),
+                MetricData::Sum(s) => RMetricData::Sum(s.into()),
+                MetricData::Histogram(h) => RMetricData::Histogram(h.into()),
+                MetricData::ExponentialHistogram(eh) => {
+                    RMetricData::ExponentialHistogram(eh.into())
+                }
+                MetricData::Summary(s) => RMetricData::Summary(s.into()),
+            }),
+        })));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct MetricsListIter {
+    inner: vec::IntoIter<Arc<Mutex<RMetric>>>,
+}
+
+#[pymethods]
+impl MetricsListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Metric>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(Metric {
+            name: inner.name.clone(),
+            description: inner.description.clone(),
+            unit: inner.unit.clone(),
+            metadata: inner.metadata.clone(),
+            data: inner.data.clone().map(|data| match data {
+                RMetricData::Gauge(g) => MetricData::Gauge(Gauge {
+                    data_points: g.data_points.clone(),
+                }),
+                RMetricData::Sum(s) => MetricData::Sum(Sum {
+                    data_points: s.data_points.clone(),
+                    aggregation_temporality: s.aggregation_temporality.into(),
+                    is_monotonic: s.is_monotonic,
+                }),
+                RMetricData::Histogram(h) => MetricData::Histogram(Histogram {
+                    data_points: h.data_points.clone(),
+                    aggregation_temporality: h.aggregation_temporality.into(),
+                }),
+                RMetricData::ExponentialHistogram(eh) => {
+                    MetricData::ExponentialHistogram(ExponentialHistogram {
+                        data_points: eh.data_points.clone(),
+                        aggregation_temporality: eh.aggregation_temporality.into(),
+                    })
+                }
+                RMetricData::Summary(s) => MetricData::Summary(Summary {
+                    data_points: s.data_points.clone(),
+                }),
+            }),
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RMetric ---
+#[pyclass]
+#[derive(Clone)]
+pub struct Metric {
+    pub name: String,
+    pub description: String,
+    pub unit: String,
+    pub metadata: Arc<Mutex<Vec<RKeyValue>>>,
+    pub data: Option<MetricData>,
+}
+
+#[pymethods]
+impl Metric {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Metric {
+            name: String::new(),
+            description: String::new(),
+            unit: String::new(),
+            metadata: Arc::new(Mutex::new(vec![])),
+            data: None,
+        })
+    }
+
+    #[getter]
+    fn name(&self) -> PyResult<String> {
+        Ok(self.name.clone())
+    }
+
+    #[setter]
+    fn set_name(&mut self, name: String) -> PyResult<()> {
+        self.name = name;
+        Ok(())
+    }
+
+    #[getter]
+    fn description(&self) -> PyResult<String> {
+        Ok(self.description.clone())
+    }
+
+    #[setter]
+    fn set_description(&mut self, description: String) -> PyResult<()> {
+        self.description = description;
+        Ok(())
+    }
+
+    #[getter]
+    fn unit(&self) -> PyResult<String> {
+        Ok(self.unit.clone())
+    }
+
+    #[setter]
+    fn set_unit(&mut self, unit: String) -> PyResult<()> {
+        self.unit = unit;
+        Ok(())
+    }
+
+    #[getter]
+    fn metadata(&self) -> PyResult<AttributesList> {
+        Ok(AttributesList(self.metadata.clone()))
+    }
+
+    #[setter]
+    fn set_metadata(&mut self, metadata: Vec<KeyValue>) -> PyResult<()> {
+        let mut inner = self.metadata.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for kv in metadata {
+            let kv_lock = kv.inner.lock().map_err(handle_poison_error).unwrap();
+            inner.push(kv_lock.clone());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn data(&self) -> PyResult<Option<MetricData>> {
+        Ok(self.data.clone())
+    }
+
+    #[setter]
+    fn set_data(&mut self, data: Option<MetricData>) -> PyResult<()> {
+        self.data = data;
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for RMetricData (Enum) ---
+#[pyclass]
+#[derive(Clone)]
+pub enum MetricData {
+    Gauge(Gauge),
+    Sum(Sum),
+    Histogram(Histogram),
+    ExponentialHistogram(ExponentialHistogram),
+    Summary(Summary),
+}
+
+impl From<Gauge> for RGauge {
+    fn from(g: Gauge) -> Self {
+        RGauge {
+            data_points: g.data_points,
+        }
+    }
+}
+
+impl From<Sum> for RSum {
+    fn from(s: Sum) -> Self {
+        RSum {
+            data_points: s.data_points,
+            aggregation_temporality: s.aggregation_temporality as i32,
+            is_monotonic: s.is_monotonic,
+        }
+    }
+}
+
+impl From<Histogram> for RHistogram {
+    fn from(h: Histogram) -> Self {
+        RHistogram {
+            data_points: h.data_points,
+            aggregation_temporality: h.aggregation_temporality as i32,
+        }
+    }
+}
+
+impl From<ExponentialHistogram> for RExponentialHistogram {
+    fn from(eh: ExponentialHistogram) -> Self {
+        RExponentialHistogram {
+            data_points: eh.data_points,
+            aggregation_temporality: eh.aggregation_temporality as i32,
+        }
+    }
+}
+
+impl From<Summary> for RSummary {
+    fn from(s: Summary) -> Self {
+        RSummary {
+            data_points: s.data_points,
+        }
+    }
+}
+
+// --- PyO3 Bindings for RGauge ---
+#[pyclass]
+#[derive(Clone)]
+pub struct Gauge {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RNumberDataPoint>>>>>,
+}
+
+#[pymethods]
+impl Gauge {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Gauge {
+            data_points: Arc::new(Mutex::new(vec![])),
+        })
+    }
+
+    #[getter]
+    fn data_points(&self) -> PyResult<NumberDataPointList> {
+        Ok(NumberDataPointList(self.data_points.clone()))
+    }
+
+    #[setter]
+    fn set_data_points(&mut self, data_points: Vec<NumberDataPoint>) -> PyResult<()> {
+        let mut inner = self.data_points.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for dp in data_points {
+            inner.push(Arc::new(Mutex::new(RNumberDataPoint {
+                attributes: dp.attributes.clone(),
+                start_time_unix_nano: dp.start_time_unix_nano,
+                time_unix_nano: dp.time_unix_nano,
+                exemplars: dp.exemplars.clone(),
+                flags: dp.flags,
+                value: dp.value.map(|v| match v {
+                    NumberDataPointValue::AsDouble(d) => RNumberDataPointValue::AsDouble(d),
+                    NumberDataPointValue::AsInt(i) => RNumberDataPointValue::AsInt(i),
+                }),
+            })));
+        }
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for RSum ---
+#[pyclass]
+#[derive(Clone)]
+pub struct Sum {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RNumberDataPoint>>>>>,
+    pub aggregation_temporality: AggregationTemporality,
+    pub is_monotonic: bool,
+}
+
+#[pymethods]
+impl Sum {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Sum {
+            data_points: Arc::new(Mutex::new(vec![])),
+            aggregation_temporality: AggregationTemporality::Unspecified,
+            is_monotonic: false,
+        })
+    }
+
+    #[getter]
+    fn data_points(&self) -> PyResult<NumberDataPointList> {
+        Ok(NumberDataPointList(self.data_points.clone()))
+    }
+
+    #[setter]
+    fn set_data_points(&mut self, data_points: Vec<NumberDataPoint>) -> PyResult<()> {
+        let mut inner = self.data_points.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for dp in data_points {
+            inner.push(Arc::new(Mutex::new(dp.into())));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn aggregation_temporality(&self) -> PyResult<AggregationTemporality> {
+        Ok(self.aggregation_temporality)
+    }
+
+    #[setter]
+    fn set_aggregation_temporality(&mut self, temporality: AggregationTemporality) -> PyResult<()> {
+        self.aggregation_temporality = temporality;
+        Ok(())
+    }
+
+    #[getter]
+    fn is_monotonic(&self) -> PyResult<bool> {
+        Ok(self.is_monotonic)
+    }
+
+    #[setter]
+    fn set_is_monotonic(&mut self, is_monotonic: bool) -> PyResult<()> {
+        self.is_monotonic = is_monotonic;
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for RHistogram ---
+#[pyclass]
+#[derive(Clone)]
+pub struct Histogram {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RHistogramDataPoint>>>>>,
+    pub aggregation_temporality: AggregationTemporality,
+}
+
+#[pymethods]
+impl Histogram {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Histogram {
+            data_points: Arc::new(Mutex::new(vec![])),
+            aggregation_temporality: AggregationTemporality::Unspecified,
+        })
+    }
+
+    #[getter]
+    fn data_points(&self) -> PyResult<HistogramDataPointList> {
+        Ok(HistogramDataPointList(self.data_points.clone()))
+    }
+
+    #[setter]
+    fn set_data_points(&mut self, data_points: Vec<HistogramDataPoint>) -> PyResult<()> {
+        let mut inner = self.data_points.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for dp in data_points {
+            inner.push(Arc::new(Mutex::new(dp.into())));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn aggregation_temporality(&self) -> PyResult<AggregationTemporality> {
+        Ok(self.aggregation_temporality)
+    }
+
+    #[setter]
+    fn set_aggregation_temporality(&mut self, temporality: AggregationTemporality) -> PyResult<()> {
+        self.aggregation_temporality = temporality;
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for RExponentialHistogram ---
+#[pyclass]
+#[derive(Clone)]
+pub struct ExponentialHistogram {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RExponentialHistogramDataPoint>>>>>,
+    pub aggregation_temporality: AggregationTemporality,
+}
+
+#[pymethods]
+impl ExponentialHistogram {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(ExponentialHistogram {
+            data_points: Arc::new(Mutex::new(vec![])),
+            aggregation_temporality: AggregationTemporality::Unspecified,
+        })
+    }
+
+    #[getter]
+    fn data_points(&self) -> PyResult<ExponentialHistogramDataPointList> {
+        Ok(ExponentialHistogramDataPointList(self.data_points.clone()))
+    }
+
+    #[setter]
+    fn set_data_points(&mut self, data_points: Vec<ExponentialHistogramDataPoint>) -> PyResult<()> {
+        let mut inner = self.data_points.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for dp in data_points {
+            inner.push(Arc::new(Mutex::new(dp.into())));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn aggregation_temporality(&self) -> PyResult<AggregationTemporality> {
+        Ok(self.aggregation_temporality)
+    }
+
+    #[setter]
+    fn set_aggregation_temporality(&mut self, temporality: AggregationTemporality) -> PyResult<()> {
+        self.aggregation_temporality = temporality;
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for RSummary ---
+#[pyclass]
+#[derive(Clone)]
+pub struct Summary {
+    pub data_points: Arc<Mutex<Vec<Arc<Mutex<RSummaryDataPoint>>>>>,
+}
+
+#[pymethods]
+impl Summary {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Summary {
+            data_points: Arc::new(Mutex::new(vec![])),
+        })
+    }
+
+    #[getter]
+    fn data_points(&self) -> PyResult<SummaryDataPointList> {
+        Ok(SummaryDataPointList(self.data_points.clone()))
+    }
+
+    #[setter]
+    fn set_data_points(&mut self, data_points: Vec<SummaryDataPoint>) -> PyResult<()> {
+        let mut inner = self.data_points.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for dp in data_points {
+            inner.push(Arc::new(Mutex::new(dp.into())));
+        }
+        Ok(())
+    }
+}
+
+// --- PyO3 Bindings for NumberDataPointList ---
+#[pyclass]
+pub struct NumberDataPointList(Arc<Mutex<Vec<Arc<Mutex<RNumberDataPoint>>>>>);
+
+#[pymethods]
+impl NumberDataPointList {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<NumberDataPointListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = NumberDataPointListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<NumberDataPoint> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item_lock = item.lock().unwrap();
+                Ok(NumberDataPoint {
+                    attributes: item_lock.attributes.clone(),
+                    start_time_unix_nano: item_lock.start_time_unix_nano,
+                    time_unix_nano: item_lock.time_unix_nano,
+                    exemplars: item_lock.exemplars.clone(),
+                    flags: item_lock.flags,
+                    value: item_lock.value.clone().map(|v| match v {
+                        RNumberDataPointValue::AsDouble(d) => NumberDataPointValue::AsDouble(d),
+                        RNumberDataPointValue::AsInt(i) => NumberDataPointValue::AsInt(i),
+                    }),
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &NumberDataPoint) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+
+        inner[index] = Arc::new(Mutex::new(RNumberDataPoint {
+            attributes: value.attributes.clone(),
+            start_time_unix_nano: value.start_time_unix_nano,
+            time_unix_nano: value.time_unix_nano,
+            exemplars: value.exemplars.clone(),
+            flags: value.flags,
+            value: value.value.clone().map(|v| match v {
+                NumberDataPointValue::AsDouble(d) => RNumberDataPointValue::AsDouble(d),
+                NumberDataPointValue::AsInt(i) => RNumberDataPointValue::AsInt(i),
+            }),
+        }));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &NumberDataPoint) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(item.to_owned().into())));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct NumberDataPointListIter {
+    inner: vec::IntoIter<Arc<Mutex<RNumberDataPoint>>>,
+}
+
+#[pymethods]
+impl NumberDataPointListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<NumberDataPoint>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(NumberDataPoint {
+            attributes: inner.attributes.clone(),
+            start_time_unix_nano: inner.start_time_unix_nano,
+            time_unix_nano: inner.time_unix_nano,
+            exemplars: inner.exemplars.clone(),
+            flags: inner.flags,
+            value: inner.value.clone().map(|v| match v {
+                RNumberDataPointValue::AsDouble(d) => NumberDataPointValue::AsDouble(d),
+                RNumberDataPointValue::AsInt(i) => NumberDataPointValue::AsInt(i),
+            }),
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RNumberDataPoint ---
+#[pyclass]
+#[derive(Clone)]
+pub struct NumberDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
+    pub flags: u32,
+    pub value: Option<NumberDataPointValue>,
+}
+
+#[pymethods]
+impl NumberDataPoint {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(NumberDataPoint {
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            exemplars: Arc::new(Mutex::new(vec![])),
+            flags: 0,
+            value: None,
+        })
+    }
+
+    #[getter]
+    fn attributes(&self) -> PyResult<AttributesList> {
+        Ok(AttributesList(self.attributes.clone()))
+    }
+
+    #[setter]
+    fn set_attributes(&mut self, attributes: Vec<KeyValue>) -> PyResult<()> {
+        let mut inner = self.attributes.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for kv in attributes {
+            let kv_lock = kv.inner.lock().map_err(handle_poison_error).unwrap();
+            inner.push(kv_lock.clone());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn start_time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.start_time_unix_nano)
+    }
+
+    #[setter]
+    fn set_start_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.start_time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.time_unix_nano)
+    }
+
+    #[setter]
+    fn set_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn exemplars(&self) -> PyResult<ExemplarList> {
+        Ok(ExemplarList(self.exemplars.clone()))
+    }
+
+    #[setter]
+    fn set_exemplars(&mut self, exemplars: Vec<Exemplar>) -> PyResult<()> {
+        let mut inner = self.exemplars.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for e in exemplars {
+            inner.push(Arc::new(Mutex::new(e.into())));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn flags(&self) -> PyResult<u32> {
+        Ok(self.flags)
+    }
+
+    #[setter]
+    fn set_flags(&mut self, flags: u32) -> PyResult<()> {
+        self.flags = flags;
+        Ok(())
+    }
+
+    #[getter]
+    fn value(&self) -> PyResult<Option<NumberDataPointValue>> {
+        Ok(self.value.clone())
+    }
+
+    #[setter]
+    fn set_value(&mut self, value: Option<NumberDataPointValue>) -> PyResult<()> {
+        self.value = value;
+        Ok(())
+    }
+}
+
+impl From<NumberDataPoint> for RNumberDataPoint {
+    fn from(dp: NumberDataPoint) -> Self {
+        RNumberDataPoint {
+            attributes: dp.attributes,
+            start_time_unix_nano: dp.start_time_unix_nano,
+            time_unix_nano: dp.time_unix_nano,
+            exemplars: dp.exemplars,
+            flags: dp.flags,
+            value: dp.value.map(|v| match v {
+                NumberDataPointValue::AsDouble(d) => RNumberDataPointValue::AsDouble(d),
+                NumberDataPointValue::AsInt(i) => RNumberDataPointValue::AsInt(i),
+            }),
+        }
+    }
+}
+
+// --- PyO3 Bindings for RNumberDataPointValue (Enum) ---
+#[pyclass]
+#[derive(Clone)]
+pub enum NumberDataPointValue {
+    AsDouble(f64),
+    AsInt(i64),
+}
+
+// --- PyO3 Bindings for HistogramDataPointList ---
+#[pyclass]
+pub struct HistogramDataPointList(Arc<Mutex<Vec<Arc<Mutex<RHistogramDataPoint>>>>>);
+
+#[pymethods]
+impl HistogramDataPointList {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<HistogramDataPointListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = HistogramDataPointListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<HistogramDataPoint> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item_lock = item.lock().unwrap();
+                Ok(HistogramDataPoint {
+                    attributes: item_lock.attributes.clone(),
+                    start_time_unix_nano: item_lock.start_time_unix_nano,
+                    time_unix_nano: item_lock.time_unix_nano,
+                    count: item_lock.count,
+                    sum: item_lock.sum,
+                    bucket_counts: item_lock.bucket_counts.clone(),
+                    explicit_bounds: item_lock.explicit_bounds.clone(),
+                    exemplars: item_lock.exemplars.clone(),
+                    flags: item_lock.flags,
+                    min: item_lock.min,
+                    max: item_lock.max,
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &HistogramDataPoint) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner[index] = Arc::new(Mutex::new(value.to_owned().into()));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &HistogramDataPoint) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(item.to_owned().into())));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct HistogramDataPointListIter {
+    inner: vec::IntoIter<Arc<Mutex<RHistogramDataPoint>>>,
+}
+
+#[pymethods]
+impl HistogramDataPointListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<HistogramDataPoint>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(HistogramDataPoint {
+            attributes: inner.attributes.clone(),
+            start_time_unix_nano: inner.start_time_unix_nano,
+            time_unix_nano: inner.time_unix_nano,
+            count: inner.count,
+            sum: inner.sum,
+            bucket_counts: inner.bucket_counts.clone(),
+            explicit_bounds: inner.explicit_bounds.clone(),
+            exemplars: inner.exemplars.clone(),
+            flags: inner.flags,
+            min: inner.min,
+            max: inner.max,
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RHistogramDataPoint ---
+#[pyclass]
+#[derive(Clone)]
+pub struct HistogramDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub count: u64,
+    pub sum: Option<f64>,
+    pub bucket_counts: Vec<u64>,
+    pub explicit_bounds: Vec<f64>,
+    pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
+    pub flags: u32,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+#[pymethods]
+impl HistogramDataPoint {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(HistogramDataPoint {
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            count: 0,
+            sum: None,
+            bucket_counts: vec![],
+            explicit_bounds: vec![],
+            exemplars: Arc::new(Mutex::new(vec![])),
+            flags: 0,
+            min: None,
+            max: None,
+        })
+    }
+
+    #[getter]
+    fn attributes(&self) -> PyResult<AttributesList> {
+        Ok(AttributesList(self.attributes.clone()))
+    }
+
+    #[setter]
+    fn set_attributes(&mut self, attributes: Vec<KeyValue>) -> PyResult<()> {
+        let mut inner = self.attributes.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for kv in attributes {
+            let kv_lock = kv.inner.lock().map_err(handle_poison_error).unwrap();
+            inner.push(kv_lock.clone());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn start_time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.start_time_unix_nano)
+    }
+
+    #[setter]
+    fn set_start_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.start_time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.time_unix_nano)
+    }
+
+    #[setter]
+    fn set_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn count(&self) -> PyResult<u64> {
+        Ok(self.count)
+    }
+
+    #[setter]
+    fn set_count(&mut self, count: u64) -> PyResult<()> {
+        self.count = count;
+        Ok(())
+    }
+
+    #[getter]
+    fn sum(&self) -> PyResult<Option<f64>> {
+        Ok(self.sum)
+    }
+
+    #[setter]
+    fn set_sum(&mut self, sum: Option<f64>) -> PyResult<()> {
+        self.sum = sum;
+        Ok(())
+    }
+
+    #[getter]
+    fn bucket_counts(&self) -> PyResult<Vec<u64>> {
+        Ok(self.bucket_counts.clone())
+    }
+
+    #[setter]
+    fn set_bucket_counts(&mut self, bucket_counts: Vec<u64>) -> PyResult<()> {
+        self.bucket_counts = bucket_counts;
+        Ok(())
+    }
+
+    #[getter]
+    fn explicit_bounds(&self) -> PyResult<Vec<f64>> {
+        Ok(self.explicit_bounds.clone())
+    }
+
+    #[setter]
+    fn set_explicit_bounds(&mut self, explicit_bounds: Vec<f64>) -> PyResult<()> {
+        self.explicit_bounds = explicit_bounds;
+        Ok(())
+    }
+
+    #[getter]
+    fn exemplars(&self) -> PyResult<ExemplarList> {
+        Ok(ExemplarList(self.exemplars.clone()))
+    }
+
+    #[setter]
+    fn set_exemplars(&mut self, exemplars: Vec<Exemplar>) -> PyResult<()> {
+        let mut inner = self.exemplars.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for e in exemplars {
+            inner.push(Arc::new(Mutex::new(e.into())));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn flags(&self) -> PyResult<u32> {
+        Ok(self.flags)
+    }
+
+    #[setter]
+    fn set_flags(&mut self, flags: u32) -> PyResult<()> {
+        self.flags = flags;
+        Ok(())
+    }
+
+    #[getter]
+    fn min(&self) -> PyResult<Option<f64>> {
+        Ok(self.min)
+    }
+
+    #[setter]
+    fn set_min(&mut self, min: Option<f64>) -> PyResult<()> {
+        self.min = min;
+        Ok(())
+    }
+
+    #[getter]
+    fn max(&self) -> PyResult<Option<f64>> {
+        Ok(self.max)
+    }
+
+    #[setter]
+    fn set_max(&mut self, max: Option<f64>) -> PyResult<()> {
+        self.max = max;
+        Ok(())
+    }
+}
+
+impl From<HistogramDataPoint> for RHistogramDataPoint {
+    fn from(dp: HistogramDataPoint) -> Self {
+        RHistogramDataPoint {
+            attributes: dp.attributes,
+            start_time_unix_nano: dp.start_time_unix_nano,
+            time_unix_nano: dp.time_unix_nano,
+            count: dp.count,
+            sum: dp.sum,
+            bucket_counts: dp.bucket_counts,
+            explicit_bounds: dp.explicit_bounds,
+            exemplars: dp.exemplars,
+            flags: dp.flags,
+            min: dp.min,
+            max: dp.max,
+        }
+    }
+}
+
+// --- PyO3 Bindings for ExponentialHistogramDataPointList ---
+#[pyclass]
+pub struct ExponentialHistogramDataPointList(
+    Arc<Mutex<Vec<Arc<Mutex<RExponentialHistogramDataPoint>>>>>,
+);
+
+#[pymethods]
+impl ExponentialHistogramDataPointList {
+    fn __iter__<'py>(
+        &'py self,
+        py: Python<'py>,
+    ) -> PyResult<Py<ExponentialHistogramDataPointListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = ExponentialHistogramDataPointListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<ExponentialHistogramDataPoint> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item_lock = item.lock().unwrap();
+                Ok(ExponentialHistogramDataPoint {
+                    attributes: item_lock.attributes.clone(),
+                    start_time_unix_nano: item_lock.start_time_unix_nano,
+                    time_unix_nano: item_lock.time_unix_nano,
+                    count: item_lock.count,
+                    sum: item_lock.sum,
+                    scale: item_lock.scale,
+                    zero_count: item_lock.zero_count,
+                    positive: item_lock.positive.clone().map(|p| p.to_owned().into()),
+                    negative: item_lock.negative.clone().map(|n| n.to_owned().into()),
+                    flags: item_lock.flags,
+                    exemplars: item_lock.exemplars.clone(),
+                    min: item_lock.min,
+                    max: item_lock.max,
+                    zero_threshold: item_lock.zero_threshold,
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &ExponentialHistogramDataPoint) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner[index] = Arc::new(Mutex::new(value.to_owned().into()));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &ExponentialHistogramDataPoint) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(item.to_owned().into())));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct ExponentialHistogramDataPointListIter {
+    inner: vec::IntoIter<Arc<Mutex<RExponentialHistogramDataPoint>>>,
+}
+
+#[pymethods]
+impl ExponentialHistogramDataPointListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<ExponentialHistogramDataPoint>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(ExponentialHistogramDataPoint {
+            attributes: inner.attributes.clone(),
+            start_time_unix_nano: inner.start_time_unix_nano,
+            time_unix_nano: inner.time_unix_nano,
+            count: inner.count,
+            sum: inner.sum,
+            scale: inner.scale,
+            zero_count: inner.zero_count,
+            positive: inner.positive.clone().map(|p| p.into()),
+            negative: inner.negative.clone().map(|n| n.into()),
+            flags: inner.flags,
+            exemplars: inner.exemplars.clone(),
+            min: inner.min,
+            max: inner.max,
+            zero_threshold: inner.zero_threshold,
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RExponentialHistogramDataPoint ---
+#[pyclass]
+#[derive(Clone)]
+pub struct ExponentialHistogramDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub count: u64,
+    pub sum: Option<f64>,
+    pub scale: i32,
+    pub zero_count: u64,
+    pub positive: Option<ExponentialHistogramBuckets>,
+    pub negative: Option<ExponentialHistogramBuckets>,
+    pub flags: u32,
+    pub exemplars: Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+    pub zero_threshold: f64,
+}
+
+#[pymethods]
+impl ExponentialHistogramDataPoint {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(ExponentialHistogramDataPoint {
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            count: 0,
+            sum: None,
+            scale: 0,
+            zero_count: 0,
+            positive: None,
+            negative: None,
+            flags: 0,
+            exemplars: Arc::new(Mutex::new(vec![])),
+            min: None,
+            max: None,
+            zero_threshold: 0.0,
+        })
+    }
+
+    #[getter]
+    fn attributes(&self) -> PyResult<AttributesList> {
+        Ok(AttributesList(self.attributes.clone()))
+    }
+
+    #[setter]
+    fn set_attributes(&mut self, attributes: Vec<KeyValue>) -> PyResult<()> {
+        let mut inner = self.attributes.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for kv in attributes {
+            let kv_lock = kv.inner.lock().map_err(handle_poison_error).unwrap();
+            inner.push(kv_lock.clone());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn start_time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.start_time_unix_nano)
+    }
+
+    #[setter]
+    fn set_start_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.start_time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.time_unix_nano)
+    }
+
+    #[setter]
+    fn set_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn count(&self) -> PyResult<u64> {
+        Ok(self.count)
+    }
+
+    #[setter]
+    fn set_count(&mut self, count: u64) -> PyResult<()> {
+        self.count = count;
+        Ok(())
+    }
+
+    #[getter]
+    fn sum(&self) -> PyResult<Option<f64>> {
+        Ok(self.sum)
+    }
+
+    #[setter]
+    fn set_sum(&mut self, sum: Option<f64>) -> PyResult<()> {
+        self.sum = sum;
+        Ok(())
+    }
+
+    #[getter]
+    fn scale(&self) -> PyResult<i32> {
+        Ok(self.scale)
+    }
+
+    #[setter]
+    fn set_scale(&mut self, scale: i32) -> PyResult<()> {
+        self.scale = scale;
+        Ok(())
+    }
+
+    #[getter]
+    fn zero_count(&self) -> PyResult<u64> {
+        Ok(self.zero_count)
+    }
+
+    #[setter]
+    fn set_zero_count(&mut self, count: u64) -> PyResult<()> {
+        self.zero_count = count;
+        Ok(())
+    }
+
+    #[getter]
+    fn positive(&self) -> PyResult<Option<ExponentialHistogramBuckets>> {
+        Ok(self.positive.clone())
+    }
+
+    #[setter]
+    fn set_positive(&mut self, buckets: Option<ExponentialHistogramBuckets>) -> PyResult<()> {
+        self.positive = buckets;
+        Ok(())
+    }
+
+    #[getter]
+    fn negative(&self) -> PyResult<Option<ExponentialHistogramBuckets>> {
+        Ok(self.negative.clone())
+    }
+
+    #[setter]
+    fn set_negative(&mut self, buckets: Option<ExponentialHistogramBuckets>) -> PyResult<()> {
+        self.negative = buckets;
+        Ok(())
+    }
+
+    #[getter]
+    fn flags(&self) -> PyResult<u32> {
+        Ok(self.flags)
+    }
+
+    #[setter]
+    fn set_flags(&mut self, flags: u32) -> PyResult<()> {
+        self.flags = flags;
+        Ok(())
+    }
+
+    #[getter]
+    fn exemplars(&self) -> PyResult<ExemplarList> {
+        Ok(ExemplarList(self.exemplars.clone()))
+    }
+
+    #[setter]
+    fn set_exemplars(&mut self, exemplars: Vec<Exemplar>) -> PyResult<()> {
+        let mut inner = self.exemplars.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for e in exemplars {
+            inner.push(Arc::new(Mutex::new(e.into())));
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn min(&self) -> PyResult<Option<f64>> {
+        Ok(self.min)
+    }
+
+    #[setter]
+    fn set_min(&mut self, min: Option<f64>) -> PyResult<()> {
+        self.min = min;
+        Ok(())
+    }
+
+    #[getter]
+    fn max(&self) -> PyResult<Option<f64>> {
+        Ok(self.max)
+    }
+
+    #[setter]
+    fn set_max(&mut self, max: Option<f64>) -> PyResult<()> {
+        self.max = max;
+        Ok(())
+    }
+
+    #[getter]
+    fn zero_threshold(&self) -> PyResult<f64> {
+        Ok(self.zero_threshold)
+    }
+
+    #[setter]
+    fn set_zero_threshold(&mut self, threshold: f64) -> PyResult<()> {
+        self.zero_threshold = threshold;
+        Ok(())
+    }
+}
+
+impl From<ExponentialHistogramDataPoint> for RExponentialHistogramDataPoint {
+    fn from(dp: ExponentialHistogramDataPoint) -> Self {
+        RExponentialHistogramDataPoint {
+            attributes: dp.attributes,
+            start_time_unix_nano: dp.start_time_unix_nano,
+            time_unix_nano: dp.time_unix_nano,
+            count: dp.count,
+            sum: dp.sum,
+            scale: dp.scale,
+            zero_count: dp.zero_count,
+            positive: dp.positive.map(|p| p.into()),
+            negative: dp.negative.map(|n| n.into()),
+            flags: dp.flags,
+            exemplars: dp.exemplars,
+            min: dp.min,
+            max: dp.max,
+            zero_threshold: dp.zero_threshold,
+        }
+    }
+}
+
+impl From<RExponentialHistogramDataPoint> for ExponentialHistogramDataPoint {
+    fn from(dp: RExponentialHistogramDataPoint) -> Self {
+        ExponentialHistogramDataPoint {
+            attributes: dp.attributes.clone(),
+            start_time_unix_nano: dp.start_time_unix_nano,
+            time_unix_nano: dp.time_unix_nano,
+            count: dp.count,
+            sum: dp.sum,
+            scale: dp.scale,
+            zero_count: dp.zero_count,
+            positive: dp.positive.map(|p| p.into()),
+            negative: dp.negative.map(|n| n.into()),
+            flags: dp.flags,
+            exemplars: dp.exemplars.clone(),
+            min: dp.min,
+            max: dp.max,
+            zero_threshold: dp.zero_threshold,
+        }
+    }
+}
+
+// --- PyO3 Bindings for RExponentialHistogramBuckets ---
+#[pyclass]
+#[derive(Clone)]
+pub struct ExponentialHistogramBuckets {
+    pub offset: i32,
+    pub bucket_counts: Vec<u64>,
+}
+
+#[pymethods]
+impl ExponentialHistogramBuckets {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(ExponentialHistogramBuckets {
+            offset: 0,
+            bucket_counts: vec![],
+        })
+    }
+
+    #[getter]
+    fn offset(&self) -> PyResult<i32> {
+        Ok(self.offset)
+    }
+
+    #[setter]
+    fn set_offset(&mut self, offset: i32) -> PyResult<()> {
+        self.offset = offset;
+        Ok(())
+    }
+
+    #[getter]
+    fn bucket_counts(&self) -> PyResult<Vec<u64>> {
+        Ok(self.bucket_counts.clone())
+    }
+
+    #[setter]
+    fn set_bucket_counts(&mut self, bucket_counts: Vec<u64>) -> PyResult<()> {
+        self.bucket_counts = bucket_counts;
+        Ok(())
+    }
+}
+
+impl From<ExponentialHistogramBuckets> for RExponentialHistogramBuckets {
+    fn from(b: ExponentialHistogramBuckets) -> Self {
+        RExponentialHistogramBuckets {
+            offset: b.offset,
+            bucket_counts: b.bucket_counts,
+        }
+    }
+}
+
+impl From<RExponentialHistogramBuckets> for ExponentialHistogramBuckets {
+    fn from(b: RExponentialHistogramBuckets) -> Self {
+        ExponentialHistogramBuckets {
+            offset: b.offset,
+            bucket_counts: b.bucket_counts,
+        }
+    }
+}
+
+// --- PyO3 Bindings for SummaryDataPointList ---
+#[pyclass]
+pub struct SummaryDataPointList(Arc<Mutex<Vec<Arc<Mutex<RSummaryDataPoint>>>>>);
+
+#[pymethods]
+impl SummaryDataPointList {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<SummaryDataPointListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = SummaryDataPointListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<SummaryDataPoint> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item_lock = item.lock().unwrap();
+                Ok(SummaryDataPoint {
+                    attributes: item_lock.attributes.clone(),
+                    start_time_unix_nano: item_lock.start_time_unix_nano,
+                    time_unix_nano: item_lock.time_unix_nano,
+                    count: item_lock.count,
+                    sum: item_lock.sum,
+                    quantile_values: item_lock
+                        .quantile_values
+                        .clone()
+                        .into_iter()
+                        .map(|v| v.into())
+                        .collect(),
+                    flags: item_lock.flags,
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &SummaryDataPoint) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner[index] = Arc::new(Mutex::new(value.to_owned().into()));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &SummaryDataPoint) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(item.to_owned().into())));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct SummaryDataPointListIter {
+    inner: vec::IntoIter<Arc<Mutex<RSummaryDataPoint>>>,
+}
+
+#[pymethods]
+impl SummaryDataPointListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<SummaryDataPoint>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(SummaryDataPoint {
+            attributes: inner.attributes.clone(),
+            start_time_unix_nano: inner.start_time_unix_nano,
+            time_unix_nano: inner.time_unix_nano,
+            count: inner.count,
+            sum: inner.sum,
+            quantile_values: inner
+                .quantile_values
+                .clone()
+                .into_iter()
+                .map(|v| v.into())
+                .collect(),
+            flags: inner.flags,
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RSummaryDataPoint ---
+#[pyclass]
+#[derive(Clone)]
+pub struct SummaryDataPoint {
+    pub attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub start_time_unix_nano: u64,
+    pub time_unix_nano: u64,
+    pub count: u64,
+    pub sum: f64,
+    pub quantile_values: Vec<ValueAtQuantile>,
+    pub flags: u32,
+}
+
+#[pymethods]
+impl SummaryDataPoint {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(SummaryDataPoint {
+            attributes: Arc::new(Mutex::new(vec![])),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
+            count: 0,
+            sum: 0.0,
+            quantile_values: vec![],
+            flags: 0,
+        })
+    }
+
+    #[getter]
+    fn attributes(&self) -> PyResult<AttributesList> {
+        Ok(AttributesList(self.attributes.clone()))
+    }
+
+    #[setter]
+    fn set_attributes(&mut self, attributes: Vec<KeyValue>) -> PyResult<()> {
+        let mut inner = self.attributes.lock().map_err(handle_poison_error)?;
+        inner.clear();
+        for kv in attributes {
+            let kv_lock = kv.inner.lock().map_err(handle_poison_error).unwrap();
+            inner.push(kv_lock.clone());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn start_time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.start_time_unix_nano)
+    }
+
+    #[setter]
+    fn set_start_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.start_time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.time_unix_nano)
+    }
+
+    #[setter]
+    fn set_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn count(&self) -> PyResult<u64> {
+        Ok(self.count)
+    }
+
+    #[setter]
+    fn set_count(&mut self, count: u64) -> PyResult<()> {
+        self.count = count;
+        Ok(())
+    }
+
+    #[getter]
+    fn sum(&self) -> PyResult<f64> {
+        Ok(self.sum)
+    }
+
+    #[setter]
+    fn set_sum(&mut self, sum: f64) -> PyResult<()> {
+        self.sum = sum;
+        Ok(())
+    }
+
+    #[getter]
+    fn quantile_values(&self) -> PyResult<Vec<ValueAtQuantile>> {
+        Ok(self.quantile_values.clone())
+    }
+
+    #[setter]
+    fn set_quantile_values(&mut self, values: Vec<ValueAtQuantile>) -> PyResult<()> {
+        self.quantile_values = values;
+        Ok(())
+    }
+
+    #[getter]
+    fn flags(&self) -> PyResult<u32> {
+        Ok(self.flags)
+    }
+
+    #[setter]
+    fn set_flags(&mut self, flags: u32) -> PyResult<()> {
+        self.flags = flags;
+        Ok(())
+    }
+}
+
+impl From<SummaryDataPoint> for RSummaryDataPoint {
+    fn from(dp: SummaryDataPoint) -> Self {
+        RSummaryDataPoint {
+            attributes: dp.attributes,
+            start_time_unix_nano: dp.start_time_unix_nano,
+            time_unix_nano: dp.time_unix_nano,
+            count: dp.count,
+            sum: dp.sum,
+            quantile_values: dp.quantile_values.into_iter().map(|v| v.into()).collect(),
+            flags: dp.flags,
+        }
+    }
+}
+
+// --- PyO3 Bindings for RValueAtQuantile ---
+#[pyclass]
+#[derive(Clone)]
+pub struct ValueAtQuantile {
+    pub inner: RValueAtQuantile, // This one was already direct, keeping as is
+}
+
+#[pymethods]
+impl ValueAtQuantile {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(ValueAtQuantile {
+            inner: RValueAtQuantile {
+                quantile: 0.0,
+                value: 0.0,
+            },
+        })
+    }
+
+    #[getter]
+    fn quantile(&self) -> PyResult<f64> {
+        Ok(self.inner.quantile)
+    }
+
+    #[setter]
+    fn set_quantile(&mut self, quantile: f64) -> PyResult<()> {
+        self.inner.quantile = quantile;
+        Ok(())
+    }
+
+    #[getter]
+    fn value(&self) -> PyResult<f64> {
+        Ok(self.inner.value)
+    }
+
+    #[setter]
+    fn set_value(&mut self, value: f64) -> PyResult<()> {
+        self.inner.value = value;
+        Ok(())
+    }
+}
+
+impl From<ValueAtQuantile> for RValueAtQuantile {
+    fn from(v: ValueAtQuantile) -> Self {
+        v.inner
+    }
+}
+
+impl From<RValueAtQuantile> for ValueAtQuantile {
+    fn from(v: RValueAtQuantile) -> Self {
+        ValueAtQuantile { inner: v }
+    }
+}
+
+// --- PyO3 Bindings for ExemplarList ---
+#[pyclass]
+pub struct ExemplarList(Arc<Mutex<Vec<Arc<Mutex<RExemplar>>>>>);
+
+#[pymethods]
+impl ExemplarList {
+    fn __iter__<'py>(&'py self, py: Python<'py>) -> PyResult<Py<ExemplarListIter>> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        let iter = ExemplarListIter {
+            inner: inner.clone().into_iter(),
+        };
+        Py::new(py, iter)
+    }
+
+    fn __getitem__(&self, index: usize) -> PyResult<Exemplar> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        match inner.get(index) {
+            Some(item) => {
+                let item_lock = item.lock().unwrap();
+                Ok(Exemplar {
+                    filtered_attributes: item_lock.filtered_attributes.clone(),
+                    time_unix_nano: item_lock.time_unix_nano,
+                    span_id: item_lock.span_id.clone(),
+                    trace_id: item_lock.trace_id.clone(),
+                    value: item_lock.value.clone().map(|v| match v {
+                        RExemplarValue::AsDouble(d) => ExemplarValue::AsDouble(d),
+                        RExemplarValue::AsInt(i) => ExemplarValue::AsInt(i),
+                    }),
+                })
+            }
+            None => Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            )),
+        }
+    }
+    fn __setitem__(&self, index: usize, value: &Exemplar) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner[index] = Arc::new(Mutex::new(value.to_owned().into()));
+        Ok(())
+    }
+    fn __delitem__(&self, index: usize) -> PyResult<()> {
+        let mut inner = self.0.lock().map_err(handle_poison_error)?;
+        if index >= inner.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
+                "Index out of bounds",
+            ));
+        }
+        inner.remove(index);
+        Ok(())
+    }
+    fn append(&self, item: &Exemplar) -> PyResult<()> {
+        let mut k = self.0.lock().map_err(handle_poison_error)?;
+        k.push(Arc::new(Mutex::new(item.to_owned().into())));
+        Ok(())
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        let inner = self.0.lock().map_err(handle_poison_error)?;
+        Ok(inner.len())
+    }
+}
+
+#[pyclass]
+pub struct ExemplarListIter {
+    inner: vec::IntoIter<Arc<Mutex<RExemplar>>>,
+}
+
+#[pymethods]
+impl ExemplarListIter {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Exemplar>> {
+        let item = slf.inner.next();
+        if item.is_none() {
+            return Ok(None);
+        }
+        let inner = item.unwrap();
+        let inner = inner.lock().unwrap();
+        Ok(Some(Exemplar {
+            filtered_attributes: inner.filtered_attributes.clone(),
+            time_unix_nano: inner.time_unix_nano,
+            span_id: inner.span_id.clone(),
+            trace_id: inner.trace_id.clone(),
+            value: inner.value.clone().map(|v| match v {
+                RExemplarValue::AsDouble(d) => ExemplarValue::AsDouble(d),
+                RExemplarValue::AsInt(i) => ExemplarValue::AsInt(i),
+            }),
+        }))
+    }
+}
+
+// --- PyO3 Bindings for RExemplar ---
+#[pyclass]
+#[derive(Clone)]
+pub struct Exemplar {
+    pub filtered_attributes: Arc<Mutex<Vec<RKeyValue>>>,
+    pub time_unix_nano: u64,
+    pub span_id: Vec<u8>,
+    pub trace_id: Vec<u8>,
+    pub value: Option<ExemplarValue>,
+}
+
+#[pymethods]
+impl Exemplar {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(Exemplar {
+            filtered_attributes: Arc::new(Mutex::new(vec![])),
+            time_unix_nano: 0,
+            span_id: vec![],
+            trace_id: vec![],
+            value: None,
+        })
+    }
+
+    #[getter]
+    fn filtered_attributes(&self) -> PyResult<AttributesList> {
+        Ok(AttributesList(self.filtered_attributes.clone()))
+    }
+
+    #[setter]
+    fn set_filtered_attributes(&mut self, attributes: Vec<KeyValue>) -> PyResult<()> {
+        let mut inner = self
+            .filtered_attributes
+            .lock()
+            .map_err(handle_poison_error)?;
+        inner.clear();
+        for kv in attributes {
+            let kv_lock = kv.inner.lock().map_err(handle_poison_error).unwrap();
+            inner.push(kv_lock.clone());
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn time_unix_nano(&self) -> PyResult<u64> {
+        Ok(self.time_unix_nano)
+    }
+
+    #[setter]
+    fn set_time_unix_nano(&mut self, time: u64) -> PyResult<()> {
+        self.time_unix_nano = time;
+        Ok(())
+    }
+
+    #[getter]
+    fn span_id(&self) -> PyResult<Vec<u8>> {
+        Ok(self.span_id.clone())
+    }
+
+    #[setter]
+    fn set_span_id(&mut self, id: Vec<u8>) -> PyResult<()> {
+        self.span_id = id;
+        Ok(())
+    }
+
+    #[getter]
+    fn trace_id(&self) -> PyResult<Vec<u8>> {
+        Ok(self.trace_id.clone())
+    }
+
+    #[setter]
+    fn set_trace_id(&mut self, id: Vec<u8>) -> PyResult<()> {
+        self.trace_id = id;
+        Ok(())
+    }
+
+    #[getter]
+    fn value(&self) -> PyResult<Option<ExemplarValue>> {
+        Ok(self.value.clone())
+    }
+
+    #[setter]
+    fn set_value(&mut self, value: Option<ExemplarValue>) -> PyResult<()> {
+        self.value = value;
+        Ok(())
+    }
+}
+
+impl From<Exemplar> for RExemplar {
+    fn from(e: Exemplar) -> Self {
+        RExemplar {
+            filtered_attributes: e.filtered_attributes,
+            time_unix_nano: e.time_unix_nano,
+            span_id: e.span_id,
+            trace_id: e.trace_id,
+            value: e.value.map(|v| match v {
+                ExemplarValue::AsDouble(d) => RExemplarValue::AsDouble(d),
+                ExemplarValue::AsInt(i) => RExemplarValue::AsInt(i),
+            }),
+        }
+    }
+}
+
+// --- PyO3 Bindings for RExemplarValue (Enum) ---
+#[pyclass]
+#[derive(Clone)]
+pub enum ExemplarValue {
+    AsDouble(f64),
+    AsInt(i64),
+}
+
+// --- PyO3 Bindings for RAggregationTemporality (Enum) ---
+#[pyclass]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AggregationTemporality {
+    Unspecified = 0,
+    Delta = 1,
+    Cumulative = 2,
+}
+
+#[pymethods]
+impl AggregationTemporality {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(AggregationTemporality::Unspecified)
+    }
+
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "AGGREGATION_TEMPORALITY_UNSPECIFIED",
+            Self::Delta => "AGGREGATION_TEMPORALITY_DELTA",
+            Self::Cumulative => "AGGREGATION_TEMPORALITY_CUMULATIVE",
+        }
+    }
+}
+
+impl From<i32> for AggregationTemporality {
+    fn from(value: i32) -> Self {
+        match value {
+            1 => AggregationTemporality::Delta,
+            2 => AggregationTemporality::Cumulative,
+            _ => AggregationTemporality::Unspecified,
+        }
+    }
+}
+impl From<AggregationTemporality> for i32 {
+    fn from(value: AggregationTemporality) -> i32 {
+        match value {
+            AggregationTemporality::Unspecified => 3,
+            AggregationTemporality::Delta => 1,
+            AggregationTemporality::Cumulative => 2,
+        }
+    }
+}
+
+// --- PyO3 Bindings for RDataPointFlags (Enum) ---
+#[pyclass]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum DataPointFlags {
+    DoNotUse = 0,
+    NoRecordedValueMask = 1,
+}
+
+#[pymethods]
+impl DataPointFlags {
+    #[new]
+    fn new() -> PyResult<Self> {
+        Ok(DataPointFlags::DoNotUse)
+    }
+
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::DoNotUse => "DATA_POINT_FLAGS_DO_NOT_USE",
+            Self::NoRecordedValueMask => "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK",
+        }
+    }
+}
+
+impl From<u32> for DataPointFlags {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => DataPointFlags::NoRecordedValueMask,
+            _ => DataPointFlags::DoNotUse,
+        }
+    }
+}
+
+impl From<DataPointFlags> for u32 {
+    fn from(value: DataPointFlags) -> Self {
+        match value {
+            DataPointFlags::DoNotUse => 0,
+            DataPointFlags::NoRecordedValueMask => 1,
+        }
+    }
+}

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -6,6 +6,10 @@ pub mod trace;
 
 use crate::py;
 use crate::py::common::KeyValue;
+use crate::py::metrics::{
+    AggregationTemporality, DataPointFlags, Exemplar, ExemplarValue, Gauge, Histogram,
+    HistogramDataPoint, Metric, MetricData, NumberDataPoint, NumberDataPointValue, Sum,
+};
 use py::common::*;
 use py::logs::*;
 use py::resource::*;
@@ -37,10 +41,12 @@ pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let resource_module = PyModule::new(open_telemetry_module.py(), "resource")?;
     let common_module = PyModule::new(open_telemetry_module.py(), "common")?;
     let logs_module = PyModule::new(open_telemetry_module.py(), "logs")?; // Added logs module
+    let metrics_module = PyModule::new(open_telemetry_module.py(), "metrics")?; // Added logs module
     let trace_v1_module = PyModule::new(trace_module.py(), "v1")?;
     let common_v1_module = PyModule::new(common_module.py(), "v1")?;
     let resource_v1_module = PyModule::new(resource_module.py(), "v1")?;
-    let logs_v1_module = PyModule::new(logs_module.py(), "v1")?; // Added logs v1 module
+    let logs_v1_module = PyModule::new(logs_module.py(), "v1")?;
+    let metrics_v1_module = PyModule::new(metrics_module.py(), "v1")?; // Added logs v1 module
 
     trace_module.add_submodule(&trace_v1_module)?;
     common_module.add_submodule(&common_v1_module)?;
@@ -91,6 +97,15 @@ pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
         .getattr("modules")?
         .set_item("rotel_sdk.open_telemetry.logs.v1", &logs_v1_module)?;
 
+    m.py()
+        .import("sys")?
+        .getattr("modules")?
+        .set_item("rotel_sdk.open_telemetry.metrics", &metrics_module)?;
+    m.py()
+        .import("sys")?
+        .getattr("modules")?
+        .set_item("rotel_sdk.open_telemetry.metrics.v1", &metrics_v1_module)?;
+
     common_v1_module.add_class::<AnyValue>()?;
     common_v1_module.add_class::<ArrayValue>()?;
     common_v1_module.add_class::<KeyValueList>()?;
@@ -113,6 +128,19 @@ pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
     logs_v1_module.add_class::<LogRecords>()?; // Added LogRecords class
     logs_v1_module.add_class::<LogRecord>()?; // Added LogRecord class
 
+    metrics_v1_module.add_class::<Metric>()?;
+    metrics_v1_module.add_class::<MetricData>()?;
+    metrics_v1_module.add_class::<Gauge>()?;
+    metrics_v1_module.add_class::<Sum>()?;
+    metrics_v1_module.add_class::<Histogram>()?;
+    metrics_v1_module.add_class::<NumberDataPoint>()?;
+    metrics_v1_module.add_class::<HistogramDataPoint>()?;
+    metrics_v1_module.add_class::<Exemplar>()?;
+    metrics_v1_module.add_class::<ExemplarValue>()?;
+    metrics_v1_module.add_class::<AggregationTemporality>()?;
+    metrics_v1_module.add_class::<DataPointFlags>()?;
+    metrics_v1_module.add_class::<NumberDataPointValue>()?;
+
     Ok(())
 }
 
@@ -121,15 +149,12 @@ pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
 mod tests {
     use super::*;
     use crate::model::common::RValue::*;
-    use crate::model::common::{RAnyValue, RKeyValue};
+    use crate::model::{otel_transform, py_transform};
+    use crate::py::metrics::ResourceMetrics;
     use chrono::Utc;
-    use opentelemetry_proto::tonic::common::v1::any_value::Value;
-    use opentelemetry_proto::tonic::trace::v1;
     use pyo3::ffi::c_str;
-    use std::collections::HashMap;
     use std::ffi::CString;
-    use std::sync::{Arc, Mutex, Once};
-    use utilities::otlp::FakeOTLP;
+    use std::sync::{Arc, Once};
 
     static INIT: Once = Once::new();
 
@@ -171,2385 +196,2712 @@ mod tests {
         Ok(())
     }
 
+    // #[test]
+    // fn test_read_any_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //
+    //     let pv = AnyValue {
+    //         inner: any_value_arc.clone(),
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> { run_script("read_value_test.py", py, pv) })
+    //         .unwrap();
+    //     let av = any_value_arc.lock().unwrap().clone().unwrap();
+    //     let avx = av.value.lock().unwrap().clone();
+    //     match avx.unwrap() {
+    //         StringValue(s) => {
+    //             assert_eq!(s, "foo");
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn write_string_any_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let pv = AnyValue {
+    //         inner: any_value_arc.clone(),
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> { run_script("write_string_value_test.py", py, pv) })
+    //         .unwrap();
+    //     let av = any_value_arc.lock().unwrap().clone().unwrap();
+    //     let avx = av.value.lock().unwrap().clone();
+    //     match avx.unwrap() {
+    //         StringValue(s) => {
+    //             assert_eq!(s, "changed");
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn write_bool_any_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //
+    //     let pv = AnyValue {
+    //         inner: any_value_arc.clone(),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> { run_script("write_bool_value_test.py", py, pv) })
+    //         .unwrap();
+    //     match arc_value.lock().unwrap().clone().unwrap() {
+    //         BoolValue(b) => {
+    //             assert!(b);
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn write_bytes_any_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //
+    //     let pv = AnyValue {
+    //         inner: any_value_arc.clone(),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> { run_script("write_bytes_value_test.py", py, pv) })
+    //         .unwrap();
+    //     match arc_value.lock().unwrap().clone().unwrap() {
+    //         BytesValue(b) => {
+    //             assert_eq!(b"111111".to_vec(), b);
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn read_key_value_key() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = KeyValue {
+    //         inner: Arc::new(Mutex::new(RKeyValue {
+    //             key: key.clone(),
+    //             value: any_value_arc.clone(),
+    //         })),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> { run_script("read_key_value_key_test.py", py, kv) })
+    //         .unwrap();
+    //     let av = key.clone().lock().unwrap().clone();
+    //     assert_eq!(av, "key".to_string());
+    //     println!("{:?}", av);
+    // }
+    //
+    // #[test]
+    // fn write_key_value_key() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = KeyValue {
+    //         inner: Arc::new(Mutex::new(RKeyValue {
+    //             key: key.clone(),
+    //             value: any_value_arc.clone(),
+    //         })),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("write_key_value_key_test.py", py, kv)
+    //     })
+    //     .unwrap();
+    //     let av = key.clone().lock().unwrap().clone();
+    //     assert_eq!(av, "new_key".to_string());
+    //     println!("{:?}", av);
+    // }
+    //
+    // #[test]
+    // fn read_key_value_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = KeyValue {
+    //         inner: Arc::new(Mutex::new(RKeyValue {
+    //             key: key.clone(),
+    //             value: any_value_arc.clone(),
+    //         })),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("read_key_value_value_test.py", py, kv)
+    //     })
+    //     .unwrap();
+    //     match arc_value.lock().unwrap().clone().unwrap() {
+    //         StringValue(s) => {
+    //             assert_eq!(s, "foo");
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn write_key_value_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = KeyValue {
+    //         inner: Arc::new(Mutex::new(RKeyValue {
+    //             key: key.clone(),
+    //             value: any_value_arc.clone(),
+    //         })),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("write_key_value_value_test.py", py, kv)
+    //     })
+    //     .unwrap();
+    //     match arc_value.lock().unwrap().clone().unwrap() {
+    //         StringValue(s) => {
+    //             assert_eq!(s, "changed");
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn write_key_value_bytes_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = KeyValue {
+    //         inner: Arc::new(Mutex::new(RKeyValue {
+    //             key: key.clone(),
+    //             value: any_value_arc.clone(),
+    //         })),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("write_key_value_bytes_value_test.py", py, kv)
+    //     })
+    //     .unwrap();
+    //     match arc_value.lock().unwrap().clone().unwrap() {
+    //         BytesValue(s) => {
+    //             assert_eq!(b"111111".to_vec(), s);
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn read_resource_attributes() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //
+    //     let resource = Resource {
+    //         attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("read_resource_attributes_test.py", py, resource)
+    //     })
+    //     .unwrap();
+    // }
+    //
+    // #[test]
+    // fn read_and_write_attributes_array_value() {
+    //     initialize();
+    //
+    //     let arc_value = Some(StringValue("foo".to_string()));
+    //     let any_value_arc = Some(RAnyValue {
+    //         value: Arc::new(Mutex::new(arc_value)),
+    //     });
+    //     let array_value = crate::model::common::RArrayValue {
+    //         values: Arc::new(Mutex::new(vec![Arc::new(Mutex::new(
+    //             any_value_arc.clone(),
+    //         ))])),
+    //     };
+    //     let array_value_arc = Arc::new(Mutex::new(Some(RVArrayValue(array_value))));
+    //     let any_value_array_value_wrapper = Some(RAnyValue {
+    //         value: array_value_arc.clone(),
+    //     });
+    //
+    //     let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
+    //
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_array_value_wrapper_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //     let attrs = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+    //
+    //     let resource = Resource {
+    //         attributes: attrs.clone(),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script(
+    //             "read_and_write_attributes_array_value_test.py",
+    //             py,
+    //             resource,
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let attrs = Arc::into_inner(attrs).unwrap();
+    //     let mut attrs = attrs.into_inner().unwrap();
+    //     let attr = Arc::into_inner(attrs.pop().unwrap()).unwrap();
+    //     let attr = attr.into_inner().unwrap();
+    //     let key = attr.key.lock().unwrap();
+    //     assert_eq!("my_array", *key);
+    //     let value = attr.value.lock().unwrap();
+    //     assert!(value.is_some());
+    //     let v = value.clone().unwrap();
+    //     let v = v.value.lock().unwrap();
+    //     assert!(v.is_some());
+    //     let v = v.clone().unwrap();
+    //     match v {
+    //         RVArrayValue(av) => {
+    //             println!("{:?}", av);
+    //             let mut vals = av.values.lock().unwrap();
+    //             let vv = vals.pop().unwrap();
+    //             let v = vv.lock().unwrap();
+    //             let v = v.clone().unwrap();
+    //             let v = v.value.clone().lock().unwrap().clone().unwrap();
+    //             match v {
+    //                 IntValue(v) => {
+    //                     assert_eq!(v, 123456789)
+    //                 }
+    //                 _ => panic!("wrong value type"),
+    //             }
+    //         }
+    //         _ => panic!("wrong value type"),
+    //     }
+    // }
+    //
+    // #[test]
+    // fn read_and_write_attributes_key_value_list_value() {
+    //     initialize();
+    //
+    //     let value = Some(StringValue("foo".to_string()));
+    //     let any_value = Some(RAnyValue {
+    //         value: Arc::new(Mutex::new(value)),
+    //     });
+    //     let any_value_arc = Arc::new(Mutex::new(any_value));
+    //     let arc_key = Arc::new(Mutex::new("inner_key".to_string()));
+    //
+    //     let kev_value = RKeyValue {
+    //         key: arc_key.clone(),
+    //         value: any_value_arc.clone(),
+    //     };
+    //
+    //     let kv_list = crate::model::common::RKeyValueList {
+    //         values: Arc::new(Mutex::new(vec![kev_value])),
+    //     };
+    //
+    //     let array_value_arc = Arc::new(Mutex::new(Some(KvListValue(kv_list))));
+    //     let any_value_array_value_wrapper = Some(RAnyValue {
+    //         value: array_value_arc.clone(),
+    //     });
+    //
+    //     let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
+    //
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_array_value_wrapper_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //
+    //     let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+    //     let resource = Resource {
+    //         attributes: attrs_arc.clone(),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script(
+    //             "read_and_write_attributes_key_value_list_test.py",
+    //             py,
+    //             resource,
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let mut value = attrs_arc.lock().unwrap();
+    //     let value = value.pop().unwrap();
+    //     let value = Arc::into_inner(value).unwrap().into_inner().unwrap();
+    //     let value = Arc::into_inner(value.value).unwrap().into_inner().unwrap();
+    //     let value = value.unwrap().value;
+    //     let value = Arc::into_inner(value)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap()
+    //         .unwrap();
+    //     match value {
+    //         KvListValue(k) => {
+    //             let mut value = k.values.lock().unwrap().clone();
+    //             let value = value.pop();
+    //             match value {
+    //                 None => {
+    //                     panic!("wrong type")
+    //                 }
+    //                 Some(v) => {
+    //                     let v = v.value.lock().unwrap().clone();
+    //                     match v {
+    //                         None => {
+    //                             panic!("wrong type")
+    //                         }
+    //                         Some(v) => {
+    //                             let value = v.value.lock().unwrap().clone().unwrap();
+    //                             match value {
+    //                                 IntValue(i) => assert_eq!(100, i),
+    //                                 _ => panic!("wrong type"),
+    //                             }
+    //                         }
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    // }
+    //
+    // #[test]
+    // fn write_resource_attributes_key_value_key() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //
+    //     let resource = Resource {
+    //         attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script(
+    //             "write_resource_attributes_key_value_key_test.py",
+    //             py,
+    //             resource,
+    //         )
+    //     })
+    //     .unwrap();
+    //     let av = key.clone().lock().unwrap().clone();
+    //     assert_eq!(av, "new_key".to_string());
+    //     println!("{:?}", av);
+    // }
+    //
+    // #[test]
+    // fn write_resource_attributes_key_value_value() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //
+    //     let resource = Resource {
+    //         attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script(
+    //             "write_resource_attributes_key_value_value_test.py",
+    //             py,
+    //             resource,
+    //         )
+    //     })
+    //     .unwrap();
+    //     match arc_value.lock().unwrap().clone().unwrap() {
+    //         StringValue(s) => {
+    //             assert_eq!(s, "changed");
+    //         }
+    //         _ => panic!("wrong type"),
+    //     }
+    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    // }
+    //
+    // #[test]
+    // fn resource_attributes_append_attribute() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //     let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+    //     let resource = Resource {
+    //         attributes: attrs_arc.clone(),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("resource_attributes_append_attribute.py", py, resource)
+    //     })
+    //     .unwrap();
+    //     println!("{:#?}", attrs_arc.lock().unwrap());
+    // }
+    //
+    // #[test]
+    // fn resource_attributes_set_attributes() {
+    //     initialize();
+    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+    //         value: arc_value.clone(),
+    //     })));
+    //     let key = Arc::new(Mutex::new("key".to_string()));
+    //
+    //     let kv = RKeyValue {
+    //         key: key.clone(),
+    //         value: any_value_arc.clone(),
+    //     };
+    //
+    //     let kv_arc = Arc::new(Mutex::new(kv));
+    //     let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+    //     let resource = Resource {
+    //         attributes: attrs_arc.clone(),
+    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
+    //     };
+    //
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("resource_attributes_set_attributes.py", py, resource)
+    //     })
+    //     .unwrap();
+    //     println!("{:#?}", attrs_arc.lock().unwrap());
+    //     let attrs = attrs_arc.lock().unwrap();
+    //     assert_eq!(2, attrs.len());
+    //     for kv in attrs.iter() {
+    //         let guard = kv.lock();
+    //         let kv_guard = guard.unwrap();
+    //         let key = kv_guard.key.lock().unwrap().to_string();
+    //         let value = kv_guard.value.lock().unwrap();
+    //         assert_ne!(key, "key");
+    //         assert!(key == "double.value" || key == "os.version");
+    //         assert!(value.is_some());
+    //         let av = value.clone().unwrap();
+    //         let value = av.value.lock().unwrap();
+    //         assert!(value.is_some());
+    //     }
+    // }
+    //
+    // #[test]
+    // fn resource_spans_append_attributes() {
+    //     initialize();
+    //     let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: Arc::new(Mutex::new(vec![])),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("resource_spans_append_attribute.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //     println!("{:#?}", resource_spans.resource.lock().unwrap());
+    // }
+    //
+    // #[test]
+    // fn resource_spans_iterate_spans() {
+    //     initialize();
+    //     let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("resource_spans_iterate_spans.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //     println!("{:#?}", resource_spans.resource.lock().unwrap());
+    // }
+    //
+    // #[test]
+    // fn read_and_write_instrumentation_scope() {
+    //     initialize();
+    //     let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script(
+    //             "read_and_write_instrumentation_scope_test.py",
+    //             py,
+    //             py_resource_spans,
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let scope_spans = scope_spans.pop().unwrap();
+    //     let scope = scope_spans.scope.unwrap();
+    //     assert_eq!("name_changed", scope.name);
+    //     assert_eq!("0.0.2", scope.version);
+    //     assert_eq!(100, scope.dropped_attributes_count);
+    //     assert_eq!(scope.attributes.len(), 2);
+    //     for attr in &scope.attributes {
+    //         let value = attr.value.clone().unwrap();
+    //         let value = value.value.unwrap();
+    //         match attr.key.as_str() {
+    //             "key_changed" => match value {
+    //                 opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i) => {
+    //                     assert_eq!(i, 200);
+    //                 }
+    //                 _ => {
+    //                     panic!("wrong type for key_changed: {:?}", value);
+    //                 }
+    //             },
+    //             "severity" => match value {
+    //                 opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
+    //                     assert_eq!(s, "WARN");
+    //                 }
+    //                 _ => {
+    //                     panic!("wrong type for severity: {:?}", value);
+    //                 }
+    //             },
+    //             _ => {
+    //                 panic!("unexpected key")
+    //             }
+    //         }
+    //     }
+    // }
+    // #[test]
+    // fn set_instrumentation_scope() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("set_instrumentation_scope_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let scope_spans = scope_spans.pop().unwrap();
+    //     let scope = scope_spans.scope.unwrap();
+    //     assert_eq!("name_changed", scope.name);
+    //     assert_eq!("0.0.2", scope.version);
+    //     assert_eq!(100, scope.dropped_attributes_count);
+    //     assert_eq!(scope.attributes.len(), 1);
+    //     for attr in &scope.attributes {
+    //         let value = attr.value.clone().unwrap();
+    //         let value = value.value.unwrap();
+    //         match attr.key.as_str() {
+    //             "severity" => match value {
+    //                 Value::StringValue(s) => {
+    //                     assert_eq!(s, "WARN");
+    //                 }
+    //                 _ => {
+    //                     panic!("wrong type for severity: {:?}", value);
+    //                 }
+    //             },
+    //             _ => {
+    //                 panic!("unexpected key")
+    //             }
+    //         }
+    //     }
+    // }
+    //
+    // #[test]
+    // fn read_and_write_spans() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("read_and_write_spans_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let resource = Arc::into_inner(resource_spans.resource);
+    //     let resource = resource.unwrap().into_inner().unwrap().unwrap();
+    //     let dropped = Arc::into_inner(resource.dropped_attributes_count);
+    //     let dropped = dropped.unwrap().into_inner().unwrap();
+    //
+    //     assert_eq!(15, dropped);
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let mut scope_spans = scope_spans.pop().unwrap();
+    //     let mut span = scope_spans.spans.pop().unwrap();
+    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
+    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
+    //     assert_eq!("test=1234567890", span.trace_state);
+    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+    //     assert_eq!(1, span.flags);
+    //     assert_eq!("py_processed_span", span.name);
+    //     assert_eq!(4, span.kind);
+    //     assert_eq!(1234567890, span.start_time_unix_nano);
+    //     assert_eq!(1234567890, span.end_time_unix_nano);
+    //     assert_eq!(100, span.dropped_attributes_count);
+    //     assert_eq!(200, span.dropped_events_count);
+    //     assert_eq!(300, span.dropped_links_count);
+    //     assert_eq!("error message", span.status.clone().unwrap().message);
+    //     assert_eq!(2, span.status.unwrap().code);
+    //     assert_eq!(1, span.events.len());
+    //     assert_eq!("py_processed_event", span.events[0].name);
+    //     assert_eq!(1234567890, span.events[0].time_unix_nano);
+    //     assert_eq!(400, span.events[0].dropped_attributes_count);
+    //     assert_eq!(1, span.events[0].attributes.len());
+    //     assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
+    //     let value = span.events[0].attributes[0]
+    //         .value
+    //         .clone()
+    //         .unwrap()
+    //         .value
+    //         .unwrap();
+    //     match value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!("event_attr_value", s)
+    //         }
+    //         _ => panic!("unexpected type"),
+    //     }
+    //
+    //     assert_eq!(2, span.links.len());
+    //     // get the newly added link
+    //     let new_link = span.links.remove(1);
+    //     assert_eq!(b"88888888".to_vec(), new_link.trace_id);
+    //     assert_eq!(b"99999999".to_vec(), new_link.span_id);
+    //     assert_eq!("test=1234567890", new_link.trace_state);
+    //     assert_eq!(300, new_link.dropped_attributes_count);
+    //     assert_eq!(1, new_link.flags);
+    //     assert_eq!(1, new_link.attributes.len());
+    //     let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
+    //     match value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!("link_attr_value", s)
+    //         }
+    //         _ => panic!("unexpected type"),
+    //     }
+    //
+    //     assert_eq!(3, span.attributes.len());
+    //     let new_attr = span.attributes.remove(2);
+    //     assert_eq!("span_attr_key2", new_attr.key);
+    //     let value = new_attr.value.clone().unwrap().value.unwrap();
+    //     match value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!("span_attr_value2", s)
+    //         }
+    //         _ => panic!("unexpected type"),
+    //     }
+    // }
+    // #[test]
+    // fn set_scope_spans_span_test() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("set_scope_spans_span_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let mut scope_spans = scope_spans.pop().unwrap();
+    //     let mut span = scope_spans.spans.pop().unwrap();
+    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
+    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
+    //     assert_eq!("test=1234567890", span.trace_state);
+    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+    //     assert_eq!(1, span.flags);
+    //     assert_eq!("py_processed_span", span.name);
+    //     assert_eq!(4, span.kind);
+    //     assert_eq!(1234567890, span.start_time_unix_nano);
+    //     assert_eq!(1234567890, span.end_time_unix_nano);
+    //     assert_eq!(100, span.dropped_attributes_count);
+    //     assert_eq!(200, span.dropped_events_count);
+    //     assert_eq!(300, span.dropped_links_count);
+    //     assert_eq!("error message", span.status.clone().unwrap().message);
+    //     assert_eq!(2, span.status.unwrap().code);
+    //     assert_eq!(1, span.events.len());
+    //     assert_eq!("py_processed_event", span.events[0].name);
+    //     assert_eq!(1234567890, span.events[0].time_unix_nano);
+    //     assert_eq!(400, span.events[0].dropped_attributes_count);
+    //     assert_eq!(1, span.events[0].attributes.len());
+    //     assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
+    //     let value = span.events[0].attributes[0]
+    //         .value
+    //         .clone()
+    //         .unwrap()
+    //         .value
+    //         .unwrap();
+    //     match value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!("event_attr_value", s)
+    //         }
+    //         _ => panic!("unexpected type"),
+    //     }
+    //
+    //     assert_eq!(1, span.links.len());
+    //     // get the newly added link
+    //     let new_link = span.links.remove(0);
+    //     assert_eq!(b"88888888".to_vec(), new_link.trace_id);
+    //     assert_eq!(b"99999999".to_vec(), new_link.span_id);
+    //     assert_eq!("test=1234567890", new_link.trace_state);
+    //     assert_eq!(300, new_link.dropped_attributes_count);
+    //     assert_eq!(1, new_link.flags);
+    //     assert_eq!(1, new_link.attributes.len());
+    //     let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
+    //     match value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!("link_attr_value", s)
+    //         }
+    //         _ => panic!("unexpected type"),
+    //     }
+    //
+    //     assert_eq!(1, span.attributes.len());
+    //     let new_attr = span.attributes.remove(0);
+    //     assert_eq!("span_attr_key", new_attr.key);
+    //     let value = new_attr.value.clone().unwrap().value.unwrap();
+    //     match value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!("span_attr_value", s)
+    //         }
+    //         _ => panic!("unexpected type"),
+    //     }
+    // }
+    // #[test]
+    // fn set_resource_spans_resource() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script(
+    //             "write_resource_spans_resource_test.py",
+    //             py,
+    //             py_resource_spans,
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let resource = Arc::into_inner(resource_spans.resource).unwrap();
+    //     let resource = resource.into_inner().unwrap().unwrap();
+    //     let resource = crate::model::py_transform::transform_resource(resource).unwrap();
+    //     assert_eq!(2, resource.attributes.len());
+    //     assert_eq!(35, resource.dropped_attributes_count);
+    //     for attr in &resource.attributes {
+    //         match attr.key.as_str() {
+    //             "key" => assert_eq!(
+    //                 Value::StringValue("value".to_string()),
+    //                 attr.value.clone().unwrap().value.unwrap()
+    //             ),
+    //             "boolean" => assert_eq!(
+    //                 Value::BoolValue(true),
+    //                 attr.value.clone().unwrap().value.unwrap()
+    //             ),
+    //             _ => panic!("unexpected attribute key"),
+    //         }
+    //     }
+    // }
+    // #[test]
+    // fn set_span_events() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("write_span_events_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let mut scope_spans = scope_spans.pop().unwrap();
+    //     let span = scope_spans.spans.pop().unwrap();
+    //
+    //     assert_eq!(2, span.events.len());
+    //     let event = &span.events[0];
+    //     assert_eq!("first_event", event.name);
+    //     assert_eq!(123, event.time_unix_nano);
+    //     assert_eq!(1, event.dropped_attributes_count);
+    //     assert_eq!(1, event.attributes.len());
+    //     let attr = &event.attributes[0];
+    //     assert_eq!("first_event_attr_key", attr.key);
+    //     assert_eq!(
+    //         Value::StringValue("first_event_attr_value".to_string()),
+    //         attr.value.clone().unwrap().value.unwrap()
+    //     );
+    //
+    //     let event = &span.events[1];
+    //     assert_eq!("second_event", event.name);
+    //     assert_eq!(456, event.time_unix_nano);
+    //     assert_eq!(2, event.dropped_attributes_count);
+    //     assert_eq!(1, event.attributes.len());
+    //     let attr = &event.attributes[0];
+    //     assert_eq!("second_event_attr_key", attr.key);
+    //     assert_eq!(
+    //         Value::StringValue("second_event_attr_value".to_string()),
+    //         attr.value.clone().unwrap().value.unwrap()
+    //     )
+    // }
+    // #[test]
+    // fn set_scope_spans() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("write_scope_spans_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let mut scope_spans = scope_spans.pop().unwrap();
+    //     assert_eq!(
+    //         "https://github.com/streamfold/rotel",
+    //         scope_spans.schema_url
+    //     );
+    //     let inst_scope = scope_spans.scope.unwrap();
+    //     assert_eq!("rotel-sdk-new", inst_scope.name);
+    //     assert_eq!("v1.0.1", inst_scope.version);
+    //     let attr = &inst_scope.attributes[0];
+    //     assert_eq!("rotel-sdk", attr.key);
+    //     assert_eq!(
+    //         Value::StringValue("v1.0.0".to_string()),
+    //         attr.value.clone().unwrap().value.unwrap()
+    //     );
+    //
+    //     let span = scope_spans.spans.pop().unwrap();
+    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
+    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
+    //     assert_eq!("test=1234567890", span.trace_state);
+    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+    //     assert_eq!(1, span.flags);
+    //     assert_eq!("py_processed_span", span.name);
+    //     assert_eq!(4, span.kind);
+    //     assert_eq!(1234567890, span.start_time_unix_nano);
+    //     assert_eq!(1234567890, span.end_time_unix_nano);
+    //     let attr = &span.attributes[0];
+    //     assert_eq!("span_attr_key", attr.key);
+    //     assert_eq!(
+    //         Value::StringValue("span_attr_value".to_string()),
+    //         attr.value.clone().unwrap().value.unwrap()
+    //     );
+    // }
+    //
+    // #[test]
+    // fn set_spans() {
+    //     initialize();
+    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         export_req.resource_spans[0].clone(),
+    //     );
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: resource_spans.resource.clone(),
+    //         scope_spans: resource_spans.scope_spans.clone(),
+    //         schema_url: resource_spans.schema_url,
+    //     };
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("write_spans_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+    //
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     let mut scope_spans = scope_spans.pop().unwrap();
+    //     let span = scope_spans.spans.pop().unwrap();
+    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
+    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
+    //     assert_eq!("test=1234567890", span.trace_state);
+    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+    //     assert_eq!(1, span.flags);
+    //     assert_eq!("py_processed_span", span.name);
+    //     assert_eq!(4, span.kind);
+    //     assert_eq!(1234567890, span.start_time_unix_nano);
+    //     assert_eq!(1234567890, span.end_time_unix_nano);
+    //     let attr = &span.attributes[0];
+    //     assert_eq!("span_attr_key", attr.key);
+    //     assert_eq!(
+    //         Value::StringValue("span_attr_value".to_string()),
+    //         attr.value.clone().unwrap().value.unwrap()
+    //     );
+    // }
+    //
+    // #[test]
+    // fn read_and_write_log_record() {
+    //     initialize();
+    //
+    //     // Create a mock ResourceLogs protobuf object for testing
+    //     // In a real scenario, you might use a utility like FakeOTLP if available for logs.
+    //     let initial_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
+    //         time_unix_nano: 1000000000,
+    //         observed_time_unix_nano: 1000000001,
+    //         severity_number: 9, // INFO
+    //         severity_text: "INFO".to_string(),
+    //         body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //             value: Some(Value::StringValue("initial log message".to_string())),
+    //         }),
+    //         attributes: vec![
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "log.source".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::StringValue("my_app".to_string())),
+    //                 }),
+    //             },
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "component".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::StringValue("backend".to_string())),
+    //                 }),
+    //             },
+    //         ],
+    //         dropped_attributes_count: 0,
+    //         flags: 0,
+    //         trace_id: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    //         span_id: vec![17, 18, 19, 20, 21, 22, 23, 24],
+    //         event_name: "".to_string(),
+    //     };
+    //
+    //     let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
+    //         scope: Some(
+    //             opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+    //                 name: "test-instrumentation-scope".to_string(),
+    //                 version: "1.0.0".to_string(),
+    //                 attributes: vec![],
+    //                 dropped_attributes_count: 0,
+    //             },
+    //         ),
+    //         log_records: vec![initial_log_record],
+    //         schema_url: "http://example.com/logs-schema".to_string(),
+    //     };
+    //
+    //     let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+    //         resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
+    //             attributes: vec![],
+    //             dropped_attributes_count: 0,
+    //         }),
+    //         scope_logs: vec![initial_scope_logs],
+    //         schema_url: "http://example.com/resource-logs-schema".to_string(),
+    //     };
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs =
+    //         crate::model::otel_transform::transform_resource_logs(export_req.clone());
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("read_and_write_logs_test.py", py, py_resource_logs)
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //
+    //     // Assert the changes made by the Python script
+    //     assert_eq!(transformed_scope_logs.len(), 1);
+    //     let mut scope_log = transformed_scope_logs.remove(0);
+    //     assert_eq!(scope_log.log_records.len(), 1);
+    //     let log_record = scope_log.log_records.remove(0);
+    //
+    //     assert_eq!(log_record.time_unix_nano, 2000000000);
+    //     assert_eq!(log_record.observed_time_unix_nano, 2000000001);
+    //     assert_eq!(log_record.severity_number, 13);
+    //     assert_eq!(log_record.severity_text, "ERROR");
+    //
+    //     let body_value = log_record.body.unwrap().value.unwrap();
+    //     match body_value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!(s, "processed log message");
+    //         }
+    //         _ => panic!("Body value is not a string"),
+    //     }
+    //
+    //     assert_eq!(log_record.dropped_attributes_count, 5);
+    //     assert_eq!(log_record.flags, 1);
+    //     assert_eq!(log_record.trace_id, b"abcdefghijklmnop".to_vec());
+    //     assert_eq!(log_record.span_id, b"qrstuvwx".to_vec());
+    //
+    //     assert_eq!(log_record.attributes.len(), 3);
+    //     // Verify the new attribute
+    //     let new_attr = &log_record.attributes[2];
+    //     assert_eq!(new_attr.key, "new_log_attr");
+    //     assert_eq!(
+    //         new_attr.value.clone().unwrap().value.unwrap(),
+    //         Value::StringValue("new_log_value".to_string())
+    //     );
+    //
+    //     // Verify the modified attribute
+    //     let modified_attr = &log_record.attributes[1];
+    //     assert_eq!(modified_attr.key, "component");
+    //     assert_eq!(
+    //         modified_attr.value.clone().unwrap().value.unwrap(),
+    //         Value::StringValue("modified_component_value".to_string())
+    //     );
+    // }
+    //
+    // #[test]
+    // fn add_new_log_record() {
+    //     initialize();
+    //
+    //     // Create a mock ResourceLogs protobuf object with an empty ScopeLogs initially
+    //     let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
+    //         scope: Some(
+    //             opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+    //                 name: "test-instrumentation-scope".to_string(),
+    //                 version: "1.0.0".to_string(),
+    //                 attributes: vec![],
+    //                 dropped_attributes_count: 0,
+    //             },
+    //         ),
+    //         log_records: vec![], // Start with no log records
+    //         schema_url: "http://example.com/logs-schema".to_string(),
+    //     };
+    //
+    //     let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+    //         resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
+    //             attributes: vec![],
+    //             dropped_attributes_count: 0,
+    //         }),
+    //         scope_logs: vec![initial_scope_logs],
+    //         schema_url: "http://example.com/resource-logs-schema".to_string(),
+    //     };
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs =
+    //         crate::model::otel_transform::transform_resource_logs(export_req.clone());
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that adds a new log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("add_log_record_test.py", py, py_resource_logs)
+    //     })
+    //     .unwrap();
+    //
+    //     // Transform the modified RResourceLogs back into protobuf format
+    //     let mut resource = r_resource_logs.resource.lock().unwrap();
+    //     let _resource_proto = resource
+    //         .take()
+    //         .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
+    //
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //
+    //     // Assert the changes made by the Python script
+    //     assert_eq!(transformed_scope_logs.len(), 1);
+    //     let mut scope_log = transformed_scope_logs.remove(0);
+    //     assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
+    //     let log_record = scope_log.log_records.remove(0);
+    //
+    //     assert_eq!(log_record.time_unix_nano, 9876543210);
+    //     assert_eq!(log_record.observed_time_unix_nano, 9876543211);
+    //     assert_eq!(log_record.severity_number, 17); // FATAL
+    //     assert_eq!(log_record.severity_text, "FATAL");
+    //
+    //     let body_value = log_record.body.unwrap().value.unwrap();
+    //     match body_value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!(s, "This is a newly added log message.");
+    //         }
+    //         _ => panic!("Body value is not a string"),
+    //     }
+    //
+    //     assert_eq!(log_record.attributes.len(), 1);
+    //     let new_attr = &log_record.attributes[0];
+    //     assert_eq!(new_attr.key, "new_log_key");
+    //     assert_eq!(
+    //         new_attr.value.clone().unwrap().value.unwrap(),
+    //         Value::StringValue("new_log_value".to_string())
+    //     );
+    //
+    //     assert_eq!(log_record.dropped_attributes_count, 2);
+    //     assert_eq!(log_record.flags, 4);
+    //     assert_eq!(log_record.trace_id, b"fedcba9876543210".to_vec());
+    //     assert_eq!(log_record.span_id, b"fedcba98".to_vec());
+    // }
+    //
+    // #[test]
+    // fn remove_log_record_test() {
+    //     initialize();
+    //
+    //     // Create a mock ResourceLogs protobuf object with two initial LogRecords
+    //     let first_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
+    //         time_unix_nano: 1000000000,
+    //         observed_time_unix_nano: 1000000001,
+    //         severity_number: 9, // INFO
+    //         severity_text: "INFO".to_string(),
+    //         body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //             value: Some(
+    //                 opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+    //                     "first log message".to_string(),
+    //                 ),
+    //             ),
+    //         }),
+    //         attributes: vec![],
+    //         dropped_attributes_count: 0,
+    //         flags: 0,
+    //         trace_id: vec![],
+    //         span_id: vec![],
+    //         event_name: "first_event".to_string(),
+    //     };
+    //
+    //     let second_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
+    //         time_unix_nano: 2000000000,
+    //         observed_time_unix_nano: 2000000001,
+    //         severity_number: 13, // ERROR
+    //         severity_text: "ERROR".to_string(),
+    //         body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //             value: Some(Value::StringValue("second log message".to_string())),
+    //         }),
+    //         attributes: vec![],
+    //         dropped_attributes_count: 0,
+    //         flags: 0,
+    //         trace_id: vec![],
+    //         span_id: vec![],
+    //         event_name: "second_event".to_string(),
+    //     };
+    //
+    //     let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
+    //         scope: Some(
+    //             opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+    //                 name: "test-instrumentation-scope".to_string(),
+    //                 version: "1.0.0".to_string(),
+    //                 attributes: vec![],
+    //                 dropped_attributes_count: 0,
+    //             },
+    //         ),
+    //         log_records: vec![first_log_record, second_log_record], // Two log records
+    //         schema_url: "http://example.com/logs-schema".to_string(),
+    //     };
+    //
+    //     let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+    //         resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
+    //             attributes: vec![],
+    //             dropped_attributes_count: 0,
+    //         }),
+    //         scope_logs: vec![initial_scope_logs],
+    //         schema_url: "http://example.com/resource-logs-schema".to_string(),
+    //     };
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs =
+    //         crate::model::otel_transform::transform_resource_logs(export_req.clone());
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("remove_log_record_test.py", py, py_resource_logs)
+    //     })
+    //     .unwrap();
+    //
+    //     // Transform the modified RResourceLogs back into protobuf format
+    //     let mut resource = r_resource_logs.resource.lock().unwrap();
+    //     let _resource_proto = resource
+    //         .take()
+    //         .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
+    //
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //
+    //     // Assert the changes made by the Python script
+    //     assert_eq!(transformed_scope_logs.len(), 1);
+    //     let mut scope_log = transformed_scope_logs.remove(0);
+    //     assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
+    //     let log_record = scope_log.log_records.remove(0);
+    //
+    //     // Verify that the correct log record remains
+    //     let body_value = log_record.body.unwrap().value.unwrap();
+    //     match body_value {
+    //         Value::StringValue(s) => {
+    //             assert_eq!(s, "first log message");
+    //         }
+    //         _ => panic!("Body value is not the expected string"),
+    //     }
+    // }
+    //
+    // #[test]
+    // fn traces_delitem_test() {
+    //     initialize();
+    //     let av = opentelemetry_proto::tonic::common::v1::ArrayValue {
+    //         values: vec![
+    //             opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("first value".to_string())),
+    //             },
+    //             opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("second value".to_string())),
+    //             },
+    //         ],
+    //     };
+    //     let kvlist = opentelemetry_proto::tonic::common::v1::KeyValueList {
+    //         values: vec![
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "first_key".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::BoolValue(true)),
+    //                 }),
+    //             },
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "second_key".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::StringValue("second_value".to_string())),
+    //                 }),
+    //             },
+    //         ],
+    //     };
+    //     let resource = opentelemetry_proto::tonic::resource::v1::Resource {
+    //         attributes: vec![
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "first_attr".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::KvlistValue(kvlist)),
+    //                 }),
+    //             },
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "second_attr".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::ArrayValue(av)),
+    //                 }),
+    //             },
+    //             opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                 key: "third_attr".to_string(),
+    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                     value: Some(Value::StringValue("to_remove_value".to_string())),
+    //                 }),
+    //             },
+    //         ],
+    //         dropped_attributes_count: 0,
+    //     };
+    //
+    //     let mut spans = FakeOTLP::trace_spans(2);
+    //     let now_ns = Utc::now().timestamp_nanos_opt().unwrap();
+    //
+    //     // Adding additional data here to test __delitem__
+    //     spans[0].events.push(v1::span::Event {
+    //         time_unix_nano: now_ns as u64,
+    //         name: "second test event".to_string(),
+    //         attributes: vec![],
+    //         dropped_attributes_count: 0,
+    //     });
+    //
+    //     spans[0].links.push(v1::span::Link {
+    //         trace_id: vec![5, 5, 5, 5, 5, 5, 5, 5],
+    //         span_id: vec![6, 6, 6, 6, 6, 6, 6, 6],
+    //         trace_state: "secondtrace=00f067aa0ba902b7".to_string(),
+    //         attributes: vec![],
+    //         dropped_attributes_count: 0,
+    //         flags: 0,
+    //     });
+    //
+    //     let first_scope_spans = v1::ScopeSpans {
+    //         scope: None,
+    //         spans,
+    //         schema_url: "".to_string(),
+    //     };
+    //
+    //     let second_scope_spans = v1::ScopeSpans {
+    //         scope: None,
+    //         spans: vec![],
+    //         schema_url: "".to_string(),
+    //     };
+    //
+    //     let resource_spans = v1::ResourceSpans {
+    //         resource: Some(resource),
+    //         scope_spans: vec![first_scope_spans, second_scope_spans],
+    //         schema_url: "".to_string(),
+    //     };
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_spans =
+    //         crate::model::otel_transform::transform_resource_spans(resource_spans);
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: r_resource_spans.resource.clone(),
+    //         scope_spans: r_resource_spans.scope_spans.clone(),
+    //         schema_url: r_resource_spans.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("traces_delitem_test.py", py, py_resource_spans)
+    //     })
+    //     .unwrap();
+    //
+    //     let mut resource = r_resource_spans.resource.lock().unwrap();
+    //     let mut resource_p = resource
+    //         .take()
+    //         .map(|r| crate::model::py_transform::transform_resource(r).unwrap())
+    //         .unwrap();
+    //
+    //     assert_eq!(2, resource_p.attributes.len());
+    //     // Assert the kvlist only has one item now
+    //     let kvlist = resource_p
+    //         .attributes
+    //         .remove(0)
+    //         .value
+    //         .unwrap()
+    //         .value
+    //         .unwrap();
+    //     match kvlist {
+    //         Value::KvlistValue(mut kvl) => {
+    //             assert_eq!(1, kvl.values.len());
+    //             let value = kvl.values.remove(0);
+    //             assert_eq!(value.key, "second_key");
+    //             let value = value.value.clone().unwrap().value.unwrap();
+    //             match value {
+    //                 Value::StringValue(s) => {
+    //                     assert_eq!(s, "second_value");
+    //                 }
+    //                 _ => {
+    //                     panic!("expected StringValue")
+    //                 }
+    //             }
+    //         }
+    //         _ => {
+    //             panic!("expected kvlist")
+    //         }
+    //     }
+    //
+    //     let arvalue = resource_p
+    //         .attributes
+    //         .remove(0)
+    //         .value
+    //         .unwrap()
+    //         .value
+    //         .unwrap();
+    //     match arvalue {
+    //         Value::ArrayValue(mut av) => {
+    //             assert_eq!(1, av.values.len());
+    //             let value = av.values.remove(0).value.unwrap();
+    //             match value {
+    //                 Value::StringValue(s) => {
+    //                     assert_eq!(s, "first value")
+    //                 }
+    //                 _ => {
+    //                     panic!("expected StringValue");
+    //                 }
+    //             }
+    //         }
+    //         _ => {
+    //             panic!("expected ArrayValue");
+    //         }
+    //     }
+    //
+    //     // Verify the second scope span has been removed
+    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_spans_vec = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //     assert_eq!(1, scope_spans_vec.len());
+    //     let scope_spans = scope_spans_vec.remove(0);
+    //     let mut spans = scope_spans.spans;
+    //     assert_eq!(1, spans.len());
+    //     let span = spans.remove(0);
+    //     assert_eq!(1, span.events.len());
+    //     assert_eq!(span.events[0].name, "second test event");
+    //     assert_eq!(1, span.links.len());
+    //     assert_eq!(span.links[0].trace_state, "secondtrace=00f067aa0ba902b7")
+    // }
+    //
+    // #[test]
+    // fn attributes_processor_test() {
+    //     initialize();
+    //     let mut log_request = FakeOTLP::logs_service_request();
+    //
+    //     let attrs = vec![
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "http.status_code".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::IntValue(200)),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "user.id".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("abc-123".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "user.email".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("test@example.com".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "request.id".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("req-456".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "message".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("User login successful.".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "raw_data".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("id:123,name:Alice,age:30".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "temp_str_int".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("123".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "temp_str_bool".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("true".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "temp_str_float".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::DoubleValue(10.0)),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "path".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("https://rotel.dev/blog".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "super.secret".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("don't tell anyone".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "trace.id".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("12345678".to_string())),
+    //             }),
+    //         },
+    //     ];
+    //     log_request.resource_logs[0].scope_logs[0].log_records[0].attributes = attrs.clone();
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+    //         log_request.resource_logs[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "attributes_processor_test.py",
+    //             py,
+    //             py_resource_logs,
+    //             Some("process_logs".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //
+    //     let log_record = scope_logs.pop().unwrap().log_records.pop().unwrap();
+    //     let attrs_to_verify: HashMap<
+    //         String,
+    //         Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+    //     > = log_record
+    //         .attributes
+    //         .into_iter()
+    //         .map(|kv| (kv.key, kv.value))
+    //         .collect();
+    //
+    //     let verify_attrs = |mut attrs: HashMap<
+    //         String,
+    //         Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+    //     >| {
+    //         let host_name = attrs.remove("host.name").unwrap();
+    //         match host_name.unwrap().value.unwrap() {
+    //             Value::StringValue(h) => {
+    //                 assert_eq!(h, "my-server-1");
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let http_status_code = attrs.remove("http.status_code").unwrap();
+    //         match http_status_code.unwrap().value.unwrap() {
+    //             Value::StringValue(c) => {
+    //                 assert_eq!(c, "OK");
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let env = attrs.remove("env").unwrap();
+    //         match env.unwrap().value.unwrap() {
+    //             Value::StringValue(e) => {
+    //                 assert_eq!(e, "production");
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let email = attrs.remove("email").unwrap();
+    //         match email.unwrap().value.unwrap() {
+    //             Value::StringValue(h) => {
+    //                 assert_eq!(h, "test@example.com");
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let user_id = attrs.remove("user.id").unwrap();
+    //         match user_id.unwrap().value.unwrap() {
+    //             Value::StringValue(s) => {
+    //                 assert_eq!(
+    //                     s,
+    //                     "5942d94f524882e0f29bf0a1e5a6dcc952eea1c0c21dd3588a3fc7db9716db0c"
+    //                 );
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let trace_id = attrs.remove("trace.id").unwrap();
+    //         match trace_id.unwrap().value.unwrap() {
+    //             Value::StringValue(s) => {
+    //                 assert_eq!(
+    //                     s,
+    //                     "ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f"
+    //                 );
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let id = attrs.remove("extracted_id").unwrap();
+    //         match id.unwrap().value.unwrap() {
+    //             Value::StringValue(s) => {
+    //                 assert_eq!(s, "123");
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let temp_str_int = attrs.remove("temp_str_int").unwrap();
+    //         match temp_str_int.unwrap().value.unwrap() {
+    //             Value::IntValue(i) => {
+    //                 assert_eq!(i, 123);
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let temp_str_bool = attrs.remove("temp_str_bool").unwrap();
+    //         match temp_str_bool.unwrap().value.unwrap() {
+    //             Value::BoolValue(b) => {
+    //                 assert_eq!(b, true);
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let temp_str_float = attrs.remove("temp_str_float").unwrap();
+    //         match temp_str_float.unwrap().value.unwrap() {
+    //             Value::DoubleValue(d) => {
+    //                 assert_eq!(d, 10.0);
+    //             }
+    //             _ => panic!("Unexpected value type"),
+    //         }
+    //         let path = attrs.remove("path");
+    //         assert_eq!(path, None);
+    //         let super_secret = attrs.remove("super.secret");
+    //         assert_eq!(super_secret, None);
+    //     };
+    //
+    //     verify_attrs(attrs_to_verify);
+    //
+    //     let mut trace_request = FakeOTLP::trace_service_request();
+    //     trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = attrs.clone();
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         trace_request.resource_spans[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: r_resource_spans.resource.clone(),
+    //         scope_spans: r_resource_spans.scope_spans.clone(),
+    //         schema_url: r_resource_spans.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "attributes_processor_test.py",
+    //             py,
+    //             py_resource_spans,
+    //             Some("process_spans".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //
+    //     let span = scope_spans.pop().unwrap().spans.pop().unwrap();
+    //     let attrs_to_verify: HashMap<
+    //         String,
+    //         Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+    //     > = span
+    //         .attributes
+    //         .into_iter()
+    //         .map(|kv| (kv.key, kv.value))
+    //         .collect();
+    //
+    //     verify_attrs(attrs_to_verify);
+    // }
+    // #[test]
+    // fn redaction_processor_restrictive_test() {
+    //     initialize();
+    //     let resource_attrs = vec![
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "host.arch".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("amd64".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "os.type".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("linux".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "region".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("us-east-1".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "service.name".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("my-service".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "unallowed_resource_key".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("some_value".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "deployment.environment".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("prod".to_string())),
+    //             }),
+    //         },
+    //     ];
+    //
+    //     let span_attrs = vec![
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "user.email".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("test@example.com".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "http.url".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue(
+    //                     "https://example.com/sensitive/path".to_string(),
+    //                 )),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "db.statement".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue(
+    //                     "SELECT * FROM users WHERE id = 1".to_string(),
+    //                 )),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "operation".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("get_data".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "some_token".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("abcdef123".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "api_key_header".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("xyz789".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "safe_attribute".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("this should remain".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "unallowed_span_key".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("should_be_deleted".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "my_company_email".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("user@mycompany.com".to_string())),
+    //             }),
+    //         },
+    //     ];
+    //
+    //     let mut trace_request = FakeOTLP::trace_service_request();
+    //     trace_request.resource_spans[0].resource =
+    //         Some(opentelemetry_proto::tonic::resource::v1::Resource {
+    //             attributes: resource_attrs.clone(),
+    //             dropped_attributes_count: 0,
+    //         });
+    //     trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         trace_request.resource_spans[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: r_resource_spans.resource.clone(),
+    //         scope_spans: r_resource_spans.scope_spans.clone(),
+    //         schema_url: r_resource_spans.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "redaction_processor_restrictive_test.py",
+    //             py,
+    //             py_resource_spans,
+    //             Some("process_spans".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let resource = Arc::into_inner(r_resource_spans.resource)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap()
+    //         .unwrap();
+    //     let resource = crate::model::py_transform::transform_resource(resource).unwrap();
+    //     assert_eq!(9, resource.attributes.len());
+    //     let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
+    //         resource
+    //             .attributes
+    //             .into_iter()
+    //             .map(|kv| (kv.key.clone(), kv.value.clone()))
+    //             .collect();
+    //
+    //     let expected_attributes = HashMap::from([
+    //         ("host.arch", "amd64"),
+    //         ("os.type", "linux"),
+    //         ("region", "us-east-1"),
+    //         ("service.name", "my-service"),
+    //         ("deployment.environment", "prod"),
+    //         (
+    //             "redaction.resource.redacted_keys.names",
+    //             "unallowed_resource_key",
+    //         ),
+    //         (
+    //             "redaction.resource.allowed_keys.names",
+    //             "deployment.environment,host.arch,os.type,region,service.name",
+    //         ),
+    //         ("redaction.resource.redacted_keys.count", "1"),
+    //         ("redaction.resource.allowed_keys.count", "5"),
+    //     ]);
+    //
+    //     let validate =
+    //         |kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>>,
+    //          expected_attributes: HashMap<&str, &str>| {
+    //             for (key, value) in kv_map {
+    //                 let ev = expected_attributes.get(key.as_str());
+    //                 match ev {
+    //                     None => {
+    //                         panic!("key {:?} not found in expected attributes", key)
+    //                     }
+    //                     Some(v) => match value.unwrap().value.unwrap() {
+    //                         Value::StringValue(sv) => {
+    //                             assert_eq!(v.to_string(), sv.to_string());
+    //                         }
+    //                         Value::IntValue(i) => {
+    //                             let v: i64 = v.parse().expect("can't convert to int");
+    //                             assert_eq!(v, i);
+    //                         }
+    //                         _ => {
+    //                             panic!("expected string value")
+    //                         }
+    //                     },
+    //                 }
+    //             }
+    //         };
+    //
+    //     validate(kv_map, expected_attributes);
+    //
+    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //
+    //     let span = scope_spans.pop().unwrap().spans.pop().unwrap();
+    //     println!("span is {:?}", span);
+    //     assert_eq!(7, span.attributes.len());
+    //
+    //     let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
+    //         span.attributes
+    //             .into_iter()
+    //             .map(|kv| (kv.key.clone(), kv.value.clone()))
+    //             .collect();
+    //
+    //     let expected_attributes = HashMap::from([
+    //         ("operation", "get_data"),
+    //         ("safe_attribute", "this should remain"),
+    //         ("redaction.span.redacted_keys.count", "7"),
+    //         ("redaction.span.allowed_keys.names", "operation"),
+    //         ("redaction.span.allowed_keys.count", "1"),
+    //         ("redaction.span.redacted_keys.names", "api_key_header,db.statement,http.url,my_company_email,some_token,unallowed_span_key,user.email"),
+    //         ("redaction.span.ignored_keys.count", "1"),
+    //     ]);
+    //
+    //     validate(kv_map, expected_attributes)
+    // }
+    //
+    // #[test]
+    // fn redaction_processor_blocking_test() {
+    //     initialize();
+    //     let span_attrs = vec![
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "session_token".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("foo".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "api_key".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("bar".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "password_hash".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("xyz123".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "visa".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("4123456789012".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "mastercard".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("5234567890123456".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "bl_email".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("foo@bar.com".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "allowed_email".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("test@mycompany.com".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "ip".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("10.0.1.100".to_string())),
+    //             }),
+    //         },
+    //         opentelemetry_proto::tonic::common::v1::KeyValue {
+    //             key: "query".to_string(),
+    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                 value: Some(Value::StringValue("SELECT * FROM USERS".to_string())),
+    //             }),
+    //         },
+    //     ];
+    //
+    //     let mut trace_request = FakeOTLP::trace_service_request();
+    //     trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
+    //         trace_request.resource_spans[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_spans = ResourceSpans {
+    //         resource: r_resource_spans.resource.clone(),
+    //         scope_spans: r_resource_spans.scope_spans.clone(),
+    //         schema_url: r_resource_spans.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "redaction_processor_blocking_test.py",
+    //             py,
+    //             py_resource_spans,
+    //             Some("process_spans".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+    //
+    //     let span = scope_spans.pop().unwrap().spans.pop().unwrap();
+    //     assert_eq!(13, span.attributes.len());
+    //
+    //     let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
+    //         span.attributes
+    //             .into_iter()
+    //             .map(|kv| (kv.key.clone(), kv.value.clone()))
+    //             .collect();
+    //
+    //     let expected_attributes = HashMap::from([
+    //         ("visa", "8d9e470bdd9f6e6e18023938497857dc"),
+    //         ("mastercard", "aad9ce9b62a1f697745fcd81314b877f"),
+    //         ("ip", "f5c45dc3c8fb04f638ad27a711910390"),
+    //         ("query", "06c445f7ade97a964f7c466575f8b508"),
+    //         ("bl_email", "f3ada405ce890b6f8204094deb12d8a8"),
+    //         ("session_token", "acbd18db4cc2f85cedef654fccc4a4d8"),
+    //         ("allowed_email", "test@mycompany.com"),
+    //         ("api_key", "37b51d194a7513e45b56f6524f2d51f2"),
+    //         ("password_hash", "613d3b9c91e9445abaeca02f2342e5a6"),
+    //         ("redaction.span.allowed_keys.names", "allowed_email,api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
+    //         ("redaction.span.allowed_keys.count", "9"),
+    //         ("redaction.span.masked_keys.names", "api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
+    //         ("redaction.span.masked_keys.count", "8"),
+    //     ]);
+    //
+    //     for (key, value) in kv_map {
+    //         let ev = expected_attributes.get(key.as_str());
+    //         match ev {
+    //             None => {
+    //                 panic!("key {:?} not found in expected attributes", key)
+    //             }
+    //             Some(v) => match value.unwrap().value.unwrap() {
+    //                 Value::StringValue(sv) => {
+    //                     assert_eq!(v.to_string(), sv.to_string());
+    //                 }
+    //                 Value::IntValue(i) => {
+    //                     let v: i64 = v.parse().expect("can't convert to int");
+    //                     assert_eq!(v, i);
+    //                 }
+    //                 _ => {
+    //                     panic!("expected string value")
+    //                 }
+    //             },
+    //         }
+    //     }
+    // }
+    //
+    // #[test]
+    // fn redaction_processor_log_body_test() {
+    //     initialize();
+    //     let mut logs_request = FakeOTLP::logs_service_request();
+    //     let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
+    //         value: Some(Value::StringValue(
+    //             "Login successful: password=1234567890".to_string(),
+    //         )),
+    //     };
+    //     logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+    //         logs_request.resource_logs[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "redaction_processor_log_body_test.py",
+    //             py,
+    //             py_resource_logs,
+    //             Some("process_logs".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //     let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
+    //     let body = log.body.unwrap().value.unwrap();
+    //     match body {
+    //         Value::StringValue(b) => {
+    //             assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
+    //         }
+    //         _ => panic!("Unexpected log record value type"),
+    //     }
+    //
+    //     let mut logs_request = FakeOTLP::logs_service_request();
+    //     let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
+    //         value: Some(Value::KvlistValue(
+    //             opentelemetry_proto::tonic::common::v1::KeyValueList {
+    //                 values: vec![opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                     key: "another_body".to_string(),
+    //                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                         value: Some(Value::StringValue(
+    //                             "Login successful: password=1234567890".to_string(),
+    //                         )),
+    //                     }),
+    //                 }],
+    //             },
+    //         )),
+    //     };
+    //     logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+    //         logs_request.resource_logs[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "redaction_processor_log_body_test.py",
+    //             py,
+    //             py_resource_logs,
+    //             Some("process_logs".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //     let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
+    //     let body = log.body.unwrap().value.unwrap();
+    //     match body {
+    //         Value::KvlistValue(mut kvl) => {
+    //             let v = kvl.values.pop().unwrap();
+    //             match v.value.unwrap().value.unwrap() {
+    //                 Value::StringValue(b) => {
+    //                     assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
+    //                 }
+    //                 _ => {
+    //                     panic!("Unexpected log record value type");
+    //                 }
+    //             }
+    //         }
+    //         _ => panic!("Unexpected log record value type"),
+    //     }
+    //
+    //     let mut logs_request = FakeOTLP::logs_service_request();
+    //     let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
+    //         value: Some(Value::ArrayValue(
+    //             opentelemetry_proto::tonic::common::v1::ArrayValue {
+    //                 values: vec![
+    //                     opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                         value: Some(Value::StringValue(
+    //                             "Login failed: password=1234567890".to_string(),
+    //                         )),
+    //                     },
+    //                     opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                         value: Some(Value::KvlistValue(
+    //                             opentelemetry_proto::tonic::common::v1::KeyValueList {
+    //                                 values: vec![
+    //                                     opentelemetry_proto::tonic::common::v1::KeyValue {
+    //                                         key: "another_body".to_string(),
+    //                                         value: Some(
+    //                                             opentelemetry_proto::tonic::common::v1::AnyValue {
+    //                                                 value: Some(Value::StringValue(
+    //                                                     "Login successful: password=1234567890"
+    //                                                         .to_string(),
+    //                                                 )),
+    //                                             },
+    //                                         ),
+    //                                     },
+    //                                 ],
+    //                             },
+    //                         )),
+    //                     },
+    //                 ],
+    //             },
+    //         )),
+    //     };
+    //     logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+    //         logs_request.resource_logs[0].clone(),
+    //     );
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_logs = ResourceLogs {
+    //         resource: r_resource_logs.resource.clone(),
+    //         scope_logs: r_resource_logs.scope_logs.clone(),
+    //         schema_url: r_resource_logs.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         _run_script(
+    //             "redaction_processor_log_body_test.py",
+    //             py,
+    //             py_resource_logs,
+    //             Some("process_logs".to_string()),
+    //         )
+    //     })
+    //     .unwrap();
+    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+    //         .unwrap()
+    //         .into_inner()
+    //         .unwrap();
+    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+    //     let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
+    //     let body = log.body.unwrap().value.unwrap();
+    //     match body {
+    //         Value::ArrayValue(mut av) => {
+    //             assert_eq!(av.values.len(), 2);
+    //             while !av.values.is_empty() {
+    //                 let v = av.values.pop().unwrap();
+    //                 match v.value.unwrap() {
+    //                     Value::StringValue(b) => {
+    //                         assert_eq!(b, "34c37eb5ba287d52490cc8c2e3ebc231");
+    //                     }
+    //                     Value::KvlistValue(mut kvl) => {
+    //                         let v = kvl.values.pop().unwrap();
+    //                         match v.value.unwrap().value.unwrap() {
+    //                             Value::StringValue(b) => {
+    //                                 assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
+    //                             }
+    //                             _ => {
+    //                                 panic!("Unexpected log record value type");
+    //                             }
+    //                         }
+    //                     }
+    //                     _ => {
+    //                         panic!("Unexpected log record value type");
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //         _ => {
+    //             panic!("Unexpected log record value type");
+    //         }
+    //     }
+    // }
+    //
+    // #[test]
+    // fn metrics_processor_test() {
+    //     initialize();
+    //
+    //     let mut resource_metrics = opentelemetry_proto::tonic::metrics::v1::ResourceMetrics {
+    //         resource: None,
+    //         scope_metrics: vec![],
+    //         schema_url: "".to_string(),
+    //     };
+    //
+    //     let mut scope_metrics = opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
+    //         scope: None,
+    //         metrics: vec![],
+    //         schema_url: "".to_string(),
+    //     };
+    //
+    //     let metrics = vec![opentelemetry_proto::tonic::metrics::v1::Metric {
+    //         name: "test_metrics".to_string(),
+    //         description: "an example test metrics".to_string(),
+    //         unit: "bytes".to_string(),
+    //         metadata: vec![],
+    //         data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(opentelemetry_proto::tonic::metrics::v1::Gauge {
+    //             data_points: vec![
+    //                 opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+    //                     attributes: vec![],
+    //                     start_time_unix_nano: 1,
+    //                     time_unix_nano: 1,
+    //                     exemplars: vec![],
+    //                     flags: 0,
+    //                     value: Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsDouble(101.0)),
+    //                 }
+    //             ]
+    //         })),
+    //     }];
+    //
+    //     scope_metrics.metrics = metrics;
+    //     resource_metrics.scope_metrics = vec![scope_metrics];
+    //
+    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
+    //     let r_resource_metrics = otel_transform::transform_resource_metrics(resource_metrics);
+    //
+    //     // Create the Python-exposed ResourceLogs object
+    //     let py_resource_metrics = ResourceMetrics {
+    //         resource: r_resource_metrics.resource.clone(),
+    //         scope_metrics: r_resource_metrics.scope_metrics.clone(),
+    //         schema_url: r_resource_metrics.schema_url.clone(),
+    //     };
+    //
+    //     // Execute the Python script that removes a log record
+    //     Python::with_gil(|py| -> PyResult<()> {
+    //         run_script("resource_metrics_test.py", py, py_resource_metrics)
+    //     })
+    //     .unwrap();
+    // }
+    //
     #[test]
-    fn test_read_any_value() {
+    fn read_and_write_metrics() {
         initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-
-        let pv = AnyValue {
-            inner: any_value_arc.clone(),
-        };
-        Python::with_gil(|py| -> PyResult<()> { run_script("read_value_test.py", py, pv) })
-            .unwrap();
-        let av = any_value_arc.lock().unwrap().clone().unwrap();
-        let avx = av.value.lock().unwrap().clone();
-        match avx.unwrap() {
-            StringValue(s) => {
-                assert_eq!(s, "foo");
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn write_string_any_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let pv = AnyValue {
-            inner: any_value_arc.clone(),
-        };
-        Python::with_gil(|py| -> PyResult<()> { run_script("write_string_value_test.py", py, pv) })
-            .unwrap();
-        let av = any_value_arc.lock().unwrap().clone().unwrap();
-        let avx = av.value.lock().unwrap().clone();
-        match avx.unwrap() {
-            StringValue(s) => {
-                assert_eq!(s, "changed");
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn write_bool_any_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-
-        let pv = AnyValue {
-            inner: any_value_arc.clone(),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> { run_script("write_bool_value_test.py", py, pv) })
-            .unwrap();
-        match arc_value.lock().unwrap().clone().unwrap() {
-            BoolValue(b) => {
-                assert!(b);
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn write_bytes_any_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-
-        let pv = AnyValue {
-            inner: any_value_arc.clone(),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> { run_script("write_bytes_value_test.py", py, pv) })
-            .unwrap();
-        match arc_value.lock().unwrap().clone().unwrap() {
-            BytesValue(b) => {
-                assert_eq!(b"111111".to_vec(), b);
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn read_key_value_key() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = KeyValue {
-            inner: Arc::new(Mutex::new(RKeyValue {
-                key: key.clone(),
-                value: any_value_arc.clone(),
-            })),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> { run_script("read_key_value_key_test.py", py, kv) })
-            .unwrap();
-        let av = key.clone().lock().unwrap().clone();
-        assert_eq!(av, "key".to_string());
-        println!("{:?}", av);
-    }
-
-    #[test]
-    fn write_key_value_key() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = KeyValue {
-            inner: Arc::new(Mutex::new(RKeyValue {
-                key: key.clone(),
-                value: any_value_arc.clone(),
-            })),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("write_key_value_key_test.py", py, kv)
-        })
-        .unwrap();
-        let av = key.clone().lock().unwrap().clone();
-        assert_eq!(av, "new_key".to_string());
-        println!("{:?}", av);
-    }
-
-    #[test]
-    fn read_key_value_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = KeyValue {
-            inner: Arc::new(Mutex::new(RKeyValue {
-                key: key.clone(),
-                value: any_value_arc.clone(),
-            })),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("read_key_value_value_test.py", py, kv)
-        })
-        .unwrap();
-        match arc_value.lock().unwrap().clone().unwrap() {
-            StringValue(s) => {
-                assert_eq!(s, "foo");
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn write_key_value_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = KeyValue {
-            inner: Arc::new(Mutex::new(RKeyValue {
-                key: key.clone(),
-                value: any_value_arc.clone(),
-            })),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("write_key_value_value_test.py", py, kv)
-        })
-        .unwrap();
-        match arc_value.lock().unwrap().clone().unwrap() {
-            StringValue(s) => {
-                assert_eq!(s, "changed");
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn write_key_value_bytes_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = KeyValue {
-            inner: Arc::new(Mutex::new(RKeyValue {
-                key: key.clone(),
-                value: any_value_arc.clone(),
-            })),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("write_key_value_bytes_value_test.py", py, kv)
-        })
-        .unwrap();
-        match arc_value.lock().unwrap().clone().unwrap() {
-            BytesValue(s) => {
-                assert_eq!(b"111111".to_vec(), s);
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn read_resource_attributes() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-
-        let resource = Resource {
-            attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("read_resource_attributes_test.py", py, resource)
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn read_and_write_attributes_array_value() {
-        initialize();
-
-        let arc_value = Some(StringValue("foo".to_string()));
-        let any_value_arc = Some(RAnyValue {
-            value: Arc::new(Mutex::new(arc_value)),
-        });
-        let array_value = crate::model::common::RArrayValue {
-            values: Arc::new(Mutex::new(vec![Arc::new(Mutex::new(
-                any_value_arc.clone(),
-            ))])),
-        };
-        let array_value_arc = Arc::new(Mutex::new(Some(RVArrayValue(array_value))));
-        let any_value_array_value_wrapper = Some(RAnyValue {
-            value: array_value_arc.clone(),
-        });
-
-        let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
-
-        let key = Arc::new(Mutex::new("key".to_string()));
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_array_value_wrapper_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-        let attrs = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-
-        let resource = Resource {
-            attributes: attrs.clone(),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script(
-                "read_and_write_attributes_array_value_test.py",
-                py,
-                resource,
-            )
-        })
-        .unwrap();
-
-        let attrs = Arc::into_inner(attrs).unwrap();
-        let mut attrs = attrs.into_inner().unwrap();
-        let attr = Arc::into_inner(attrs.pop().unwrap()).unwrap();
-        let attr = attr.into_inner().unwrap();
-        let key = attr.key.lock().unwrap();
-        assert_eq!("my_array", *key);
-        let value = attr.value.lock().unwrap();
-        assert!(value.is_some());
-        let v = value.clone().unwrap();
-        let v = v.value.lock().unwrap();
-        assert!(v.is_some());
-        let v = v.clone().unwrap();
-        match v {
-            RVArrayValue(av) => {
-                println!("{:?}", av);
-                let mut vals = av.values.lock().unwrap();
-                let vv = vals.pop().unwrap();
-                let v = vv.lock().unwrap();
-                let v = v.clone().unwrap();
-                let v = v.value.clone().lock().unwrap().clone().unwrap();
-                match v {
-                    IntValue(v) => {
-                        assert_eq!(v, 123456789)
-                    }
-                    _ => panic!("wrong value type"),
-                }
-            }
-            _ => panic!("wrong value type"),
-        }
-    }
-
-    #[test]
-    fn read_and_write_attributes_key_value_list_value() {
-        initialize();
-
-        let value = Some(StringValue("foo".to_string()));
-        let any_value = Some(RAnyValue {
-            value: Arc::new(Mutex::new(value)),
-        });
-        let any_value_arc = Arc::new(Mutex::new(any_value));
-        let arc_key = Arc::new(Mutex::new("inner_key".to_string()));
-
-        let kev_value = RKeyValue {
-            key: arc_key.clone(),
-            value: any_value_arc.clone(),
-        };
-
-        let kv_list = crate::model::common::RKeyValueList {
-            values: Arc::new(Mutex::new(vec![kev_value])),
-        };
-
-        let array_value_arc = Arc::new(Mutex::new(Some(KvListValue(kv_list))));
-        let any_value_array_value_wrapper = Some(RAnyValue {
-            value: array_value_arc.clone(),
-        });
-
-        let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
-
-        let key = Arc::new(Mutex::new("key".to_string()));
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_array_value_wrapper_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-
-        let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-        let resource = Resource {
-            attributes: attrs_arc.clone(),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script(
-                "read_and_write_attributes_key_value_list_test.py",
-                py,
-                resource,
-            )
-        })
-        .unwrap();
-
-        let mut value = attrs_arc.lock().unwrap();
-        let value = value.pop().unwrap();
-        let value = Arc::into_inner(value).unwrap().into_inner().unwrap();
-        let value = Arc::into_inner(value.value).unwrap().into_inner().unwrap();
-        let value = value.unwrap().value;
-        let value = Arc::into_inner(value)
-            .unwrap()
-            .into_inner()
-            .unwrap()
-            .unwrap();
-        match value {
-            KvListValue(k) => {
-                let mut value = k.values.lock().unwrap().clone();
-                let value = value.pop();
-                match value {
-                    None => {
-                        panic!("wrong type")
-                    }
-                    Some(v) => {
-                        let v = v.value.lock().unwrap().clone();
-                        match v {
-                            None => {
-                                panic!("wrong type")
-                            }
-                            Some(v) => {
-                                let value = v.value.lock().unwrap().clone().unwrap();
-                                match value {
-                                    IntValue(i) => assert_eq!(100, i),
-                                    _ => panic!("wrong type"),
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            _ => panic!("wrong type"),
-        }
-    }
-
-    #[test]
-    fn write_resource_attributes_key_value_key() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-
-        let resource = Resource {
-            attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script(
-                "write_resource_attributes_key_value_key_test.py",
-                py,
-                resource,
-            )
-        })
-        .unwrap();
-        let av = key.clone().lock().unwrap().clone();
-        assert_eq!(av, "new_key".to_string());
-        println!("{:?}", av);
-    }
-
-    #[test]
-    fn write_resource_attributes_key_value_value() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-
-        let resource = Resource {
-            attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script(
-                "write_resource_attributes_key_value_value_test.py",
-                py,
-                resource,
-            )
-        })
-        .unwrap();
-        match arc_value.lock().unwrap().clone().unwrap() {
-            StringValue(s) => {
-                assert_eq!(s, "changed");
-            }
-            _ => panic!("wrong type"),
-        }
-        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    }
-
-    #[test]
-    fn resource_attributes_append_attribute() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-        let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-        let resource = Resource {
-            attributes: attrs_arc.clone(),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("resource_attributes_append_attribute.py", py, resource)
-        })
-        .unwrap();
-        println!("{:#?}", attrs_arc.lock().unwrap());
-    }
-
-    #[test]
-    fn resource_attributes_set_attributes() {
-        initialize();
-        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-            value: arc_value.clone(),
-        })));
-        let key = Arc::new(Mutex::new("key".to_string()));
-
-        let kv = RKeyValue {
-            key: key.clone(),
-            value: any_value_arc.clone(),
-        };
-
-        let kv_arc = Arc::new(Mutex::new(kv));
-        let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-        let resource = Resource {
-            attributes: attrs_arc.clone(),
-            dropped_attributes_count: Arc::new(Mutex::new(0)),
-        };
-
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("resource_attributes_set_attributes.py", py, resource)
-        })
-        .unwrap();
-        println!("{:#?}", attrs_arc.lock().unwrap());
-        let attrs = attrs_arc.lock().unwrap();
-        assert_eq!(2, attrs.len());
-        for kv in attrs.iter() {
-            let guard = kv.lock();
-            let kv_guard = guard.unwrap();
-            let key = kv_guard.key.lock().unwrap().to_string();
-            let value = kv_guard.value.lock().unwrap();
-            assert_ne!(key, "key");
-            assert!(key == "double.value" || key == "os.version");
-            assert!(value.is_some());
-            let av = value.clone().unwrap();
-            let value = av.value.lock().unwrap();
-            assert!(value.is_some());
-        }
-    }
-
-    #[test]
-    fn resource_spans_append_attributes() {
-        initialize();
-        let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: Arc::new(Mutex::new(vec![])),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("resource_spans_append_attribute.py", py, py_resource_spans)
-        })
-        .unwrap();
-        println!("{:#?}", resource_spans.resource.lock().unwrap());
-    }
-
-    #[test]
-    fn resource_spans_iterate_spans() {
-        initialize();
-        let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("resource_spans_iterate_spans.py", py, py_resource_spans)
-        })
-        .unwrap();
-        println!("{:#?}", resource_spans.resource.lock().unwrap());
-    }
-
-    #[test]
-    fn read_and_write_instrumentation_scope() {
-        initialize();
-        let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script(
-                "read_and_write_instrumentation_scope_test.py",
-                py,
-                py_resource_spans,
-            )
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let scope_spans = scope_spans.pop().unwrap();
-        let scope = scope_spans.scope.unwrap();
-        assert_eq!("name_changed", scope.name);
-        assert_eq!("0.0.2", scope.version);
-        assert_eq!(100, scope.dropped_attributes_count);
-        assert_eq!(scope.attributes.len(), 2);
-        for attr in &scope.attributes {
-            let value = attr.value.clone().unwrap();
-            let value = value.value.unwrap();
-            match attr.key.as_str() {
-                "key_changed" => match value {
-                    opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i) => {
-                        assert_eq!(i, 200);
-                    }
-                    _ => {
-                        panic!("wrong type for key_changed: {:?}", value);
-                    }
-                },
-                "severity" => match value {
-                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
-                        assert_eq!(s, "WARN");
-                    }
-                    _ => {
-                        panic!("wrong type for severity: {:?}", value);
-                    }
-                },
-                _ => {
-                    panic!("unexpected key")
-                }
-            }
-        }
-    }
-    #[test]
-    fn set_instrumentation_scope() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("set_instrumentation_scope_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let scope_spans = scope_spans.pop().unwrap();
-        let scope = scope_spans.scope.unwrap();
-        assert_eq!("name_changed", scope.name);
-        assert_eq!("0.0.2", scope.version);
-        assert_eq!(100, scope.dropped_attributes_count);
-        assert_eq!(scope.attributes.len(), 1);
-        for attr in &scope.attributes {
-            let value = attr.value.clone().unwrap();
-            let value = value.value.unwrap();
-            match attr.key.as_str() {
-                "severity" => match value {
-                    Value::StringValue(s) => {
-                        assert_eq!(s, "WARN");
-                    }
-                    _ => {
-                        panic!("wrong type for severity: {:?}", value);
-                    }
-                },
-                _ => {
-                    panic!("unexpected key")
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn read_and_write_spans() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("read_and_write_spans_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let resource = Arc::into_inner(resource_spans.resource);
-        let resource = resource.unwrap().into_inner().unwrap().unwrap();
-        let dropped = Arc::into_inner(resource.dropped_attributes_count);
-        let dropped = dropped.unwrap().into_inner().unwrap();
-
-        assert_eq!(15, dropped);
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let mut scope_spans = scope_spans.pop().unwrap();
-        let mut span = scope_spans.spans.pop().unwrap();
-        assert_eq!(b"5555555555".to_vec(), span.trace_id);
-        assert_eq!(b"6666666666".to_vec(), span.span_id);
-        assert_eq!("test=1234567890", span.trace_state);
-        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-        assert_eq!(1, span.flags);
-        assert_eq!("py_processed_span", span.name);
-        assert_eq!(4, span.kind);
-        assert_eq!(1234567890, span.start_time_unix_nano);
-        assert_eq!(1234567890, span.end_time_unix_nano);
-        assert_eq!(100, span.dropped_attributes_count);
-        assert_eq!(200, span.dropped_events_count);
-        assert_eq!(300, span.dropped_links_count);
-        assert_eq!("error message", span.status.clone().unwrap().message);
-        assert_eq!(2, span.status.unwrap().code);
-        assert_eq!(1, span.events.len());
-        assert_eq!("py_processed_event", span.events[0].name);
-        assert_eq!(1234567890, span.events[0].time_unix_nano);
-        assert_eq!(400, span.events[0].dropped_attributes_count);
-        assert_eq!(1, span.events[0].attributes.len());
-        assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
-        let value = span.events[0].attributes[0]
-            .value
-            .clone()
-            .unwrap()
-            .value
-            .unwrap();
-        match value {
-            Value::StringValue(s) => {
-                assert_eq!("event_attr_value", s)
-            }
-            _ => panic!("unexpected type"),
-        }
-
-        assert_eq!(2, span.links.len());
-        // get the newly added link
-        let new_link = span.links.remove(1);
-        assert_eq!(b"88888888".to_vec(), new_link.trace_id);
-        assert_eq!(b"99999999".to_vec(), new_link.span_id);
-        assert_eq!("test=1234567890", new_link.trace_state);
-        assert_eq!(300, new_link.dropped_attributes_count);
-        assert_eq!(1, new_link.flags);
-        assert_eq!(1, new_link.attributes.len());
-        let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
-        match value {
-            Value::StringValue(s) => {
-                assert_eq!("link_attr_value", s)
-            }
-            _ => panic!("unexpected type"),
-        }
-
-        assert_eq!(3, span.attributes.len());
-        let new_attr = span.attributes.remove(2);
-        assert_eq!("span_attr_key2", new_attr.key);
-        let value = new_attr.value.clone().unwrap().value.unwrap();
-        match value {
-            Value::StringValue(s) => {
-                assert_eq!("span_attr_value2", s)
-            }
-            _ => panic!("unexpected type"),
-        }
-    }
-    #[test]
-    fn set_scope_spans_span_test() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("set_scope_spans_span_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let mut scope_spans = scope_spans.pop().unwrap();
-        let mut span = scope_spans.spans.pop().unwrap();
-        assert_eq!(b"5555555555".to_vec(), span.trace_id);
-        assert_eq!(b"6666666666".to_vec(), span.span_id);
-        assert_eq!("test=1234567890", span.trace_state);
-        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-        assert_eq!(1, span.flags);
-        assert_eq!("py_processed_span", span.name);
-        assert_eq!(4, span.kind);
-        assert_eq!(1234567890, span.start_time_unix_nano);
-        assert_eq!(1234567890, span.end_time_unix_nano);
-        assert_eq!(100, span.dropped_attributes_count);
-        assert_eq!(200, span.dropped_events_count);
-        assert_eq!(300, span.dropped_links_count);
-        assert_eq!("error message", span.status.clone().unwrap().message);
-        assert_eq!(2, span.status.unwrap().code);
-        assert_eq!(1, span.events.len());
-        assert_eq!("py_processed_event", span.events[0].name);
-        assert_eq!(1234567890, span.events[0].time_unix_nano);
-        assert_eq!(400, span.events[0].dropped_attributes_count);
-        assert_eq!(1, span.events[0].attributes.len());
-        assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
-        let value = span.events[0].attributes[0]
-            .value
-            .clone()
-            .unwrap()
-            .value
-            .unwrap();
-        match value {
-            Value::StringValue(s) => {
-                assert_eq!("event_attr_value", s)
-            }
-            _ => panic!("unexpected type"),
-        }
-
-        assert_eq!(1, span.links.len());
-        // get the newly added link
-        let new_link = span.links.remove(0);
-        assert_eq!(b"88888888".to_vec(), new_link.trace_id);
-        assert_eq!(b"99999999".to_vec(), new_link.span_id);
-        assert_eq!("test=1234567890", new_link.trace_state);
-        assert_eq!(300, new_link.dropped_attributes_count);
-        assert_eq!(1, new_link.flags);
-        assert_eq!(1, new_link.attributes.len());
-        let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
-        match value {
-            Value::StringValue(s) => {
-                assert_eq!("link_attr_value", s)
-            }
-            _ => panic!("unexpected type"),
-        }
-
-        assert_eq!(1, span.attributes.len());
-        let new_attr = span.attributes.remove(0);
-        assert_eq!("span_attr_key", new_attr.key);
-        let value = new_attr.value.clone().unwrap().value.unwrap();
-        match value {
-            Value::StringValue(s) => {
-                assert_eq!("span_attr_value", s)
-            }
-            _ => panic!("unexpected type"),
-        }
-    }
-    #[test]
-    fn set_resource_spans_resource() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script(
-                "write_resource_spans_resource_test.py",
-                py,
-                py_resource_spans,
-            )
-        })
-        .unwrap();
-
-        let resource = Arc::into_inner(resource_spans.resource).unwrap();
-        let resource = resource.into_inner().unwrap().unwrap();
-        let resource = crate::model::py_transform::transform_resource(resource).unwrap();
-        assert_eq!(2, resource.attributes.len());
-        assert_eq!(35, resource.dropped_attributes_count);
-        for attr in &resource.attributes {
-            match attr.key.as_str() {
-                "key" => assert_eq!(
-                    Value::StringValue("value".to_string()),
-                    attr.value.clone().unwrap().value.unwrap()
-                ),
-                "boolean" => assert_eq!(
-                    Value::BoolValue(true),
-                    attr.value.clone().unwrap().value.unwrap()
-                ),
-                _ => panic!("unexpected attribute key"),
-            }
-        }
-    }
-    #[test]
-    fn set_span_events() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("write_span_events_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let mut scope_spans = scope_spans.pop().unwrap();
-        let span = scope_spans.spans.pop().unwrap();
-
-        assert_eq!(2, span.events.len());
-        let event = &span.events[0];
-        assert_eq!("first_event", event.name);
-        assert_eq!(123, event.time_unix_nano);
-        assert_eq!(1, event.dropped_attributes_count);
-        assert_eq!(1, event.attributes.len());
-        let attr = &event.attributes[0];
-        assert_eq!("first_event_attr_key", attr.key);
-        assert_eq!(
-            Value::StringValue("first_event_attr_value".to_string()),
-            attr.value.clone().unwrap().value.unwrap()
-        );
-
-        let event = &span.events[1];
-        assert_eq!("second_event", event.name);
-        assert_eq!(456, event.time_unix_nano);
-        assert_eq!(2, event.dropped_attributes_count);
-        assert_eq!(1, event.attributes.len());
-        let attr = &event.attributes[0];
-        assert_eq!("second_event_attr_key", attr.key);
-        assert_eq!(
-            Value::StringValue("second_event_attr_value".to_string()),
-            attr.value.clone().unwrap().value.unwrap()
-        )
-    }
-    #[test]
-    fn set_scope_spans() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("write_scope_spans_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let mut scope_spans = scope_spans.pop().unwrap();
-        assert_eq!(
-            "https://github.com/streamfold/rotel",
-            scope_spans.schema_url
-        );
-        let inst_scope = scope_spans.scope.unwrap();
-        assert_eq!("rotel-sdk-new", inst_scope.name);
-        assert_eq!("v1.0.1", inst_scope.version);
-        let attr = &inst_scope.attributes[0];
-        assert_eq!("rotel-sdk", attr.key);
-        assert_eq!(
-            Value::StringValue("v1.0.0".to_string()),
-            attr.value.clone().unwrap().value.unwrap()
-        );
-
-        let span = scope_spans.spans.pop().unwrap();
-        assert_eq!(b"5555555555".to_vec(), span.trace_id);
-        assert_eq!(b"6666666666".to_vec(), span.span_id);
-        assert_eq!("test=1234567890", span.trace_state);
-        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-        assert_eq!(1, span.flags);
-        assert_eq!("py_processed_span", span.name);
-        assert_eq!(4, span.kind);
-        assert_eq!(1234567890, span.start_time_unix_nano);
-        assert_eq!(1234567890, span.end_time_unix_nano);
-        let attr = &span.attributes[0];
-        assert_eq!("span_attr_key", attr.key);
-        assert_eq!(
-            Value::StringValue("span_attr_value".to_string()),
-            attr.value.clone().unwrap().value.unwrap()
-        );
-    }
-
-    #[test]
-    fn set_spans() {
-        initialize();
-        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-        let resource_spans = crate::model::otel_transform::transform_resource_spans(
-            export_req.resource_spans[0].clone(),
-        );
-        let py_resource_spans = ResourceSpans {
-            resource: resource_spans.resource.clone(),
-            scope_spans: resource_spans.scope_spans.clone(),
-            schema_url: resource_spans.schema_url,
-        };
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("write_spans_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-        let mut scope_spans = scope_spans.pop().unwrap();
-        let span = scope_spans.spans.pop().unwrap();
-        assert_eq!(b"5555555555".to_vec(), span.trace_id);
-        assert_eq!(b"6666666666".to_vec(), span.span_id);
-        assert_eq!("test=1234567890", span.trace_state);
-        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-        assert_eq!(1, span.flags);
-        assert_eq!("py_processed_span", span.name);
-        assert_eq!(4, span.kind);
-        assert_eq!(1234567890, span.start_time_unix_nano);
-        assert_eq!(1234567890, span.end_time_unix_nano);
-        let attr = &span.attributes[0];
-        assert_eq!("span_attr_key", attr.key);
-        assert_eq!(
-            Value::StringValue("span_attr_value".to_string()),
-            attr.value.clone().unwrap().value.unwrap()
-        );
-    }
-
-    #[test]
-    fn read_and_write_log_record() {
-        initialize();
-
-        // Create a mock ResourceLogs protobuf object for testing
-        // In a real scenario, you might use a utility like FakeOTLP if available for logs.
-        let initial_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
-            time_unix_nano: 1000000000,
-            observed_time_unix_nano: 1000000001,
-            severity_number: 9, // INFO
-            severity_text: "INFO".to_string(),
-            body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                value: Some(Value::StringValue("initial log message".to_string())),
-            }),
-            attributes: vec![
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "log.source".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::StringValue("my_app".to_string())),
-                    }),
-                },
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "component".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::StringValue("backend".to_string())),
-                    }),
-                },
-            ],
-            dropped_attributes_count: 0,
-            flags: 0,
-            trace_id: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-            span_id: vec![17, 18, 19, 20, 21, 22, 23, 24],
-            event_name: "".to_string(),
-        };
-
-        let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
-            scope: Some(
-                opentelemetry_proto::tonic::common::v1::InstrumentationScope {
-                    name: "test-instrumentation-scope".to_string(),
-                    version: "1.0.0".to_string(),
-                    attributes: vec![],
-                    dropped_attributes_count: 0,
-                },
-            ),
-            log_records: vec![initial_log_record],
-            schema_url: "http://example.com/logs-schema".to_string(),
-        };
-
-        let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+        // 1. Create initial OpenTelemetry protobuf MetricsData
+        let resource_metrics = opentelemetry_proto::tonic::metrics::v1::ResourceMetrics {
             resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
-                attributes: vec![],
-                dropped_attributes_count: 0,
-            }),
-            scope_logs: vec![initial_scope_logs],
-            schema_url: "http://example.com/resource-logs-schema".to_string(),
-        };
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs =
-            crate::model::otel_transform::transform_resource_logs(export_req.clone());
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
-        };
-
-        // Execute the Python script
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("read_and_write_logs_test.py", py, py_resource_logs)
-        })
-        .unwrap();
-
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-
-        // Assert the changes made by the Python script
-        assert_eq!(transformed_scope_logs.len(), 1);
-        let mut scope_log = transformed_scope_logs.remove(0);
-        assert_eq!(scope_log.log_records.len(), 1);
-        let log_record = scope_log.log_records.remove(0);
-
-        assert_eq!(log_record.time_unix_nano, 2000000000);
-        assert_eq!(log_record.observed_time_unix_nano, 2000000001);
-        assert_eq!(log_record.severity_number, 13);
-        assert_eq!(log_record.severity_text, "ERROR");
-
-        let body_value = log_record.body.unwrap().value.unwrap();
-        match body_value {
-            Value::StringValue(s) => {
-                assert_eq!(s, "processed log message");
-            }
-            _ => panic!("Body value is not a string"),
-        }
-
-        assert_eq!(log_record.dropped_attributes_count, 5);
-        assert_eq!(log_record.flags, 1);
-        assert_eq!(log_record.trace_id, b"abcdefghijklmnop".to_vec());
-        assert_eq!(log_record.span_id, b"qrstuvwx".to_vec());
-
-        assert_eq!(log_record.attributes.len(), 3);
-        // Verify the new attribute
-        let new_attr = &log_record.attributes[2];
-        assert_eq!(new_attr.key, "new_log_attr");
-        assert_eq!(
-            new_attr.value.clone().unwrap().value.unwrap(),
-            Value::StringValue("new_log_value".to_string())
-        );
-
-        // Verify the modified attribute
-        let modified_attr = &log_record.attributes[1];
-        assert_eq!(modified_attr.key, "component");
-        assert_eq!(
-            modified_attr.value.clone().unwrap().value.unwrap(),
-            Value::StringValue("modified_component_value".to_string())
-        );
-    }
-
-    #[test]
-    fn add_new_log_record() {
-        initialize();
-
-        // Create a mock ResourceLogs protobuf object with an empty ScopeLogs initially
-        let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
-            scope: Some(
-                opentelemetry_proto::tonic::common::v1::InstrumentationScope {
-                    name: "test-instrumentation-scope".to_string(),
-                    version: "1.0.0".to_string(),
-                    attributes: vec![],
-                    dropped_attributes_count: 0,
-                },
-            ),
-            log_records: vec![], // Start with no log records
-            schema_url: "http://example.com/logs-schema".to_string(),
-        };
-
-        let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
-            resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
-                attributes: vec![],
-                dropped_attributes_count: 0,
-            }),
-            scope_logs: vec![initial_scope_logs],
-            schema_url: "http://example.com/resource-logs-schema".to_string(),
-        };
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs =
-            crate::model::otel_transform::transform_resource_logs(export_req.clone());
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
-        };
-
-        // Execute the Python script that adds a new log record
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("add_log_record_test.py", py, py_resource_logs)
-        })
-        .unwrap();
-
-        // Transform the modified RResourceLogs back into protobuf format
-        let mut resource = r_resource_logs.resource.lock().unwrap();
-        let _resource_proto = resource
-            .take()
-            .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
-
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-
-        // Assert the changes made by the Python script
-        assert_eq!(transformed_scope_logs.len(), 1);
-        let mut scope_log = transformed_scope_logs.remove(0);
-        assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
-        let log_record = scope_log.log_records.remove(0);
-
-        assert_eq!(log_record.time_unix_nano, 9876543210);
-        assert_eq!(log_record.observed_time_unix_nano, 9876543211);
-        assert_eq!(log_record.severity_number, 17); // FATAL
-        assert_eq!(log_record.severity_text, "FATAL");
-
-        let body_value = log_record.body.unwrap().value.unwrap();
-        match body_value {
-            Value::StringValue(s) => {
-                assert_eq!(s, "This is a newly added log message.");
-            }
-            _ => panic!("Body value is not a string"),
-        }
-
-        assert_eq!(log_record.attributes.len(), 1);
-        let new_attr = &log_record.attributes[0];
-        assert_eq!(new_attr.key, "new_log_key");
-        assert_eq!(
-            new_attr.value.clone().unwrap().value.unwrap(),
-            Value::StringValue("new_log_value".to_string())
-        );
-
-        assert_eq!(log_record.dropped_attributes_count, 2);
-        assert_eq!(log_record.flags, 4);
-        assert_eq!(log_record.trace_id, b"fedcba9876543210".to_vec());
-        assert_eq!(log_record.span_id, b"fedcba98".to_vec());
-    }
-
-    #[test]
-    fn remove_log_record_test() {
-        initialize();
-
-        // Create a mock ResourceLogs protobuf object with two initial LogRecords
-        let first_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
-            time_unix_nano: 1000000000,
-            observed_time_unix_nano: 1000000001,
-            severity_number: 9, // INFO
-            severity_text: "INFO".to_string(),
-            body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                value: Some(
-                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                        "first log message".to_string(),
-                    ),
-                ),
-            }),
-            attributes: vec![],
-            dropped_attributes_count: 0,
-            flags: 0,
-            trace_id: vec![],
-            span_id: vec![],
-            event_name: "first_event".to_string(),
-        };
-
-        let second_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
-            time_unix_nano: 2000000000,
-            observed_time_unix_nano: 2000000001,
-            severity_number: 13, // ERROR
-            severity_text: "ERROR".to_string(),
-            body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                value: Some(Value::StringValue("second log message".to_string())),
-            }),
-            attributes: vec![],
-            dropped_attributes_count: 0,
-            flags: 0,
-            trace_id: vec![],
-            span_id: vec![],
-            event_name: "second_event".to_string(),
-        };
-
-        let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
-            scope: Some(
-                opentelemetry_proto::tonic::common::v1::InstrumentationScope {
-                    name: "test-instrumentation-scope".to_string(),
-                    version: "1.0.0".to_string(),
-                    attributes: vec![],
-                    dropped_attributes_count: 0,
-                },
-            ),
-            log_records: vec![first_log_record, second_log_record], // Two log records
-            schema_url: "http://example.com/logs-schema".to_string(),
-        };
-
-        let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
-            resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
-                attributes: vec![],
-                dropped_attributes_count: 0,
-            }),
-            scope_logs: vec![initial_scope_logs],
-            schema_url: "http://example.com/resource-logs-schema".to_string(),
-        };
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs =
-            crate::model::otel_transform::transform_resource_logs(export_req.clone());
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("remove_log_record_test.py", py, py_resource_logs)
-        })
-        .unwrap();
-
-        // Transform the modified RResourceLogs back into protobuf format
-        let mut resource = r_resource_logs.resource.lock().unwrap();
-        let _resource_proto = resource
-            .take()
-            .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
-
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-
-        // Assert the changes made by the Python script
-        assert_eq!(transformed_scope_logs.len(), 1);
-        let mut scope_log = transformed_scope_logs.remove(0);
-        assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
-        let log_record = scope_log.log_records.remove(0);
-
-        // Verify that the correct log record remains
-        let body_value = log_record.body.unwrap().value.unwrap();
-        match body_value {
-            Value::StringValue(s) => {
-                assert_eq!(s, "first log message");
-            }
-            _ => panic!("Body value is not the expected string"),
-        }
-    }
-
-    #[test]
-    fn traces_delitem_test() {
-        initialize();
-        let av = opentelemetry_proto::tonic::common::v1::ArrayValue {
-            values: vec![
-                opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("first value".to_string())),
-                },
-                opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("second value".to_string())),
-                },
-            ],
-        };
-        let kvlist = opentelemetry_proto::tonic::common::v1::KeyValueList {
-            values: vec![
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "first_key".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::BoolValue(true)),
-                    }),
-                },
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "second_key".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::StringValue("second_value".to_string())),
-                    }),
-                },
-            ],
-        };
-        let resource = opentelemetry_proto::tonic::resource::v1::Resource {
-            attributes: vec![
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "first_attr".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::KvlistValue(kvlist)),
-                    }),
-                },
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "second_attr".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::ArrayValue(av)),
-                    }),
-                },
-                opentelemetry_proto::tonic::common::v1::KeyValue {
-                    key: "third_attr".to_string(),
-                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                        value: Some(Value::StringValue("to_remove_value".to_string())),
-                    }),
-                },
-            ],
-            dropped_attributes_count: 0,
-        };
-
-        let mut spans = FakeOTLP::trace_spans(2);
-        let now_ns = Utc::now().timestamp_nanos_opt().unwrap();
-
-        // Adding additional data here to test __delitem__
-        spans[0].events.push(v1::span::Event {
-            time_unix_nano: now_ns as u64,
-            name: "second test event".to_string(),
-            attributes: vec![],
-            dropped_attributes_count: 0,
-        });
-
-        spans[0].links.push(v1::span::Link {
-            trace_id: vec![5, 5, 5, 5, 5, 5, 5, 5],
-            span_id: vec![6, 6, 6, 6, 6, 6, 6, 6],
-            trace_state: "secondtrace=00f067aa0ba902b7".to_string(),
-            attributes: vec![],
-            dropped_attributes_count: 0,
-            flags: 0,
-        });
-
-        let first_scope_spans = v1::ScopeSpans {
-            scope: None,
-            spans,
-            schema_url: "".to_string(),
-        };
-
-        let second_scope_spans = v1::ScopeSpans {
-            scope: None,
-            spans: vec![],
-            schema_url: "".to_string(),
-        };
-
-        let resource_spans = v1::ResourceSpans {
-            resource: Some(resource),
-            scope_spans: vec![first_scope_spans, second_scope_spans],
-            schema_url: "".to_string(),
-        };
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_spans =
-            crate::model::otel_transform::transform_resource_spans(resource_spans);
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_spans = ResourceSpans {
-            resource: r_resource_spans.resource.clone(),
-            scope_spans: r_resource_spans.scope_spans.clone(),
-            schema_url: r_resource_spans.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            run_script("traces_delitem_test.py", py, py_resource_spans)
-        })
-        .unwrap();
-
-        let mut resource = r_resource_spans.resource.lock().unwrap();
-        let mut resource_p = resource
-            .take()
-            .map(|r| crate::model::py_transform::transform_resource(r).unwrap())
-            .unwrap();
-
-        assert_eq!(2, resource_p.attributes.len());
-        // Assert the kvlist only has one item now
-        let kvlist = resource_p
-            .attributes
-            .remove(0)
-            .value
-            .unwrap()
-            .value
-            .unwrap();
-        match kvlist {
-            Value::KvlistValue(mut kvl) => {
-                assert_eq!(1, kvl.values.len());
-                let value = kvl.values.remove(0);
-                assert_eq!(value.key, "second_key");
-                let value = value.value.clone().unwrap().value.unwrap();
-                match value {
-                    Value::StringValue(s) => {
-                        assert_eq!(s, "second_value");
-                    }
-                    _ => {
-                        panic!("expected StringValue")
-                    }
-                }
-            }
-            _ => {
-                panic!("expected kvlist")
-            }
-        }
-
-        let arvalue = resource_p
-            .attributes
-            .remove(0)
-            .value
-            .unwrap()
-            .value
-            .unwrap();
-        match arvalue {
-            Value::ArrayValue(mut av) => {
-                assert_eq!(1, av.values.len());
-                let value = av.values.remove(0).value.unwrap();
-                match value {
-                    Value::StringValue(s) => {
-                        assert_eq!(s, "first value")
-                    }
-                    _ => {
-                        panic!("expected StringValue");
-                    }
-                }
-            }
-            _ => {
-                panic!("expected ArrayValue");
-            }
-        }
-
-        // Verify the second scope span has been removed
-        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_spans_vec = crate::model::py_transform::transform_spans(scope_spans_vec);
-        assert_eq!(1, scope_spans_vec.len());
-        let scope_spans = scope_spans_vec.remove(0);
-        let mut spans = scope_spans.spans;
-        assert_eq!(1, spans.len());
-        let span = spans.remove(0);
-        assert_eq!(1, span.events.len());
-        assert_eq!(span.events[0].name, "second test event");
-        assert_eq!(1, span.links.len());
-        assert_eq!(span.links[0].trace_state, "secondtrace=00f067aa0ba902b7")
-    }
-
-    #[test]
-    fn attributes_processor_test() {
-        initialize();
-        let mut log_request = FakeOTLP::logs_service_request();
-
-        let attrs = vec![
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "http.status_code".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::IntValue(200)),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "user.id".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("abc-123".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "user.email".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("test@example.com".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "request.id".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("req-456".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "message".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("User login successful.".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "raw_data".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("id:123,name:Alice,age:30".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "temp_str_int".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("123".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "temp_str_bool".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("true".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "temp_str_float".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::DoubleValue(10.0)),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "path".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("https://rotel.dev/blog".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "super.secret".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("don't tell anyone".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "trace.id".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("12345678".to_string())),
-                }),
-            },
-        ];
-        log_request.resource_logs[0].scope_logs[0].log_records[0].attributes = attrs.clone();
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-            log_request.resource_logs[0].clone(),
-        );
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            _run_script(
-                "attributes_processor_test.py",
-                py,
-                py_resource_logs,
-                Some("process_logs".to_string()),
-            )
-        })
-        .unwrap();
-
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-
-        let log_record = scope_logs.pop().unwrap().log_records.pop().unwrap();
-        let attrs_to_verify: HashMap<
-            String,
-            Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
-        > = log_record
-            .attributes
-            .into_iter()
-            .map(|kv| (kv.key, kv.value))
-            .collect();
-
-        let verify_attrs = |mut attrs: HashMap<
-            String,
-            Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
-        >| {
-            let host_name = attrs.remove("host.name").unwrap();
-            match host_name.unwrap().value.unwrap() {
-                Value::StringValue(h) => {
-                    assert_eq!(h, "my-server-1");
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let http_status_code = attrs.remove("http.status_code").unwrap();
-            match http_status_code.unwrap().value.unwrap() {
-                Value::StringValue(c) => {
-                    assert_eq!(c, "OK");
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let env = attrs.remove("env").unwrap();
-            match env.unwrap().value.unwrap() {
-                Value::StringValue(e) => {
-                    assert_eq!(e, "production");
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let email = attrs.remove("email").unwrap();
-            match email.unwrap().value.unwrap() {
-                Value::StringValue(h) => {
-                    assert_eq!(h, "test@example.com");
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let user_id = attrs.remove("user.id").unwrap();
-            match user_id.unwrap().value.unwrap() {
-                Value::StringValue(s) => {
-                    assert_eq!(
-                        s,
-                        "5942d94f524882e0f29bf0a1e5a6dcc952eea1c0c21dd3588a3fc7db9716db0c"
-                    );
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let trace_id = attrs.remove("trace.id").unwrap();
-            match trace_id.unwrap().value.unwrap() {
-                Value::StringValue(s) => {
-                    assert_eq!(
-                        s,
-                        "ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f"
-                    );
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let id = attrs.remove("extracted_id").unwrap();
-            match id.unwrap().value.unwrap() {
-                Value::StringValue(s) => {
-                    assert_eq!(s, "123");
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let temp_str_int = attrs.remove("temp_str_int").unwrap();
-            match temp_str_int.unwrap().value.unwrap() {
-                Value::IntValue(i) => {
-                    assert_eq!(i, 123);
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let temp_str_bool = attrs.remove("temp_str_bool").unwrap();
-            match temp_str_bool.unwrap().value.unwrap() {
-                Value::BoolValue(b) => {
-                    assert_eq!(b, true);
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let temp_str_float = attrs.remove("temp_str_float").unwrap();
-            match temp_str_float.unwrap().value.unwrap() {
-                Value::DoubleValue(d) => {
-                    assert_eq!(d, 10.0);
-                }
-                _ => panic!("Unexpected value type"),
-            }
-            let path = attrs.remove("path");
-            assert_eq!(path, None);
-            let super_secret = attrs.remove("super.secret");
-            assert_eq!(super_secret, None);
-        };
-
-        verify_attrs(attrs_to_verify);
-
-        let mut trace_request = FakeOTLP::trace_service_request();
-        trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = attrs.clone();
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
-            trace_request.resource_spans[0].clone(),
-        );
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_spans = ResourceSpans {
-            resource: r_resource_spans.resource.clone(),
-            scope_spans: r_resource_spans.scope_spans.clone(),
-            schema_url: r_resource_spans.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            _run_script(
-                "attributes_processor_test.py",
-                py,
-                py_resource_spans,
-                Some("process_spans".to_string()),
-            )
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-
-        let span = scope_spans.pop().unwrap().spans.pop().unwrap();
-        let attrs_to_verify: HashMap<
-            String,
-            Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
-        > = span
-            .attributes
-            .into_iter()
-            .map(|kv| (kv.key, kv.value))
-            .collect();
-
-        verify_attrs(attrs_to_verify);
-    }
-    #[test]
-    fn redaction_processor_restrictive_test() {
-        initialize();
-        let resource_attrs = vec![
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "host.arch".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("amd64".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "os.type".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("linux".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "region".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("us-east-1".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "service.name".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("my-service".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "unallowed_resource_key".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("some_value".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "deployment.environment".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("prod".to_string())),
-                }),
-            },
-        ];
-
-        let span_attrs = vec![
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "user.email".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("test@example.com".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "http.url".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue(
-                        "https://example.com/sensitive/path".to_string(),
-                    )),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "db.statement".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue(
-                        "SELECT * FROM users WHERE id = 1".to_string(),
-                    )),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "operation".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("get_data".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "some_token".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("abcdef123".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "api_key_header".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("xyz789".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "safe_attribute".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("this should remain".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "unallowed_span_key".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("should_be_deleted".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "my_company_email".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("user@mycompany.com".to_string())),
-                }),
-            },
-        ];
-
-        let mut trace_request = FakeOTLP::trace_service_request();
-        trace_request.resource_spans[0].resource =
-            Some(opentelemetry_proto::tonic::resource::v1::Resource {
-                attributes: resource_attrs.clone(),
-                dropped_attributes_count: 0,
-            });
-        trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
-            trace_request.resource_spans[0].clone(),
-        );
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_spans = ResourceSpans {
-            resource: r_resource_spans.resource.clone(),
-            scope_spans: r_resource_spans.scope_spans.clone(),
-            schema_url: r_resource_spans.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            _run_script(
-                "redaction_processor_restrictive_test.py",
-                py,
-                py_resource_spans,
-                Some("process_spans".to_string()),
-            )
-        })
-        .unwrap();
-
-        let resource = Arc::into_inner(r_resource_spans.resource)
-            .unwrap()
-            .into_inner()
-            .unwrap()
-            .unwrap();
-        let resource = crate::model::py_transform::transform_resource(resource).unwrap();
-        assert_eq!(9, resource.attributes.len());
-        let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
-            resource
-                .attributes
-                .into_iter()
-                .map(|kv| (kv.key.clone(), kv.value.clone()))
-                .collect();
-
-        let expected_attributes = HashMap::from([
-            ("host.arch", "amd64"),
-            ("os.type", "linux"),
-            ("region", "us-east-1"),
-            ("service.name", "my-service"),
-            ("deployment.environment", "prod"),
-            (
-                "redaction.resource.redacted_keys.names",
-                "unallowed_resource_key",
-            ),
-            (
-                "redaction.resource.allowed_keys.names",
-                "deployment.environment,host.arch,os.type,region,service.name",
-            ),
-            ("redaction.resource.redacted_keys.count", "1"),
-            ("redaction.resource.allowed_keys.count", "5"),
-        ]);
-
-        let validate =
-            |kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>>,
-             expected_attributes: HashMap<&str, &str>| {
-                for (key, value) in kv_map {
-                    let ev = expected_attributes.get(key.as_str());
-                    match ev {
-                        None => {
-                            panic!("key {:?} not found in expected attributes", key)
-                        }
-                        Some(v) => match value.unwrap().value.unwrap() {
-                            Value::StringValue(sv) => {
-                                assert_eq!(v.to_string(), sv.to_string());
-                            }
-                            Value::IntValue(i) => {
-                                let v: i64 = v.parse().expect("can't convert to int");
-                                assert_eq!(v, i);
-                            }
-                            _ => {
-                                panic!("expected string value")
-                            }
-                        },
-                    }
-                }
-            };
-
-        validate(kv_map, expected_attributes);
-
-        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-
-        let span = scope_spans.pop().unwrap().spans.pop().unwrap();
-        println!("span is {:?}", span);
-        assert_eq!(7, span.attributes.len());
-
-        let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
-            span.attributes
-                .into_iter()
-                .map(|kv| (kv.key.clone(), kv.value.clone()))
-                .collect();
-
-        let expected_attributes = HashMap::from([
-            ("operation", "get_data"),
-            ("safe_attribute", "this should remain"),
-            ("redaction.span.redacted_keys.count", "7"),
-            ("redaction.span.allowed_keys.names", "operation"),
-            ("redaction.span.allowed_keys.count", "1"),
-            ("redaction.span.redacted_keys.names", "api_key_header,db.statement,http.url,my_company_email,some_token,unallowed_span_key,user.email"),
-            ("redaction.span.ignored_keys.count", "1"),
-        ]);
-
-        validate(kv_map, expected_attributes)
-    }
-
-    #[test]
-    fn redaction_processor_blocking_test() {
-        initialize();
-        let span_attrs = vec![
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "session_token".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("foo".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "api_key".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("bar".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "password_hash".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("xyz123".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "visa".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("4123456789012".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "mastercard".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("5234567890123456".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "bl_email".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("foo@bar.com".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "allowed_email".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("test@mycompany.com".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "ip".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("10.0.1.100".to_string())),
-                }),
-            },
-            opentelemetry_proto::tonic::common::v1::KeyValue {
-                key: "query".to_string(),
-                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                    value: Some(Value::StringValue("SELECT * FROM USERS".to_string())),
-                }),
-            },
-        ];
-
-        let mut trace_request = FakeOTLP::trace_service_request();
-        trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
-            trace_request.resource_spans[0].clone(),
-        );
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_spans = ResourceSpans {
-            resource: r_resource_spans.resource.clone(),
-            scope_spans: r_resource_spans.scope_spans.clone(),
-            schema_url: r_resource_spans.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            _run_script(
-                "redaction_processor_blocking_test.py",
-                py,
-                py_resource_spans,
-                Some("process_spans".to_string()),
-            )
-        })
-        .unwrap();
-
-        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-
-        let span = scope_spans.pop().unwrap().spans.pop().unwrap();
-        assert_eq!(13, span.attributes.len());
-
-        let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
-            span.attributes
-                .into_iter()
-                .map(|kv| (kv.key.clone(), kv.value.clone()))
-                .collect();
-
-        let expected_attributes = HashMap::from([
-            ("visa", "8d9e470bdd9f6e6e18023938497857dc"),
-            ("mastercard", "aad9ce9b62a1f697745fcd81314b877f"),
-            ("ip", "f5c45dc3c8fb04f638ad27a711910390"),
-            ("query", "06c445f7ade97a964f7c466575f8b508"),
-            ("bl_email", "f3ada405ce890b6f8204094deb12d8a8"),
-            ("session_token", "acbd18db4cc2f85cedef654fccc4a4d8"),
-            ("allowed_email", "test@mycompany.com"),
-            ("api_key", "37b51d194a7513e45b56f6524f2d51f2"),
-            ("password_hash", "613d3b9c91e9445abaeca02f2342e5a6"),
-            ("redaction.span.allowed_keys.names", "allowed_email,api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
-            ("redaction.span.allowed_keys.count", "9"),
-            ("redaction.span.masked_keys.names", "api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
-            ("redaction.span.masked_keys.count", "8"),
-        ]);
-
-        for (key, value) in kv_map {
-            let ev = expected_attributes.get(key.as_str());
-            match ev {
-                None => {
-                    panic!("key {:?} not found in expected attributes", key)
-                }
-                Some(v) => match value.unwrap().value.unwrap() {
-                    Value::StringValue(sv) => {
-                        assert_eq!(v.to_string(), sv.to_string());
-                    }
-                    Value::IntValue(i) => {
-                        let v: i64 = v.parse().expect("can't convert to int");
-                        assert_eq!(v, i);
-                    }
-                    _ => {
-                        panic!("expected string value")
-                    }
-                },
-            }
-        }
-    }
-
-    #[test]
-    fn redaction_processor_log_body_test() {
-        initialize();
-        let mut logs_request = FakeOTLP::logs_service_request();
-        let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
-            value: Some(Value::StringValue(
-                "Login successful: password=1234567890".to_string(),
-            )),
-        };
-        logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-            logs_request.resource_logs[0].clone(),
-        );
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            _run_script(
-                "redaction_processor_log_body_test.py",
-                py,
-                py_resource_logs,
-                Some("process_logs".to_string()),
-            )
-        })
-        .unwrap();
-
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-        let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
-        let body = log.body.unwrap().value.unwrap();
-        match body {
-            Value::StringValue(b) => {
-                assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
-            }
-            _ => panic!("Unexpected log record value type"),
-        }
-
-        let mut logs_request = FakeOTLP::logs_service_request();
-        let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
-            value: Some(Value::KvlistValue(
-                opentelemetry_proto::tonic::common::v1::KeyValueList {
-                    values: vec![opentelemetry_proto::tonic::common::v1::KeyValue {
-                        key: "another_body".to_string(),
+                attributes: vec![
+                    opentelemetry_proto::tonic::common::v1::KeyValue {
+                        key: "resource_key".to_string(),
                         value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                            value: Some(Value::StringValue(
-                                "Login successful: password=1234567890".to_string(),
-                            )),
+                            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("resource_value".to_string())),
                         }),
-                    }],
-                },
-            )),
-        };
-        logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
-
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-            logs_request.resource_logs[0].clone(),
-        );
-
-        // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
-        };
-
-        // Execute the Python script that removes a log record
-        Python::with_gil(|py| -> PyResult<()> {
-            _run_script(
-                "redaction_processor_log_body_test.py",
-                py,
-                py_resource_logs,
-                Some("process_logs".to_string()),
-            )
-        })
-        .unwrap();
-
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-            .unwrap()
-            .into_inner()
-            .unwrap();
-        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-        let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
-        let body = log.body.unwrap().value.unwrap();
-        match body {
-            Value::KvlistValue(mut kvl) => {
-                let v = kvl.values.pop().unwrap();
-                match v.value.unwrap().value.unwrap() {
-                    Value::StringValue(b) => {
-                        assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
-                    }
-                    _ => {
-                        panic!("Unexpected log record value type");
-                    }
-                }
-            }
-            _ => panic!("Unexpected log record value type"),
-        }
-
-        let mut logs_request = FakeOTLP::logs_service_request();
-        let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
-            value: Some(Value::ArrayValue(
-                opentelemetry_proto::tonic::common::v1::ArrayValue {
-                    values: vec![
-                        opentelemetry_proto::tonic::common::v1::AnyValue {
-                            value: Some(Value::StringValue(
-                                "Login failed: password=1234567890".to_string(),
-                            )),
-                        },
-                        opentelemetry_proto::tonic::common::v1::AnyValue {
-                            value: Some(Value::KvlistValue(
-                                opentelemetry_proto::tonic::common::v1::KeyValueList {
-                                    values: vec![
-                                        opentelemetry_proto::tonic::common::v1::KeyValue {
-                                            key: "another_body".to_string(),
-                                            value: Some(
-                                                opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                    value: Some(Value::StringValue(
-                                                        "Login successful: password=1234567890"
-                                                            .to_string(),
-                                                    )),
+                    },
+                ],
+                dropped_attributes_count: 0,
+            }),
+            scope_metrics: vec![
+                opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
+                    scope: Some(opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+                        name: "initial_scope_name".to_string(),
+                        version: "1.0.0".to_string(),
+                        attributes: vec![
+                            opentelemetry_proto::tonic::common::v1::KeyValue {
+                                key: "initial_scope_key".to_string(),
+                                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                    value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(true)),
+                                }),
+                            },
+                        ],
+                        dropped_attributes_count: 0,
+                    }),
+                    metrics: vec![
+                        opentelemetry_proto::tonic::metrics::v1::Metric {
+                            name: "initial_metric_name".to_string(),
+                            description: "initial_description".to_string(),
+                            unit: "initial_unit".to_string(),
+                            metadata: vec![
+                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                    key: "initial_metadata_key".to_string(),
+                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("initial_metadata_value".to_string())),
+                                    }),
+                                },
+                            ],
+                            data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(
+                                opentelemetry_proto::tonic::metrics::v1::Gauge {
+                                    data_points: vec![
+                                        opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+                                            attributes: vec![
+                                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                    key: "dp_key".to_string(),
+                                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("dp_value".to_string())),
+                                                    }),
                                                 },
-                                            ),
+                                            ],
+                                            start_time_unix_nano: 1000,
+                                            time_unix_nano: 2000,
+                                            exemplars: vec![],
+                                            flags: 0,
+                                            value: Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsDouble(123.45)),
                                         },
                                     ],
                                 },
                             )),
                         },
                     ],
+                    schema_url: "initial_schema_url_scope".to_string(),
                 },
-            )),
+            ],
+            schema_url: "initial_schema_url_resource".to_string(),
         };
-        logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
 
-        // Transform the protobuf ResourceLogs into our internal RResourceLogs
-        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-            logs_request.resource_logs[0].clone(),
-        );
-
+        // 2. Use otel_transform to turn it into our RMetricsData model
+        let r_resource_metrics = otel_transform::transform_resource_metrics(resource_metrics);
         // Create the Python-exposed ResourceLogs object
-        let py_resource_logs = ResourceLogs {
-            resource: r_resource_logs.resource.clone(),
-            scope_logs: r_resource_logs.scope_logs.clone(),
-            schema_url: r_resource_logs.schema_url.clone(),
+        let py_resource_metrics = ResourceMetrics {
+            resource: r_resource_metrics.resource.clone(),
+            scope_metrics: r_resource_metrics.scope_metrics.clone(),
+            schema_url: r_resource_metrics.schema_url.clone(),
         };
 
         // Execute the Python script that removes a log record
         Python::with_gil(|py| -> PyResult<()> {
             _run_script(
-                "redaction_processor_log_body_test.py",
+                "read_and_write_metrics_test.py",
                 py,
-                py_resource_logs,
-                Some("process_logs".to_string()),
+                py_resource_metrics,
+                Some("process_metrics".to_string()),
             )
         })
         .unwrap();
-        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+
+        let scope_metrics_vec = Arc::into_inner(r_resource_metrics.scope_metrics)
             .unwrap()
             .into_inner()
             .unwrap();
-        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-        let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
-        let body = log.body.unwrap().value.unwrap();
-        match body {
-            Value::ArrayValue(mut av) => {
-                assert_eq!(av.values.len(), 2);
-                while !av.values.is_empty() {
-                    let v = av.values.pop().unwrap();
-                    match v.value.unwrap() {
-                        Value::StringValue(b) => {
-                            assert_eq!(b, "34c37eb5ba287d52490cc8c2e3ebc231");
-                        }
-                        Value::KvlistValue(mut kvl) => {
-                            let v = kvl.values.pop().unwrap();
-                            match v.value.unwrap().value.unwrap() {
-                                Value::StringValue(b) => {
-                                    assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
-                                }
-                                _ => {
-                                    panic!("Unexpected log record value type");
-                                }
-                            }
-                        }
-                        _ => {
-                            panic!("Unexpected log record value type");
-                        }
-                    }
-                }
+        let mut scope_metrics = py_transform::transform_metrics(scope_metrics_vec);
+        println!("{:#?}", scope_metrics);
+        // let final_proto_metrics_data = scope_metrics.pop().unwrap();
+        // assert_eq!(final_proto_metrics_data.resource_metrics.len(), 1);
+        // let proto_resource_metrics = &final_proto_metrics_data.resource_metrics[0];
+        //
+        // assert_eq!(proto_resource_metrics.schema_url, "py_processed_schema_url_resource");
+        // assert!(proto_resource_metrics.resource.is_some());
+        // let proto_resource = proto_resource_metrics.resource.as_ref().unwrap();
+        // assert_eq!(proto_resource.dropped_attributes_count, 5);
+
+        assert_eq!(scope_metrics.len(), 1);
+
+        let proto_scope_metrics = &scope_metrics[0];
+        assert_eq!(
+            proto_scope_metrics.schema_url,
+            "py_processed_schema_url_scope"
+        );
+        assert!(proto_scope_metrics.scope.is_some());
+        let proto_scope = proto_scope_metrics.scope.as_ref().unwrap();
+        assert_eq!(proto_scope.name, "py_processed_scope_name");
+        assert_eq!(proto_scope.version, "py_processed_scope_version");
+        assert_eq!(proto_scope.attributes.len(), 2);
+        assert_eq!(proto_scope.attributes[1].key, "scope_attr_py");
+        assert_eq!(
+            proto_scope.attributes[1]
+                .value
+                .as_ref()
+                .unwrap()
+                .value
+                .as_ref()
+                .unwrap(),
+            &opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(true)
+        );
+        assert_eq!(proto_scope.dropped_attributes_count, 1);
+
+        assert_eq!(proto_scope_metrics.metrics.len(), 2); // Original (now Sum) + new Histogram
+
+        // Assert the first metric (originally Gauge, now Sum)
+        let proto_sum_metric = &proto_scope_metrics.metrics[0];
+        assert_eq!(proto_sum_metric.name, "py_processed_metric_name");
+        assert_eq!(proto_sum_metric.description, "py_processed_description");
+        assert_eq!(proto_sum_metric.unit, "py_processed_unit");
+        assert_eq!(proto_sum_metric.metadata.len(), 2);
+        assert_eq!(proto_sum_metric.metadata[1].key, "metadata_py");
+        assert_eq!(
+            proto_sum_metric.metadata[1]
+                .value
+                .as_ref()
+                .unwrap()
+                .value
+                .as_ref()
+                .unwrap(),
+            &opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(999)
+        );
+
+        assert!(proto_sum_metric.data.is_some());
+        match proto_sum_metric.data.as_ref().unwrap() {
+            opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(s) => {
+                assert_eq!(
+                    s.aggregation_temporality,
+                    AggregationTemporality::Cumulative as i32
+                );
+                assert!(s.is_monotonic);
+                assert_eq!(s.data_points.len(), 2);
+
+                let sum_dp1 = &s.data_points[0];
+                assert_eq!(sum_dp1.start_time_unix_nano, 3000);
+                assert_eq!(sum_dp1.time_unix_nano, 4000);
+                assert_eq!(
+                    sum_dp1.value.as_ref().unwrap(),
+                    &opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(10)
+                );
+                assert_eq!(sum_dp1.attributes[0].key, "sum_dp_key");
+                assert_eq!(
+                    sum_dp1.attributes[0]
+                        .value
+                        .as_ref()
+                        .unwrap()
+                        .value
+                        .as_ref()
+                        .unwrap(),
+                    &opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                        "sum_dp_value".to_string()
+                    )
+                );
+                assert_eq!(sum_dp1.exemplars.len(), 1);
+                assert_eq!(sum_dp1.exemplars[0].time_unix_nano, 3500);
+                assert_eq!(
+                    sum_dp1.exemplars[0].value.as_ref().unwrap(),
+                    &opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsDouble(10.5)
+                );
+                assert_eq!(
+                    sum_dp1.exemplars[0].span_id,
+                    b"\x01\x02\x03\x04\x05\x06\x07\x08"
+                );
+                assert_eq!(
+                    sum_dp1.exemplars[0].trace_id,
+                    b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01"
+                );
+                assert_eq!(
+                    sum_dp1.exemplars[0].filtered_attributes[0].key,
+                    "filtered_key"
+                );
+                assert_eq!(
+                    sum_dp1.exemplars[0].filtered_attributes[0]
+                        .value
+                        .as_ref()
+                        .unwrap()
+                        .value
+                        .as_ref()
+                        .unwrap(),
+                    &opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                        "filtered_value".to_string()
+                    )
+                );
+
+                let sum_dp2 = &s.data_points[1];
+                assert_eq!(
+                    sum_dp2.value.as_ref().unwrap(),
+                    &opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(20)
+                );
+                assert_eq!(sum_dp2.flags, DataPointFlags::NoRecordedValueMask as u32);
             }
-            _ => {
-                panic!("Unexpected log record value type");
+            _ => panic!("Expected Sum metric data"),
+        }
+
+        // Assert the second metric (new Histogram)
+        let proto_hist_metric = &proto_scope_metrics.metrics[1];
+        assert_eq!(proto_hist_metric.name, "py_processed_histogram");
+        assert_eq!(proto_hist_metric.description, "A histogram from Python");
+        assert_eq!(proto_hist_metric.unit, "ms");
+
+        assert!(proto_hist_metric.data.is_some());
+        match proto_hist_metric.data.as_ref().unwrap() {
+            opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(h) => {
+                assert_eq!(
+                    h.aggregation_temporality,
+                    AggregationTemporality::Delta as i32
+                );
+                assert_eq!(h.data_points.len(), 1);
+                let hist_dp = &h.data_points[0];
+                assert_eq!(hist_dp.start_time_unix_nano, 7000);
+                assert_eq!(hist_dp.time_unix_nano, 8000);
+                assert_eq!(hist_dp.count, 100);
+                assert_eq!(hist_dp.sum.unwrap(), 1000.0);
+                assert_eq!(hist_dp.bucket_counts, vec![10, 20, 30, 40]);
+                assert_eq!(hist_dp.explicit_bounds, vec![1.0, 5.0, 10.0]);
+                assert_eq!(hist_dp.min.unwrap(), 0.5);
+                assert_eq!(hist_dp.max.unwrap(), 12.0);
+                assert_eq!(hist_dp.attributes[0].key, "hist_attr");
+                assert_eq!(
+                    hist_dp.attributes[0]
+                        .value
+                        .as_ref()
+                        .unwrap()
+                        .value
+                        .as_ref()
+                        .unwrap(),
+                    &opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                        "hist_value".to_string()
+                    )
+                );
+
+                assert_eq!(hist_dp.exemplars.len(), 1);
+                assert_eq!(hist_dp.exemplars[0].time_unix_nano, 7500);
+                assert_eq!(
+                    hist_dp.exemplars[0].value.as_ref().unwrap(),
+                    &opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsInt(75)
+                );
             }
+            _ => panic!("Expected Histogram metric data"),
         }
     }
 }

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -1,5 +1,6 @@
 pub mod common;
 pub mod logs;
+mod metrics;
 pub mod resource;
 pub mod trace;
 

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -2589,7 +2589,7 @@ mod tests {
     }
 
     #[test]
-    fn read_and_write_metrics_comprehensive() {
+    fn read_and_write_metrics_test() {
         initialize();
 
         // Create comprehensive initial OpenTelemetry protobuf with ALL metric types
@@ -2599,7 +2599,7 @@ mod tests {
                     opentelemetry_proto::tonic::common::v1::KeyValue {
                         key: "initial_resource_key".to_string(),
                         value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("initial_resource_value".to_string())),
+                            value: Some(Value::StringValue("initial_resource_value".to_string())),
                         }),
                     },
                 ],
@@ -2614,7 +2614,7 @@ mod tests {
                             opentelemetry_proto::tonic::common::v1::KeyValue {
                                 key: "initial_scope_key".to_string(),
                                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                    value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(true)),
+                                    value: Some(Value::BoolValue(true)),
                                 }),
                             },
                         ],
@@ -2630,7 +2630,7 @@ mod tests {
                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                     key: "gauge_metadata_key".to_string(),
                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("gauge_metadata_value".to_string())),
+                                        value: Some(Value::StringValue("gauge_metadata_value".to_string())),
                                     }),
                                 },
                             ],
@@ -2642,7 +2642,7 @@ mod tests {
                                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                                     key: "gauge_dp_key".to_string(),
                                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("gauge_dp_value".to_string())),
+                                                        value: Some(Value::StringValue("gauge_dp_value".to_string())),
                                                     }),
                                                 },
                                             ],
@@ -2654,7 +2654,7 @@ mod tests {
                                                         opentelemetry_proto::tonic::common::v1::KeyValue {
                                                             key: "gauge_exemplar_key".to_string(),
                                                             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                                value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("gauge_exemplar_value".to_string())),
+                                                                value: Some(Value::StringValue("gauge_exemplar_value".to_string())),
                                                             }),
                                                         },
                                                     ],
@@ -2680,7 +2680,7 @@ mod tests {
                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                     key: "sum_metadata_key".to_string(),
                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(42)),
+                                        value: Some(Value::IntValue(42)),
                                     }),
                                 },
                             ],
@@ -2692,7 +2692,7 @@ mod tests {
                                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                                     key: "sum_dp_key".to_string(),
                                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("sum_dp_value".to_string())),
+                                                        value: Some(Value::StringValue("sum_dp_value".to_string())),
                                                     }),
                                                 },
                                             ],
@@ -2717,7 +2717,7 @@ mod tests {
                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                     key: "histogram_metadata_key".to_string(),
                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(false)),
+                                        value: Some(Value::BoolValue(false)),
                                     }),
                                 },
                             ],
@@ -2729,7 +2729,7 @@ mod tests {
                                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                                     key: "histogram_dp_key".to_string(),
                                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("histogram_dp_value".to_string())),
+                                                        value: Some(Value::StringValue("histogram_dp_value".to_string())),
                                                     }),
                                                 },
                                             ],
@@ -2766,7 +2766,7 @@ mod tests {
                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                     key: "exp_histogram_metadata_key".to_string(),
                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(3.14)),
+                                        value: Some(Value::DoubleValue(3.14)),
                                     }),
                                 },
                             ],
@@ -2778,7 +2778,7 @@ mod tests {
                                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                                     key: "exp_histogram_dp_key".to_string(),
                                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("exp_histogram_dp_value".to_string())),
+                                                        value: Some(Value::StringValue("exp_histogram_dp_value".to_string())),
                                                     }),
                                                 },
                                             ],
@@ -2803,7 +2803,7 @@ mod tests {
                                                         opentelemetry_proto::tonic::common::v1::KeyValue {
                                                             key: "exp_exemplar_key".to_string(),
                                                             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                                value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("exp_exemplar_value".to_string())),
+                                                                value: Some(Value::StringValue("exp_exemplar_value".to_string())),
                                                             }),
                                                         },
                                                     ],
@@ -2831,7 +2831,7 @@ mod tests {
                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                     key: "summary_metadata_key".to_string(),
                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(b"summary_bytes".to_vec())),
+                                        value: Some(Value::BytesValue(b"summary_bytes".to_vec())),
                                     }),
                                 },
                             ],
@@ -2843,7 +2843,7 @@ mod tests {
                                                 opentelemetry_proto::tonic::common::v1::KeyValue {
                                                     key: "summary_dp_key".to_string(),
                                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("summary_dp_value".to_string())),
+                                                        value: Some(Value::StringValue("summary_dp_value".to_string())),
                                                     }),
                                                 },
                                             ],
@@ -3078,7 +3078,6 @@ mod tests {
             }
             _ => panic!("Expected Summary metric data"),
         }
-
         println!("All comprehensive metric mutation verifications passed!");
     }
 }

--- a/rotel_python_processor_sdk/src/py/mod.rs
+++ b/rotel_python_processor_sdk/src/py/mod.rs
@@ -7,8 +7,9 @@ pub mod trace;
 use crate::py;
 use crate::py::common::KeyValue;
 use crate::py::metrics::{
-    AggregationTemporality, DataPointFlags, Exemplar, ExemplarValue, Gauge, Histogram,
-    HistogramDataPoint, Metric, MetricData, NumberDataPoint, NumberDataPointValue, Sum,
+    AggregationTemporality, DataPointFlags, Exemplar, ExemplarValue, ExponentialHistogramBuckets,
+    ExponentialHistogramDataPoint, Gauge, Histogram, HistogramDataPoint, Metric, MetricData,
+    NumberDataPoint, NumberDataPointValue, Sum, SummaryDataPoint, ValueAtQuantile,
 };
 use py::common::*;
 use py::logs::*;
@@ -140,6 +141,10 @@ pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
     metrics_v1_module.add_class::<AggregationTemporality>()?;
     metrics_v1_module.add_class::<DataPointFlags>()?;
     metrics_v1_module.add_class::<NumberDataPointValue>()?;
+    metrics_v1_module.add_class::<ExponentialHistogramBuckets>()?;
+    metrics_v1_module.add_class::<ExponentialHistogramDataPoint>()?;
+    metrics_v1_module.add_class::<SummaryDataPoint>()?;
+    metrics_v1_module.add_class::<ValueAtQuantile>()?;
 
     Ok(())
 }
@@ -149,12 +154,17 @@ pub fn rotel_sdk(m: &Bound<'_, PyModule>) -> PyResult<()> {
 mod tests {
     use super::*;
     use crate::model::common::RValue::*;
+    use crate::model::common::{RAnyValue, RKeyValue};
     use crate::model::{otel_transform, py_transform};
     use crate::py::metrics::ResourceMetrics;
     use chrono::Utc;
+    use opentelemetry_proto::tonic::common::v1::any_value::Value;
+    use opentelemetry_proto::tonic::trace::v1;
     use pyo3::ffi::c_str;
+    use std::collections::HashMap;
     use std::ffi::CString;
-    use std::sync::{Arc, Once};
+    use std::sync::{Arc, Mutex, Once};
+    use utilities::otlp::FakeOTLP;
 
     static INIT: Once = Once::new();
 
@@ -196,2458 +206,2404 @@ mod tests {
         Ok(())
     }
 
-    // #[test]
-    // fn test_read_any_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //
-    //     let pv = AnyValue {
-    //         inner: any_value_arc.clone(),
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> { run_script("read_value_test.py", py, pv) })
-    //         .unwrap();
-    //     let av = any_value_arc.lock().unwrap().clone().unwrap();
-    //     let avx = av.value.lock().unwrap().clone();
-    //     match avx.unwrap() {
-    //         StringValue(s) => {
-    //             assert_eq!(s, "foo");
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn write_string_any_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let pv = AnyValue {
-    //         inner: any_value_arc.clone(),
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> { run_script("write_string_value_test.py", py, pv) })
-    //         .unwrap();
-    //     let av = any_value_arc.lock().unwrap().clone().unwrap();
-    //     let avx = av.value.lock().unwrap().clone();
-    //     match avx.unwrap() {
-    //         StringValue(s) => {
-    //             assert_eq!(s, "changed");
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn write_bool_any_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //
-    //     let pv = AnyValue {
-    //         inner: any_value_arc.clone(),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> { run_script("write_bool_value_test.py", py, pv) })
-    //         .unwrap();
-    //     match arc_value.lock().unwrap().clone().unwrap() {
-    //         BoolValue(b) => {
-    //             assert!(b);
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn write_bytes_any_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //
-    //     let pv = AnyValue {
-    //         inner: any_value_arc.clone(),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> { run_script("write_bytes_value_test.py", py, pv) })
-    //         .unwrap();
-    //     match arc_value.lock().unwrap().clone().unwrap() {
-    //         BytesValue(b) => {
-    //             assert_eq!(b"111111".to_vec(), b);
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn read_key_value_key() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = KeyValue {
-    //         inner: Arc::new(Mutex::new(RKeyValue {
-    //             key: key.clone(),
-    //             value: any_value_arc.clone(),
-    //         })),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> { run_script("read_key_value_key_test.py", py, kv) })
-    //         .unwrap();
-    //     let av = key.clone().lock().unwrap().clone();
-    //     assert_eq!(av, "key".to_string());
-    //     println!("{:?}", av);
-    // }
-    //
-    // #[test]
-    // fn write_key_value_key() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = KeyValue {
-    //         inner: Arc::new(Mutex::new(RKeyValue {
-    //             key: key.clone(),
-    //             value: any_value_arc.clone(),
-    //         })),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("write_key_value_key_test.py", py, kv)
-    //     })
-    //     .unwrap();
-    //     let av = key.clone().lock().unwrap().clone();
-    //     assert_eq!(av, "new_key".to_string());
-    //     println!("{:?}", av);
-    // }
-    //
-    // #[test]
-    // fn read_key_value_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = KeyValue {
-    //         inner: Arc::new(Mutex::new(RKeyValue {
-    //             key: key.clone(),
-    //             value: any_value_arc.clone(),
-    //         })),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("read_key_value_value_test.py", py, kv)
-    //     })
-    //     .unwrap();
-    //     match arc_value.lock().unwrap().clone().unwrap() {
-    //         StringValue(s) => {
-    //             assert_eq!(s, "foo");
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn write_key_value_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = KeyValue {
-    //         inner: Arc::new(Mutex::new(RKeyValue {
-    //             key: key.clone(),
-    //             value: any_value_arc.clone(),
-    //         })),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("write_key_value_value_test.py", py, kv)
-    //     })
-    //     .unwrap();
-    //     match arc_value.lock().unwrap().clone().unwrap() {
-    //         StringValue(s) => {
-    //             assert_eq!(s, "changed");
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn write_key_value_bytes_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = KeyValue {
-    //         inner: Arc::new(Mutex::new(RKeyValue {
-    //             key: key.clone(),
-    //             value: any_value_arc.clone(),
-    //         })),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("write_key_value_bytes_value_test.py", py, kv)
-    //     })
-    //     .unwrap();
-    //     match arc_value.lock().unwrap().clone().unwrap() {
-    //         BytesValue(s) => {
-    //             assert_eq!(b"111111".to_vec(), s);
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn read_resource_attributes() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //
-    //     let resource = Resource {
-    //         attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("read_resource_attributes_test.py", py, resource)
-    //     })
-    //     .unwrap();
-    // }
-    //
-    // #[test]
-    // fn read_and_write_attributes_array_value() {
-    //     initialize();
-    //
-    //     let arc_value = Some(StringValue("foo".to_string()));
-    //     let any_value_arc = Some(RAnyValue {
-    //         value: Arc::new(Mutex::new(arc_value)),
-    //     });
-    //     let array_value = crate::model::common::RArrayValue {
-    //         values: Arc::new(Mutex::new(vec![Arc::new(Mutex::new(
-    //             any_value_arc.clone(),
-    //         ))])),
-    //     };
-    //     let array_value_arc = Arc::new(Mutex::new(Some(RVArrayValue(array_value))));
-    //     let any_value_array_value_wrapper = Some(RAnyValue {
-    //         value: array_value_arc.clone(),
-    //     });
-    //
-    //     let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
-    //
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_array_value_wrapper_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //     let attrs = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-    //
-    //     let resource = Resource {
-    //         attributes: attrs.clone(),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script(
-    //             "read_and_write_attributes_array_value_test.py",
-    //             py,
-    //             resource,
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let attrs = Arc::into_inner(attrs).unwrap();
-    //     let mut attrs = attrs.into_inner().unwrap();
-    //     let attr = Arc::into_inner(attrs.pop().unwrap()).unwrap();
-    //     let attr = attr.into_inner().unwrap();
-    //     let key = attr.key.lock().unwrap();
-    //     assert_eq!("my_array", *key);
-    //     let value = attr.value.lock().unwrap();
-    //     assert!(value.is_some());
-    //     let v = value.clone().unwrap();
-    //     let v = v.value.lock().unwrap();
-    //     assert!(v.is_some());
-    //     let v = v.clone().unwrap();
-    //     match v {
-    //         RVArrayValue(av) => {
-    //             println!("{:?}", av);
-    //             let mut vals = av.values.lock().unwrap();
-    //             let vv = vals.pop().unwrap();
-    //             let v = vv.lock().unwrap();
-    //             let v = v.clone().unwrap();
-    //             let v = v.value.clone().lock().unwrap().clone().unwrap();
-    //             match v {
-    //                 IntValue(v) => {
-    //                     assert_eq!(v, 123456789)
-    //                 }
-    //                 _ => panic!("wrong value type"),
-    //             }
-    //         }
-    //         _ => panic!("wrong value type"),
-    //     }
-    // }
-    //
-    // #[test]
-    // fn read_and_write_attributes_key_value_list_value() {
-    //     initialize();
-    //
-    //     let value = Some(StringValue("foo".to_string()));
-    //     let any_value = Some(RAnyValue {
-    //         value: Arc::new(Mutex::new(value)),
-    //     });
-    //     let any_value_arc = Arc::new(Mutex::new(any_value));
-    //     let arc_key = Arc::new(Mutex::new("inner_key".to_string()));
-    //
-    //     let kev_value = RKeyValue {
-    //         key: arc_key.clone(),
-    //         value: any_value_arc.clone(),
-    //     };
-    //
-    //     let kv_list = crate::model::common::RKeyValueList {
-    //         values: Arc::new(Mutex::new(vec![kev_value])),
-    //     };
-    //
-    //     let array_value_arc = Arc::new(Mutex::new(Some(KvListValue(kv_list))));
-    //     let any_value_array_value_wrapper = Some(RAnyValue {
-    //         value: array_value_arc.clone(),
-    //     });
-    //
-    //     let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
-    //
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_array_value_wrapper_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //
-    //     let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-    //     let resource = Resource {
-    //         attributes: attrs_arc.clone(),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script(
-    //             "read_and_write_attributes_key_value_list_test.py",
-    //             py,
-    //             resource,
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let mut value = attrs_arc.lock().unwrap();
-    //     let value = value.pop().unwrap();
-    //     let value = Arc::into_inner(value).unwrap().into_inner().unwrap();
-    //     let value = Arc::into_inner(value.value).unwrap().into_inner().unwrap();
-    //     let value = value.unwrap().value;
-    //     let value = Arc::into_inner(value)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap()
-    //         .unwrap();
-    //     match value {
-    //         KvListValue(k) => {
-    //             let mut value = k.values.lock().unwrap().clone();
-    //             let value = value.pop();
-    //             match value {
-    //                 None => {
-    //                     panic!("wrong type")
-    //                 }
-    //                 Some(v) => {
-    //                     let v = v.value.lock().unwrap().clone();
-    //                     match v {
-    //                         None => {
-    //                             panic!("wrong type")
-    //                         }
-    //                         Some(v) => {
-    //                             let value = v.value.lock().unwrap().clone().unwrap();
-    //                             match value {
-    //                                 IntValue(i) => assert_eq!(100, i),
-    //                                 _ => panic!("wrong type"),
-    //                             }
-    //                         }
-    //                     }
-    //                 }
-    //             }
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    // }
-    //
-    // #[test]
-    // fn write_resource_attributes_key_value_key() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //
-    //     let resource = Resource {
-    //         attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script(
-    //             "write_resource_attributes_key_value_key_test.py",
-    //             py,
-    //             resource,
-    //         )
-    //     })
-    //     .unwrap();
-    //     let av = key.clone().lock().unwrap().clone();
-    //     assert_eq!(av, "new_key".to_string());
-    //     println!("{:?}", av);
-    // }
-    //
-    // #[test]
-    // fn write_resource_attributes_key_value_value() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //
-    //     let resource = Resource {
-    //         attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script(
-    //             "write_resource_attributes_key_value_value_test.py",
-    //             py,
-    //             resource,
-    //         )
-    //     })
-    //     .unwrap();
-    //     match arc_value.lock().unwrap().clone().unwrap() {
-    //         StringValue(s) => {
-    //             assert_eq!(s, "changed");
-    //         }
-    //         _ => panic!("wrong type"),
-    //     }
-    //     println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
-    // }
-    //
-    // #[test]
-    // fn resource_attributes_append_attribute() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //     let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-    //     let resource = Resource {
-    //         attributes: attrs_arc.clone(),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("resource_attributes_append_attribute.py", py, resource)
-    //     })
-    //     .unwrap();
-    //     println!("{:#?}", attrs_arc.lock().unwrap());
-    // }
-    //
-    // #[test]
-    // fn resource_attributes_set_attributes() {
-    //     initialize();
-    //     let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
-    //     let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
-    //         value: arc_value.clone(),
-    //     })));
-    //     let key = Arc::new(Mutex::new("key".to_string()));
-    //
-    //     let kv = RKeyValue {
-    //         key: key.clone(),
-    //         value: any_value_arc.clone(),
-    //     };
-    //
-    //     let kv_arc = Arc::new(Mutex::new(kv));
-    //     let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
-    //     let resource = Resource {
-    //         attributes: attrs_arc.clone(),
-    //         dropped_attributes_count: Arc::new(Mutex::new(0)),
-    //     };
-    //
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("resource_attributes_set_attributes.py", py, resource)
-    //     })
-    //     .unwrap();
-    //     println!("{:#?}", attrs_arc.lock().unwrap());
-    //     let attrs = attrs_arc.lock().unwrap();
-    //     assert_eq!(2, attrs.len());
-    //     for kv in attrs.iter() {
-    //         let guard = kv.lock();
-    //         let kv_guard = guard.unwrap();
-    //         let key = kv_guard.key.lock().unwrap().to_string();
-    //         let value = kv_guard.value.lock().unwrap();
-    //         assert_ne!(key, "key");
-    //         assert!(key == "double.value" || key == "os.version");
-    //         assert!(value.is_some());
-    //         let av = value.clone().unwrap();
-    //         let value = av.value.lock().unwrap();
-    //         assert!(value.is_some());
-    //     }
-    // }
-    //
-    // #[test]
-    // fn resource_spans_append_attributes() {
-    //     initialize();
-    //     let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: Arc::new(Mutex::new(vec![])),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("resource_spans_append_attribute.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //     println!("{:#?}", resource_spans.resource.lock().unwrap());
-    // }
-    //
-    // #[test]
-    // fn resource_spans_iterate_spans() {
-    //     initialize();
-    //     let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("resource_spans_iterate_spans.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //     println!("{:#?}", resource_spans.resource.lock().unwrap());
-    // }
-    //
-    // #[test]
-    // fn read_and_write_instrumentation_scope() {
-    //     initialize();
-    //     let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script(
-    //             "read_and_write_instrumentation_scope_test.py",
-    //             py,
-    //             py_resource_spans,
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let scope_spans = scope_spans.pop().unwrap();
-    //     let scope = scope_spans.scope.unwrap();
-    //     assert_eq!("name_changed", scope.name);
-    //     assert_eq!("0.0.2", scope.version);
-    //     assert_eq!(100, scope.dropped_attributes_count);
-    //     assert_eq!(scope.attributes.len(), 2);
-    //     for attr in &scope.attributes {
-    //         let value = attr.value.clone().unwrap();
-    //         let value = value.value.unwrap();
-    //         match attr.key.as_str() {
-    //             "key_changed" => match value {
-    //                 opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i) => {
-    //                     assert_eq!(i, 200);
-    //                 }
-    //                 _ => {
-    //                     panic!("wrong type for key_changed: {:?}", value);
-    //                 }
-    //             },
-    //             "severity" => match value {
-    //                 opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
-    //                     assert_eq!(s, "WARN");
-    //                 }
-    //                 _ => {
-    //                     panic!("wrong type for severity: {:?}", value);
-    //                 }
-    //             },
-    //             _ => {
-    //                 panic!("unexpected key")
-    //             }
-    //         }
-    //     }
-    // }
-    // #[test]
-    // fn set_instrumentation_scope() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("set_instrumentation_scope_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let scope_spans = scope_spans.pop().unwrap();
-    //     let scope = scope_spans.scope.unwrap();
-    //     assert_eq!("name_changed", scope.name);
-    //     assert_eq!("0.0.2", scope.version);
-    //     assert_eq!(100, scope.dropped_attributes_count);
-    //     assert_eq!(scope.attributes.len(), 1);
-    //     for attr in &scope.attributes {
-    //         let value = attr.value.clone().unwrap();
-    //         let value = value.value.unwrap();
-    //         match attr.key.as_str() {
-    //             "severity" => match value {
-    //                 Value::StringValue(s) => {
-    //                     assert_eq!(s, "WARN");
-    //                 }
-    //                 _ => {
-    //                     panic!("wrong type for severity: {:?}", value);
-    //                 }
-    //             },
-    //             _ => {
-    //                 panic!("unexpected key")
-    //             }
-    //         }
-    //     }
-    // }
-    //
-    // #[test]
-    // fn read_and_write_spans() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("read_and_write_spans_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let resource = Arc::into_inner(resource_spans.resource);
-    //     let resource = resource.unwrap().into_inner().unwrap().unwrap();
-    //     let dropped = Arc::into_inner(resource.dropped_attributes_count);
-    //     let dropped = dropped.unwrap().into_inner().unwrap();
-    //
-    //     assert_eq!(15, dropped);
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let mut scope_spans = scope_spans.pop().unwrap();
-    //     let mut span = scope_spans.spans.pop().unwrap();
-    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
-    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
-    //     assert_eq!("test=1234567890", span.trace_state);
-    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-    //     assert_eq!(1, span.flags);
-    //     assert_eq!("py_processed_span", span.name);
-    //     assert_eq!(4, span.kind);
-    //     assert_eq!(1234567890, span.start_time_unix_nano);
-    //     assert_eq!(1234567890, span.end_time_unix_nano);
-    //     assert_eq!(100, span.dropped_attributes_count);
-    //     assert_eq!(200, span.dropped_events_count);
-    //     assert_eq!(300, span.dropped_links_count);
-    //     assert_eq!("error message", span.status.clone().unwrap().message);
-    //     assert_eq!(2, span.status.unwrap().code);
-    //     assert_eq!(1, span.events.len());
-    //     assert_eq!("py_processed_event", span.events[0].name);
-    //     assert_eq!(1234567890, span.events[0].time_unix_nano);
-    //     assert_eq!(400, span.events[0].dropped_attributes_count);
-    //     assert_eq!(1, span.events[0].attributes.len());
-    //     assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
-    //     let value = span.events[0].attributes[0]
-    //         .value
-    //         .clone()
-    //         .unwrap()
-    //         .value
-    //         .unwrap();
-    //     match value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!("event_attr_value", s)
-    //         }
-    //         _ => panic!("unexpected type"),
-    //     }
-    //
-    //     assert_eq!(2, span.links.len());
-    //     // get the newly added link
-    //     let new_link = span.links.remove(1);
-    //     assert_eq!(b"88888888".to_vec(), new_link.trace_id);
-    //     assert_eq!(b"99999999".to_vec(), new_link.span_id);
-    //     assert_eq!("test=1234567890", new_link.trace_state);
-    //     assert_eq!(300, new_link.dropped_attributes_count);
-    //     assert_eq!(1, new_link.flags);
-    //     assert_eq!(1, new_link.attributes.len());
-    //     let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
-    //     match value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!("link_attr_value", s)
-    //         }
-    //         _ => panic!("unexpected type"),
-    //     }
-    //
-    //     assert_eq!(3, span.attributes.len());
-    //     let new_attr = span.attributes.remove(2);
-    //     assert_eq!("span_attr_key2", new_attr.key);
-    //     let value = new_attr.value.clone().unwrap().value.unwrap();
-    //     match value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!("span_attr_value2", s)
-    //         }
-    //         _ => panic!("unexpected type"),
-    //     }
-    // }
-    // #[test]
-    // fn set_scope_spans_span_test() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("set_scope_spans_span_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let mut scope_spans = scope_spans.pop().unwrap();
-    //     let mut span = scope_spans.spans.pop().unwrap();
-    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
-    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
-    //     assert_eq!("test=1234567890", span.trace_state);
-    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-    //     assert_eq!(1, span.flags);
-    //     assert_eq!("py_processed_span", span.name);
-    //     assert_eq!(4, span.kind);
-    //     assert_eq!(1234567890, span.start_time_unix_nano);
-    //     assert_eq!(1234567890, span.end_time_unix_nano);
-    //     assert_eq!(100, span.dropped_attributes_count);
-    //     assert_eq!(200, span.dropped_events_count);
-    //     assert_eq!(300, span.dropped_links_count);
-    //     assert_eq!("error message", span.status.clone().unwrap().message);
-    //     assert_eq!(2, span.status.unwrap().code);
-    //     assert_eq!(1, span.events.len());
-    //     assert_eq!("py_processed_event", span.events[0].name);
-    //     assert_eq!(1234567890, span.events[0].time_unix_nano);
-    //     assert_eq!(400, span.events[0].dropped_attributes_count);
-    //     assert_eq!(1, span.events[0].attributes.len());
-    //     assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
-    //     let value = span.events[0].attributes[0]
-    //         .value
-    //         .clone()
-    //         .unwrap()
-    //         .value
-    //         .unwrap();
-    //     match value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!("event_attr_value", s)
-    //         }
-    //         _ => panic!("unexpected type"),
-    //     }
-    //
-    //     assert_eq!(1, span.links.len());
-    //     // get the newly added link
-    //     let new_link = span.links.remove(0);
-    //     assert_eq!(b"88888888".to_vec(), new_link.trace_id);
-    //     assert_eq!(b"99999999".to_vec(), new_link.span_id);
-    //     assert_eq!("test=1234567890", new_link.trace_state);
-    //     assert_eq!(300, new_link.dropped_attributes_count);
-    //     assert_eq!(1, new_link.flags);
-    //     assert_eq!(1, new_link.attributes.len());
-    //     let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
-    //     match value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!("link_attr_value", s)
-    //         }
-    //         _ => panic!("unexpected type"),
-    //     }
-    //
-    //     assert_eq!(1, span.attributes.len());
-    //     let new_attr = span.attributes.remove(0);
-    //     assert_eq!("span_attr_key", new_attr.key);
-    //     let value = new_attr.value.clone().unwrap().value.unwrap();
-    //     match value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!("span_attr_value", s)
-    //         }
-    //         _ => panic!("unexpected type"),
-    //     }
-    // }
-    // #[test]
-    // fn set_resource_spans_resource() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script(
-    //             "write_resource_spans_resource_test.py",
-    //             py,
-    //             py_resource_spans,
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let resource = Arc::into_inner(resource_spans.resource).unwrap();
-    //     let resource = resource.into_inner().unwrap().unwrap();
-    //     let resource = crate::model::py_transform::transform_resource(resource).unwrap();
-    //     assert_eq!(2, resource.attributes.len());
-    //     assert_eq!(35, resource.dropped_attributes_count);
-    //     for attr in &resource.attributes {
-    //         match attr.key.as_str() {
-    //             "key" => assert_eq!(
-    //                 Value::StringValue("value".to_string()),
-    //                 attr.value.clone().unwrap().value.unwrap()
-    //             ),
-    //             "boolean" => assert_eq!(
-    //                 Value::BoolValue(true),
-    //                 attr.value.clone().unwrap().value.unwrap()
-    //             ),
-    //             _ => panic!("unexpected attribute key"),
-    //         }
-    //     }
-    // }
-    // #[test]
-    // fn set_span_events() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("write_span_events_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let mut scope_spans = scope_spans.pop().unwrap();
-    //     let span = scope_spans.spans.pop().unwrap();
-    //
-    //     assert_eq!(2, span.events.len());
-    //     let event = &span.events[0];
-    //     assert_eq!("first_event", event.name);
-    //     assert_eq!(123, event.time_unix_nano);
-    //     assert_eq!(1, event.dropped_attributes_count);
-    //     assert_eq!(1, event.attributes.len());
-    //     let attr = &event.attributes[0];
-    //     assert_eq!("first_event_attr_key", attr.key);
-    //     assert_eq!(
-    //         Value::StringValue("first_event_attr_value".to_string()),
-    //         attr.value.clone().unwrap().value.unwrap()
-    //     );
-    //
-    //     let event = &span.events[1];
-    //     assert_eq!("second_event", event.name);
-    //     assert_eq!(456, event.time_unix_nano);
-    //     assert_eq!(2, event.dropped_attributes_count);
-    //     assert_eq!(1, event.attributes.len());
-    //     let attr = &event.attributes[0];
-    //     assert_eq!("second_event_attr_key", attr.key);
-    //     assert_eq!(
-    //         Value::StringValue("second_event_attr_value".to_string()),
-    //         attr.value.clone().unwrap().value.unwrap()
-    //     )
-    // }
-    // #[test]
-    // fn set_scope_spans() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("write_scope_spans_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let mut scope_spans = scope_spans.pop().unwrap();
-    //     assert_eq!(
-    //         "https://github.com/streamfold/rotel",
-    //         scope_spans.schema_url
-    //     );
-    //     let inst_scope = scope_spans.scope.unwrap();
-    //     assert_eq!("rotel-sdk-new", inst_scope.name);
-    //     assert_eq!("v1.0.1", inst_scope.version);
-    //     let attr = &inst_scope.attributes[0];
-    //     assert_eq!("rotel-sdk", attr.key);
-    //     assert_eq!(
-    //         Value::StringValue("v1.0.0".to_string()),
-    //         attr.value.clone().unwrap().value.unwrap()
-    //     );
-    //
-    //     let span = scope_spans.spans.pop().unwrap();
-    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
-    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
-    //     assert_eq!("test=1234567890", span.trace_state);
-    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-    //     assert_eq!(1, span.flags);
-    //     assert_eq!("py_processed_span", span.name);
-    //     assert_eq!(4, span.kind);
-    //     assert_eq!(1234567890, span.start_time_unix_nano);
-    //     assert_eq!(1234567890, span.end_time_unix_nano);
-    //     let attr = &span.attributes[0];
-    //     assert_eq!("span_attr_key", attr.key);
-    //     assert_eq!(
-    //         Value::StringValue("span_attr_value".to_string()),
-    //         attr.value.clone().unwrap().value.unwrap()
-    //     );
-    // }
-    //
-    // #[test]
-    // fn set_spans() {
-    //     initialize();
-    //     let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
-    //     let resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         export_req.resource_spans[0].clone(),
-    //     );
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: resource_spans.resource.clone(),
-    //         scope_spans: resource_spans.scope_spans.clone(),
-    //         schema_url: resource_spans.schema_url,
-    //     };
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("write_spans_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
-    //     let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
-    //
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     let mut scope_spans = scope_spans.pop().unwrap();
-    //     let span = scope_spans.spans.pop().unwrap();
-    //     assert_eq!(b"5555555555".to_vec(), span.trace_id);
-    //     assert_eq!(b"6666666666".to_vec(), span.span_id);
-    //     assert_eq!("test=1234567890", span.trace_state);
-    //     assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
-    //     assert_eq!(1, span.flags);
-    //     assert_eq!("py_processed_span", span.name);
-    //     assert_eq!(4, span.kind);
-    //     assert_eq!(1234567890, span.start_time_unix_nano);
-    //     assert_eq!(1234567890, span.end_time_unix_nano);
-    //     let attr = &span.attributes[0];
-    //     assert_eq!("span_attr_key", attr.key);
-    //     assert_eq!(
-    //         Value::StringValue("span_attr_value".to_string()),
-    //         attr.value.clone().unwrap().value.unwrap()
-    //     );
-    // }
-    //
-    // #[test]
-    // fn read_and_write_log_record() {
-    //     initialize();
-    //
-    //     // Create a mock ResourceLogs protobuf object for testing
-    //     // In a real scenario, you might use a utility like FakeOTLP if available for logs.
-    //     let initial_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
-    //         time_unix_nano: 1000000000,
-    //         observed_time_unix_nano: 1000000001,
-    //         severity_number: 9, // INFO
-    //         severity_text: "INFO".to_string(),
-    //         body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //             value: Some(Value::StringValue("initial log message".to_string())),
-    //         }),
-    //         attributes: vec![
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "log.source".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::StringValue("my_app".to_string())),
-    //                 }),
-    //             },
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "component".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::StringValue("backend".to_string())),
-    //                 }),
-    //             },
-    //         ],
-    //         dropped_attributes_count: 0,
-    //         flags: 0,
-    //         trace_id: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    //         span_id: vec![17, 18, 19, 20, 21, 22, 23, 24],
-    //         event_name: "".to_string(),
-    //     };
-    //
-    //     let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
-    //         scope: Some(
-    //             opentelemetry_proto::tonic::common::v1::InstrumentationScope {
-    //                 name: "test-instrumentation-scope".to_string(),
-    //                 version: "1.0.0".to_string(),
-    //                 attributes: vec![],
-    //                 dropped_attributes_count: 0,
-    //             },
-    //         ),
-    //         log_records: vec![initial_log_record],
-    //         schema_url: "http://example.com/logs-schema".to_string(),
-    //     };
-    //
-    //     let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
-    //         resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
-    //             attributes: vec![],
-    //             dropped_attributes_count: 0,
-    //         }),
-    //         scope_logs: vec![initial_scope_logs],
-    //         schema_url: "http://example.com/resource-logs-schema".to_string(),
-    //     };
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs =
-    //         crate::model::otel_transform::transform_resource_logs(export_req.clone());
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("read_and_write_logs_test.py", py, py_resource_logs)
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //
-    //     // Assert the changes made by the Python script
-    //     assert_eq!(transformed_scope_logs.len(), 1);
-    //     let mut scope_log = transformed_scope_logs.remove(0);
-    //     assert_eq!(scope_log.log_records.len(), 1);
-    //     let log_record = scope_log.log_records.remove(0);
-    //
-    //     assert_eq!(log_record.time_unix_nano, 2000000000);
-    //     assert_eq!(log_record.observed_time_unix_nano, 2000000001);
-    //     assert_eq!(log_record.severity_number, 13);
-    //     assert_eq!(log_record.severity_text, "ERROR");
-    //
-    //     let body_value = log_record.body.unwrap().value.unwrap();
-    //     match body_value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!(s, "processed log message");
-    //         }
-    //         _ => panic!("Body value is not a string"),
-    //     }
-    //
-    //     assert_eq!(log_record.dropped_attributes_count, 5);
-    //     assert_eq!(log_record.flags, 1);
-    //     assert_eq!(log_record.trace_id, b"abcdefghijklmnop".to_vec());
-    //     assert_eq!(log_record.span_id, b"qrstuvwx".to_vec());
-    //
-    //     assert_eq!(log_record.attributes.len(), 3);
-    //     // Verify the new attribute
-    //     let new_attr = &log_record.attributes[2];
-    //     assert_eq!(new_attr.key, "new_log_attr");
-    //     assert_eq!(
-    //         new_attr.value.clone().unwrap().value.unwrap(),
-    //         Value::StringValue("new_log_value".to_string())
-    //     );
-    //
-    //     // Verify the modified attribute
-    //     let modified_attr = &log_record.attributes[1];
-    //     assert_eq!(modified_attr.key, "component");
-    //     assert_eq!(
-    //         modified_attr.value.clone().unwrap().value.unwrap(),
-    //         Value::StringValue("modified_component_value".to_string())
-    //     );
-    // }
-    //
-    // #[test]
-    // fn add_new_log_record() {
-    //     initialize();
-    //
-    //     // Create a mock ResourceLogs protobuf object with an empty ScopeLogs initially
-    //     let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
-    //         scope: Some(
-    //             opentelemetry_proto::tonic::common::v1::InstrumentationScope {
-    //                 name: "test-instrumentation-scope".to_string(),
-    //                 version: "1.0.0".to_string(),
-    //                 attributes: vec![],
-    //                 dropped_attributes_count: 0,
-    //             },
-    //         ),
-    //         log_records: vec![], // Start with no log records
-    //         schema_url: "http://example.com/logs-schema".to_string(),
-    //     };
-    //
-    //     let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
-    //         resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
-    //             attributes: vec![],
-    //             dropped_attributes_count: 0,
-    //         }),
-    //         scope_logs: vec![initial_scope_logs],
-    //         schema_url: "http://example.com/resource-logs-schema".to_string(),
-    //     };
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs =
-    //         crate::model::otel_transform::transform_resource_logs(export_req.clone());
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that adds a new log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("add_log_record_test.py", py, py_resource_logs)
-    //     })
-    //     .unwrap();
-    //
-    //     // Transform the modified RResourceLogs back into protobuf format
-    //     let mut resource = r_resource_logs.resource.lock().unwrap();
-    //     let _resource_proto = resource
-    //         .take()
-    //         .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
-    //
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //
-    //     // Assert the changes made by the Python script
-    //     assert_eq!(transformed_scope_logs.len(), 1);
-    //     let mut scope_log = transformed_scope_logs.remove(0);
-    //     assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
-    //     let log_record = scope_log.log_records.remove(0);
-    //
-    //     assert_eq!(log_record.time_unix_nano, 9876543210);
-    //     assert_eq!(log_record.observed_time_unix_nano, 9876543211);
-    //     assert_eq!(log_record.severity_number, 17); // FATAL
-    //     assert_eq!(log_record.severity_text, "FATAL");
-    //
-    //     let body_value = log_record.body.unwrap().value.unwrap();
-    //     match body_value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!(s, "This is a newly added log message.");
-    //         }
-    //         _ => panic!("Body value is not a string"),
-    //     }
-    //
-    //     assert_eq!(log_record.attributes.len(), 1);
-    //     let new_attr = &log_record.attributes[0];
-    //     assert_eq!(new_attr.key, "new_log_key");
-    //     assert_eq!(
-    //         new_attr.value.clone().unwrap().value.unwrap(),
-    //         Value::StringValue("new_log_value".to_string())
-    //     );
-    //
-    //     assert_eq!(log_record.dropped_attributes_count, 2);
-    //     assert_eq!(log_record.flags, 4);
-    //     assert_eq!(log_record.trace_id, b"fedcba9876543210".to_vec());
-    //     assert_eq!(log_record.span_id, b"fedcba98".to_vec());
-    // }
-    //
-    // #[test]
-    // fn remove_log_record_test() {
-    //     initialize();
-    //
-    //     // Create a mock ResourceLogs protobuf object with two initial LogRecords
-    //     let first_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
-    //         time_unix_nano: 1000000000,
-    //         observed_time_unix_nano: 1000000001,
-    //         severity_number: 9, // INFO
-    //         severity_text: "INFO".to_string(),
-    //         body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //             value: Some(
-    //                 opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-    //                     "first log message".to_string(),
-    //                 ),
-    //             ),
-    //         }),
-    //         attributes: vec![],
-    //         dropped_attributes_count: 0,
-    //         flags: 0,
-    //         trace_id: vec![],
-    //         span_id: vec![],
-    //         event_name: "first_event".to_string(),
-    //     };
-    //
-    //     let second_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
-    //         time_unix_nano: 2000000000,
-    //         observed_time_unix_nano: 2000000001,
-    //         severity_number: 13, // ERROR
-    //         severity_text: "ERROR".to_string(),
-    //         body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //             value: Some(Value::StringValue("second log message".to_string())),
-    //         }),
-    //         attributes: vec![],
-    //         dropped_attributes_count: 0,
-    //         flags: 0,
-    //         trace_id: vec![],
-    //         span_id: vec![],
-    //         event_name: "second_event".to_string(),
-    //     };
-    //
-    //     let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
-    //         scope: Some(
-    //             opentelemetry_proto::tonic::common::v1::InstrumentationScope {
-    //                 name: "test-instrumentation-scope".to_string(),
-    //                 version: "1.0.0".to_string(),
-    //                 attributes: vec![],
-    //                 dropped_attributes_count: 0,
-    //             },
-    //         ),
-    //         log_records: vec![first_log_record, second_log_record], // Two log records
-    //         schema_url: "http://example.com/logs-schema".to_string(),
-    //     };
-    //
-    //     let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
-    //         resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
-    //             attributes: vec![],
-    //             dropped_attributes_count: 0,
-    //         }),
-    //         scope_logs: vec![initial_scope_logs],
-    //         schema_url: "http://example.com/resource-logs-schema".to_string(),
-    //     };
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs =
-    //         crate::model::otel_transform::transform_resource_logs(export_req.clone());
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("remove_log_record_test.py", py, py_resource_logs)
-    //     })
-    //     .unwrap();
-    //
-    //     // Transform the modified RResourceLogs back into protobuf format
-    //     let mut resource = r_resource_logs.resource.lock().unwrap();
-    //     let _resource_proto = resource
-    //         .take()
-    //         .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
-    //
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //
-    //     // Assert the changes made by the Python script
-    //     assert_eq!(transformed_scope_logs.len(), 1);
-    //     let mut scope_log = transformed_scope_logs.remove(0);
-    //     assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
-    //     let log_record = scope_log.log_records.remove(0);
-    //
-    //     // Verify that the correct log record remains
-    //     let body_value = log_record.body.unwrap().value.unwrap();
-    //     match body_value {
-    //         Value::StringValue(s) => {
-    //             assert_eq!(s, "first log message");
-    //         }
-    //         _ => panic!("Body value is not the expected string"),
-    //     }
-    // }
-    //
-    // #[test]
-    // fn traces_delitem_test() {
-    //     initialize();
-    //     let av = opentelemetry_proto::tonic::common::v1::ArrayValue {
-    //         values: vec![
-    //             opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("first value".to_string())),
-    //             },
-    //             opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("second value".to_string())),
-    //             },
-    //         ],
-    //     };
-    //     let kvlist = opentelemetry_proto::tonic::common::v1::KeyValueList {
-    //         values: vec![
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "first_key".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::BoolValue(true)),
-    //                 }),
-    //             },
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "second_key".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::StringValue("second_value".to_string())),
-    //                 }),
-    //             },
-    //         ],
-    //     };
-    //     let resource = opentelemetry_proto::tonic::resource::v1::Resource {
-    //         attributes: vec![
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "first_attr".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::KvlistValue(kvlist)),
-    //                 }),
-    //             },
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "second_attr".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::ArrayValue(av)),
-    //                 }),
-    //             },
-    //             opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                 key: "third_attr".to_string(),
-    //                 value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                     value: Some(Value::StringValue("to_remove_value".to_string())),
-    //                 }),
-    //             },
-    //         ],
-    //         dropped_attributes_count: 0,
-    //     };
-    //
-    //     let mut spans = FakeOTLP::trace_spans(2);
-    //     let now_ns = Utc::now().timestamp_nanos_opt().unwrap();
-    //
-    //     // Adding additional data here to test __delitem__
-    //     spans[0].events.push(v1::span::Event {
-    //         time_unix_nano: now_ns as u64,
-    //         name: "second test event".to_string(),
-    //         attributes: vec![],
-    //         dropped_attributes_count: 0,
-    //     });
-    //
-    //     spans[0].links.push(v1::span::Link {
-    //         trace_id: vec![5, 5, 5, 5, 5, 5, 5, 5],
-    //         span_id: vec![6, 6, 6, 6, 6, 6, 6, 6],
-    //         trace_state: "secondtrace=00f067aa0ba902b7".to_string(),
-    //         attributes: vec![],
-    //         dropped_attributes_count: 0,
-    //         flags: 0,
-    //     });
-    //
-    //     let first_scope_spans = v1::ScopeSpans {
-    //         scope: None,
-    //         spans,
-    //         schema_url: "".to_string(),
-    //     };
-    //
-    //     let second_scope_spans = v1::ScopeSpans {
-    //         scope: None,
-    //         spans: vec![],
-    //         schema_url: "".to_string(),
-    //     };
-    //
-    //     let resource_spans = v1::ResourceSpans {
-    //         resource: Some(resource),
-    //         scope_spans: vec![first_scope_spans, second_scope_spans],
-    //         schema_url: "".to_string(),
-    //     };
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_spans =
-    //         crate::model::otel_transform::transform_resource_spans(resource_spans);
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: r_resource_spans.resource.clone(),
-    //         scope_spans: r_resource_spans.scope_spans.clone(),
-    //         schema_url: r_resource_spans.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("traces_delitem_test.py", py, py_resource_spans)
-    //     })
-    //     .unwrap();
-    //
-    //     let mut resource = r_resource_spans.resource.lock().unwrap();
-    //     let mut resource_p = resource
-    //         .take()
-    //         .map(|r| crate::model::py_transform::transform_resource(r).unwrap())
-    //         .unwrap();
-    //
-    //     assert_eq!(2, resource_p.attributes.len());
-    //     // Assert the kvlist only has one item now
-    //     let kvlist = resource_p
-    //         .attributes
-    //         .remove(0)
-    //         .value
-    //         .unwrap()
-    //         .value
-    //         .unwrap();
-    //     match kvlist {
-    //         Value::KvlistValue(mut kvl) => {
-    //             assert_eq!(1, kvl.values.len());
-    //             let value = kvl.values.remove(0);
-    //             assert_eq!(value.key, "second_key");
-    //             let value = value.value.clone().unwrap().value.unwrap();
-    //             match value {
-    //                 Value::StringValue(s) => {
-    //                     assert_eq!(s, "second_value");
-    //                 }
-    //                 _ => {
-    //                     panic!("expected StringValue")
-    //                 }
-    //             }
-    //         }
-    //         _ => {
-    //             panic!("expected kvlist")
-    //         }
-    //     }
-    //
-    //     let arvalue = resource_p
-    //         .attributes
-    //         .remove(0)
-    //         .value
-    //         .unwrap()
-    //         .value
-    //         .unwrap();
-    //     match arvalue {
-    //         Value::ArrayValue(mut av) => {
-    //             assert_eq!(1, av.values.len());
-    //             let value = av.values.remove(0).value.unwrap();
-    //             match value {
-    //                 Value::StringValue(s) => {
-    //                     assert_eq!(s, "first value")
-    //                 }
-    //                 _ => {
-    //                     panic!("expected StringValue");
-    //                 }
-    //             }
-    //         }
-    //         _ => {
-    //             panic!("expected ArrayValue");
-    //         }
-    //     }
-    //
-    //     // Verify the second scope span has been removed
-    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_spans_vec = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //     assert_eq!(1, scope_spans_vec.len());
-    //     let scope_spans = scope_spans_vec.remove(0);
-    //     let mut spans = scope_spans.spans;
-    //     assert_eq!(1, spans.len());
-    //     let span = spans.remove(0);
-    //     assert_eq!(1, span.events.len());
-    //     assert_eq!(span.events[0].name, "second test event");
-    //     assert_eq!(1, span.links.len());
-    //     assert_eq!(span.links[0].trace_state, "secondtrace=00f067aa0ba902b7")
-    // }
-    //
-    // #[test]
-    // fn attributes_processor_test() {
-    //     initialize();
-    //     let mut log_request = FakeOTLP::logs_service_request();
-    //
-    //     let attrs = vec![
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "http.status_code".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::IntValue(200)),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "user.id".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("abc-123".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "user.email".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("test@example.com".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "request.id".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("req-456".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "message".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("User login successful.".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "raw_data".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("id:123,name:Alice,age:30".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "temp_str_int".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("123".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "temp_str_bool".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("true".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "temp_str_float".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::DoubleValue(10.0)),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "path".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("https://rotel.dev/blog".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "super.secret".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("don't tell anyone".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "trace.id".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("12345678".to_string())),
-    //             }),
-    //         },
-    //     ];
-    //     log_request.resource_logs[0].scope_logs[0].log_records[0].attributes = attrs.clone();
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-    //         log_request.resource_logs[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "attributes_processor_test.py",
-    //             py,
-    //             py_resource_logs,
-    //             Some("process_logs".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //
-    //     let log_record = scope_logs.pop().unwrap().log_records.pop().unwrap();
-    //     let attrs_to_verify: HashMap<
-    //         String,
-    //         Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
-    //     > = log_record
-    //         .attributes
-    //         .into_iter()
-    //         .map(|kv| (kv.key, kv.value))
-    //         .collect();
-    //
-    //     let verify_attrs = |mut attrs: HashMap<
-    //         String,
-    //         Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
-    //     >| {
-    //         let host_name = attrs.remove("host.name").unwrap();
-    //         match host_name.unwrap().value.unwrap() {
-    //             Value::StringValue(h) => {
-    //                 assert_eq!(h, "my-server-1");
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let http_status_code = attrs.remove("http.status_code").unwrap();
-    //         match http_status_code.unwrap().value.unwrap() {
-    //             Value::StringValue(c) => {
-    //                 assert_eq!(c, "OK");
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let env = attrs.remove("env").unwrap();
-    //         match env.unwrap().value.unwrap() {
-    //             Value::StringValue(e) => {
-    //                 assert_eq!(e, "production");
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let email = attrs.remove("email").unwrap();
-    //         match email.unwrap().value.unwrap() {
-    //             Value::StringValue(h) => {
-    //                 assert_eq!(h, "test@example.com");
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let user_id = attrs.remove("user.id").unwrap();
-    //         match user_id.unwrap().value.unwrap() {
-    //             Value::StringValue(s) => {
-    //                 assert_eq!(
-    //                     s,
-    //                     "5942d94f524882e0f29bf0a1e5a6dcc952eea1c0c21dd3588a3fc7db9716db0c"
-    //                 );
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let trace_id = attrs.remove("trace.id").unwrap();
-    //         match trace_id.unwrap().value.unwrap() {
-    //             Value::StringValue(s) => {
-    //                 assert_eq!(
-    //                     s,
-    //                     "ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f"
-    //                 );
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let id = attrs.remove("extracted_id").unwrap();
-    //         match id.unwrap().value.unwrap() {
-    //             Value::StringValue(s) => {
-    //                 assert_eq!(s, "123");
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let temp_str_int = attrs.remove("temp_str_int").unwrap();
-    //         match temp_str_int.unwrap().value.unwrap() {
-    //             Value::IntValue(i) => {
-    //                 assert_eq!(i, 123);
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let temp_str_bool = attrs.remove("temp_str_bool").unwrap();
-    //         match temp_str_bool.unwrap().value.unwrap() {
-    //             Value::BoolValue(b) => {
-    //                 assert_eq!(b, true);
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let temp_str_float = attrs.remove("temp_str_float").unwrap();
-    //         match temp_str_float.unwrap().value.unwrap() {
-    //             Value::DoubleValue(d) => {
-    //                 assert_eq!(d, 10.0);
-    //             }
-    //             _ => panic!("Unexpected value type"),
-    //         }
-    //         let path = attrs.remove("path");
-    //         assert_eq!(path, None);
-    //         let super_secret = attrs.remove("super.secret");
-    //         assert_eq!(super_secret, None);
-    //     };
-    //
-    //     verify_attrs(attrs_to_verify);
-    //
-    //     let mut trace_request = FakeOTLP::trace_service_request();
-    //     trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = attrs.clone();
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         trace_request.resource_spans[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: r_resource_spans.resource.clone(),
-    //         scope_spans: r_resource_spans.scope_spans.clone(),
-    //         schema_url: r_resource_spans.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "attributes_processor_test.py",
-    //             py,
-    //             py_resource_spans,
-    //             Some("process_spans".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //
-    //     let span = scope_spans.pop().unwrap().spans.pop().unwrap();
-    //     let attrs_to_verify: HashMap<
-    //         String,
-    //         Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
-    //     > = span
-    //         .attributes
-    //         .into_iter()
-    //         .map(|kv| (kv.key, kv.value))
-    //         .collect();
-    //
-    //     verify_attrs(attrs_to_verify);
-    // }
-    // #[test]
-    // fn redaction_processor_restrictive_test() {
-    //     initialize();
-    //     let resource_attrs = vec![
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "host.arch".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("amd64".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "os.type".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("linux".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "region".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("us-east-1".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "service.name".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("my-service".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "unallowed_resource_key".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("some_value".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "deployment.environment".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("prod".to_string())),
-    //             }),
-    //         },
-    //     ];
-    //
-    //     let span_attrs = vec![
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "user.email".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("test@example.com".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "http.url".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue(
-    //                     "https://example.com/sensitive/path".to_string(),
-    //                 )),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "db.statement".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue(
-    //                     "SELECT * FROM users WHERE id = 1".to_string(),
-    //                 )),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "operation".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("get_data".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "some_token".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("abcdef123".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "api_key_header".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("xyz789".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "safe_attribute".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("this should remain".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "unallowed_span_key".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("should_be_deleted".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "my_company_email".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("user@mycompany.com".to_string())),
-    //             }),
-    //         },
-    //     ];
-    //
-    //     let mut trace_request = FakeOTLP::trace_service_request();
-    //     trace_request.resource_spans[0].resource =
-    //         Some(opentelemetry_proto::tonic::resource::v1::Resource {
-    //             attributes: resource_attrs.clone(),
-    //             dropped_attributes_count: 0,
-    //         });
-    //     trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         trace_request.resource_spans[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: r_resource_spans.resource.clone(),
-    //         scope_spans: r_resource_spans.scope_spans.clone(),
-    //         schema_url: r_resource_spans.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "redaction_processor_restrictive_test.py",
-    //             py,
-    //             py_resource_spans,
-    //             Some("process_spans".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let resource = Arc::into_inner(r_resource_spans.resource)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap()
-    //         .unwrap();
-    //     let resource = crate::model::py_transform::transform_resource(resource).unwrap();
-    //     assert_eq!(9, resource.attributes.len());
-    //     let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
-    //         resource
-    //             .attributes
-    //             .into_iter()
-    //             .map(|kv| (kv.key.clone(), kv.value.clone()))
-    //             .collect();
-    //
-    //     let expected_attributes = HashMap::from([
-    //         ("host.arch", "amd64"),
-    //         ("os.type", "linux"),
-    //         ("region", "us-east-1"),
-    //         ("service.name", "my-service"),
-    //         ("deployment.environment", "prod"),
-    //         (
-    //             "redaction.resource.redacted_keys.names",
-    //             "unallowed_resource_key",
-    //         ),
-    //         (
-    //             "redaction.resource.allowed_keys.names",
-    //             "deployment.environment,host.arch,os.type,region,service.name",
-    //         ),
-    //         ("redaction.resource.redacted_keys.count", "1"),
-    //         ("redaction.resource.allowed_keys.count", "5"),
-    //     ]);
-    //
-    //     let validate =
-    //         |kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>>,
-    //          expected_attributes: HashMap<&str, &str>| {
-    //             for (key, value) in kv_map {
-    //                 let ev = expected_attributes.get(key.as_str());
-    //                 match ev {
-    //                     None => {
-    //                         panic!("key {:?} not found in expected attributes", key)
-    //                     }
-    //                     Some(v) => match value.unwrap().value.unwrap() {
-    //                         Value::StringValue(sv) => {
-    //                             assert_eq!(v.to_string(), sv.to_string());
-    //                         }
-    //                         Value::IntValue(i) => {
-    //                             let v: i64 = v.parse().expect("can't convert to int");
-    //                             assert_eq!(v, i);
-    //                         }
-    //                         _ => {
-    //                             panic!("expected string value")
-    //                         }
-    //                     },
-    //                 }
-    //             }
-    //         };
-    //
-    //     validate(kv_map, expected_attributes);
-    //
-    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //
-    //     let span = scope_spans.pop().unwrap().spans.pop().unwrap();
-    //     println!("span is {:?}", span);
-    //     assert_eq!(7, span.attributes.len());
-    //
-    //     let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
-    //         span.attributes
-    //             .into_iter()
-    //             .map(|kv| (kv.key.clone(), kv.value.clone()))
-    //             .collect();
-    //
-    //     let expected_attributes = HashMap::from([
-    //         ("operation", "get_data"),
-    //         ("safe_attribute", "this should remain"),
-    //         ("redaction.span.redacted_keys.count", "7"),
-    //         ("redaction.span.allowed_keys.names", "operation"),
-    //         ("redaction.span.allowed_keys.count", "1"),
-    //         ("redaction.span.redacted_keys.names", "api_key_header,db.statement,http.url,my_company_email,some_token,unallowed_span_key,user.email"),
-    //         ("redaction.span.ignored_keys.count", "1"),
-    //     ]);
-    //
-    //     validate(kv_map, expected_attributes)
-    // }
-    //
-    // #[test]
-    // fn redaction_processor_blocking_test() {
-    //     initialize();
-    //     let span_attrs = vec![
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "session_token".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("foo".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "api_key".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("bar".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "password_hash".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("xyz123".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "visa".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("4123456789012".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "mastercard".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("5234567890123456".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "bl_email".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("foo@bar.com".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "allowed_email".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("test@mycompany.com".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "ip".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("10.0.1.100".to_string())),
-    //             }),
-    //         },
-    //         opentelemetry_proto::tonic::common::v1::KeyValue {
-    //             key: "query".to_string(),
-    //             value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                 value: Some(Value::StringValue("SELECT * FROM USERS".to_string())),
-    //             }),
-    //         },
-    //     ];
-    //
-    //     let mut trace_request = FakeOTLP::trace_service_request();
-    //     trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
-    //         trace_request.resource_spans[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_spans = ResourceSpans {
-    //         resource: r_resource_spans.resource.clone(),
-    //         scope_spans: r_resource_spans.scope_spans.clone(),
-    //         schema_url: r_resource_spans.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "redaction_processor_blocking_test.py",
-    //             py,
-    //             py_resource_spans,
-    //             Some("process_spans".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
-    //
-    //     let span = scope_spans.pop().unwrap().spans.pop().unwrap();
-    //     assert_eq!(13, span.attributes.len());
-    //
-    //     let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
-    //         span.attributes
-    //             .into_iter()
-    //             .map(|kv| (kv.key.clone(), kv.value.clone()))
-    //             .collect();
-    //
-    //     let expected_attributes = HashMap::from([
-    //         ("visa", "8d9e470bdd9f6e6e18023938497857dc"),
-    //         ("mastercard", "aad9ce9b62a1f697745fcd81314b877f"),
-    //         ("ip", "f5c45dc3c8fb04f638ad27a711910390"),
-    //         ("query", "06c445f7ade97a964f7c466575f8b508"),
-    //         ("bl_email", "f3ada405ce890b6f8204094deb12d8a8"),
-    //         ("session_token", "acbd18db4cc2f85cedef654fccc4a4d8"),
-    //         ("allowed_email", "test@mycompany.com"),
-    //         ("api_key", "37b51d194a7513e45b56f6524f2d51f2"),
-    //         ("password_hash", "613d3b9c91e9445abaeca02f2342e5a6"),
-    //         ("redaction.span.allowed_keys.names", "allowed_email,api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
-    //         ("redaction.span.allowed_keys.count", "9"),
-    //         ("redaction.span.masked_keys.names", "api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
-    //         ("redaction.span.masked_keys.count", "8"),
-    //     ]);
-    //
-    //     for (key, value) in kv_map {
-    //         let ev = expected_attributes.get(key.as_str());
-    //         match ev {
-    //             None => {
-    //                 panic!("key {:?} not found in expected attributes", key)
-    //             }
-    //             Some(v) => match value.unwrap().value.unwrap() {
-    //                 Value::StringValue(sv) => {
-    //                     assert_eq!(v.to_string(), sv.to_string());
-    //                 }
-    //                 Value::IntValue(i) => {
-    //                     let v: i64 = v.parse().expect("can't convert to int");
-    //                     assert_eq!(v, i);
-    //                 }
-    //                 _ => {
-    //                     panic!("expected string value")
-    //                 }
-    //             },
-    //         }
-    //     }
-    // }
-    //
-    // #[test]
-    // fn redaction_processor_log_body_test() {
-    //     initialize();
-    //     let mut logs_request = FakeOTLP::logs_service_request();
-    //     let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
-    //         value: Some(Value::StringValue(
-    //             "Login successful: password=1234567890".to_string(),
-    //         )),
-    //     };
-    //     logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-    //         logs_request.resource_logs[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "redaction_processor_log_body_test.py",
-    //             py,
-    //             py_resource_logs,
-    //             Some("process_logs".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //     let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
-    //     let body = log.body.unwrap().value.unwrap();
-    //     match body {
-    //         Value::StringValue(b) => {
-    //             assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
-    //         }
-    //         _ => panic!("Unexpected log record value type"),
-    //     }
-    //
-    //     let mut logs_request = FakeOTLP::logs_service_request();
-    //     let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
-    //         value: Some(Value::KvlistValue(
-    //             opentelemetry_proto::tonic::common::v1::KeyValueList {
-    //                 values: vec![opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                     key: "another_body".to_string(),
-    //                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                         value: Some(Value::StringValue(
-    //                             "Login successful: password=1234567890".to_string(),
-    //                         )),
-    //                     }),
-    //                 }],
-    //             },
-    //         )),
-    //     };
-    //     logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-    //         logs_request.resource_logs[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "redaction_processor_log_body_test.py",
-    //             py,
-    //             py_resource_logs,
-    //             Some("process_logs".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //     let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
-    //     let body = log.body.unwrap().value.unwrap();
-    //     match body {
-    //         Value::KvlistValue(mut kvl) => {
-    //             let v = kvl.values.pop().unwrap();
-    //             match v.value.unwrap().value.unwrap() {
-    //                 Value::StringValue(b) => {
-    //                     assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
-    //                 }
-    //                 _ => {
-    //                     panic!("Unexpected log record value type");
-    //                 }
-    //             }
-    //         }
-    //         _ => panic!("Unexpected log record value type"),
-    //     }
-    //
-    //     let mut logs_request = FakeOTLP::logs_service_request();
-    //     let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
-    //         value: Some(Value::ArrayValue(
-    //             opentelemetry_proto::tonic::common::v1::ArrayValue {
-    //                 values: vec![
-    //                     opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                         value: Some(Value::StringValue(
-    //                             "Login failed: password=1234567890".to_string(),
-    //                         )),
-    //                     },
-    //                     opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                         value: Some(Value::KvlistValue(
-    //                             opentelemetry_proto::tonic::common::v1::KeyValueList {
-    //                                 values: vec![
-    //                                     opentelemetry_proto::tonic::common::v1::KeyValue {
-    //                                         key: "another_body".to_string(),
-    //                                         value: Some(
-    //                                             opentelemetry_proto::tonic::common::v1::AnyValue {
-    //                                                 value: Some(Value::StringValue(
-    //                                                     "Login successful: password=1234567890"
-    //                                                         .to_string(),
-    //                                                 )),
-    //                                             },
-    //                                         ),
-    //                                     },
-    //                                 ],
-    //                             },
-    //                         )),
-    //                     },
-    //                 ],
-    //             },
-    //         )),
-    //     };
-    //     logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
-    //         logs_request.resource_logs[0].clone(),
-    //     );
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_logs = ResourceLogs {
-    //         resource: r_resource_logs.resource.clone(),
-    //         scope_logs: r_resource_logs.scope_logs.clone(),
-    //         schema_url: r_resource_logs.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         _run_script(
-    //             "redaction_processor_log_body_test.py",
-    //             py,
-    //             py_resource_logs,
-    //             Some("process_logs".to_string()),
-    //         )
-    //     })
-    //     .unwrap();
-    //     let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
-    //         .unwrap()
-    //         .into_inner()
-    //         .unwrap();
-    //     let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
-    //     let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
-    //     let body = log.body.unwrap().value.unwrap();
-    //     match body {
-    //         Value::ArrayValue(mut av) => {
-    //             assert_eq!(av.values.len(), 2);
-    //             while !av.values.is_empty() {
-    //                 let v = av.values.pop().unwrap();
-    //                 match v.value.unwrap() {
-    //                     Value::StringValue(b) => {
-    //                         assert_eq!(b, "34c37eb5ba287d52490cc8c2e3ebc231");
-    //                     }
-    //                     Value::KvlistValue(mut kvl) => {
-    //                         let v = kvl.values.pop().unwrap();
-    //                         match v.value.unwrap().value.unwrap() {
-    //                             Value::StringValue(b) => {
-    //                                 assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
-    //                             }
-    //                             _ => {
-    //                                 panic!("Unexpected log record value type");
-    //                             }
-    //                         }
-    //                     }
-    //                     _ => {
-    //                         panic!("Unexpected log record value type");
-    //                     }
-    //                 }
-    //             }
-    //         }
-    //         _ => {
-    //             panic!("Unexpected log record value type");
-    //         }
-    //     }
-    // }
-    //
-    // #[test]
-    // fn metrics_processor_test() {
-    //     initialize();
-    //
-    //     let mut resource_metrics = opentelemetry_proto::tonic::metrics::v1::ResourceMetrics {
-    //         resource: None,
-    //         scope_metrics: vec![],
-    //         schema_url: "".to_string(),
-    //     };
-    //
-    //     let mut scope_metrics = opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
-    //         scope: None,
-    //         metrics: vec![],
-    //         schema_url: "".to_string(),
-    //     };
-    //
-    //     let metrics = vec![opentelemetry_proto::tonic::metrics::v1::Metric {
-    //         name: "test_metrics".to_string(),
-    //         description: "an example test metrics".to_string(),
-    //         unit: "bytes".to_string(),
-    //         metadata: vec![],
-    //         data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(opentelemetry_proto::tonic::metrics::v1::Gauge {
-    //             data_points: vec![
-    //                 opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
-    //                     attributes: vec![],
-    //                     start_time_unix_nano: 1,
-    //                     time_unix_nano: 1,
-    //                     exemplars: vec![],
-    //                     flags: 0,
-    //                     value: Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsDouble(101.0)),
-    //                 }
-    //             ]
-    //         })),
-    //     }];
-    //
-    //     scope_metrics.metrics = metrics;
-    //     resource_metrics.scope_metrics = vec![scope_metrics];
-    //
-    //     // Transform the protobuf ResourceLogs into our internal RResourceLogs
-    //     let r_resource_metrics = otel_transform::transform_resource_metrics(resource_metrics);
-    //
-    //     // Create the Python-exposed ResourceLogs object
-    //     let py_resource_metrics = ResourceMetrics {
-    //         resource: r_resource_metrics.resource.clone(),
-    //         scope_metrics: r_resource_metrics.scope_metrics.clone(),
-    //         schema_url: r_resource_metrics.schema_url.clone(),
-    //     };
-    //
-    //     // Execute the Python script that removes a log record
-    //     Python::with_gil(|py| -> PyResult<()> {
-    //         run_script("resource_metrics_test.py", py, py_resource_metrics)
-    //     })
-    //     .unwrap();
-    // }
-    //
     #[test]
-    fn read_and_write_metrics() {
+    fn test_read_any_value() {
         initialize();
-        // 1. Create initial OpenTelemetry protobuf MetricsData
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+
+        let pv = AnyValue {
+            inner: any_value_arc.clone(),
+        };
+        Python::with_gil(|py| -> PyResult<()> { run_script("read_value_test.py", py, pv) })
+            .unwrap();
+        let av = any_value_arc.lock().unwrap().clone().unwrap();
+        let avx = av.value.lock().unwrap().clone();
+        match avx.unwrap() {
+            StringValue(s) => {
+                assert_eq!(s, "foo");
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn write_string_any_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let pv = AnyValue {
+            inner: any_value_arc.clone(),
+        };
+        Python::with_gil(|py| -> PyResult<()> { run_script("write_string_value_test.py", py, pv) })
+            .unwrap();
+        let av = any_value_arc.lock().unwrap().clone().unwrap();
+        let avx = av.value.lock().unwrap().clone();
+        match avx.unwrap() {
+            StringValue(s) => {
+                assert_eq!(s, "changed");
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn write_bool_any_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+
+        let pv = AnyValue {
+            inner: any_value_arc.clone(),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> { run_script("write_bool_value_test.py", py, pv) })
+            .unwrap();
+        match arc_value.lock().unwrap().clone().unwrap() {
+            BoolValue(b) => {
+                assert!(b);
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn write_bytes_any_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+
+        let pv = AnyValue {
+            inner: any_value_arc.clone(),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> { run_script("write_bytes_value_test.py", py, pv) })
+            .unwrap();
+        match arc_value.lock().unwrap().clone().unwrap() {
+            BytesValue(b) => {
+                assert_eq!(b"111111".to_vec(), b);
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn read_key_value_key() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = KeyValue {
+            inner: Arc::new(Mutex::new(RKeyValue {
+                key: key.clone(),
+                value: any_value_arc.clone(),
+            })),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> { run_script("read_key_value_key_test.py", py, kv) })
+            .unwrap();
+        let av = key.clone().lock().unwrap().clone();
+        assert_eq!(av, "key".to_string());
+        println!("{:?}", av);
+    }
+
+    #[test]
+    fn write_key_value_key() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = KeyValue {
+            inner: Arc::new(Mutex::new(RKeyValue {
+                key: key.clone(),
+                value: any_value_arc.clone(),
+            })),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("write_key_value_key_test.py", py, kv)
+        })
+        .unwrap();
+        let av = key.clone().lock().unwrap().clone();
+        assert_eq!(av, "new_key".to_string());
+        println!("{:?}", av);
+    }
+
+    #[test]
+    fn read_key_value_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = KeyValue {
+            inner: Arc::new(Mutex::new(RKeyValue {
+                key: key.clone(),
+                value: any_value_arc.clone(),
+            })),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("read_key_value_value_test.py", py, kv)
+        })
+        .unwrap();
+        match arc_value.lock().unwrap().clone().unwrap() {
+            StringValue(s) => {
+                assert_eq!(s, "foo");
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn write_key_value_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = KeyValue {
+            inner: Arc::new(Mutex::new(RKeyValue {
+                key: key.clone(),
+                value: any_value_arc.clone(),
+            })),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("write_key_value_value_test.py", py, kv)
+        })
+        .unwrap();
+        match arc_value.lock().unwrap().clone().unwrap() {
+            StringValue(s) => {
+                assert_eq!(s, "changed");
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn write_key_value_bytes_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = KeyValue {
+            inner: Arc::new(Mutex::new(RKeyValue {
+                key: key.clone(),
+                value: any_value_arc.clone(),
+            })),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("write_key_value_bytes_value_test.py", py, kv)
+        })
+        .unwrap();
+        match arc_value.lock().unwrap().clone().unwrap() {
+            BytesValue(s) => {
+                assert_eq!(b"111111".to_vec(), s);
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn read_resource_attributes() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+
+        let resource = Resource {
+            attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("read_resource_attributes_test.py", py, resource)
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn read_and_write_attributes_array_value() {
+        initialize();
+
+        let arc_value = Some(StringValue("foo".to_string()));
+        let any_value_arc = Some(RAnyValue {
+            value: Arc::new(Mutex::new(arc_value)),
+        });
+        let array_value = crate::model::common::RArrayValue {
+            values: Arc::new(Mutex::new(vec![Arc::new(Mutex::new(
+                any_value_arc.clone(),
+            ))])),
+        };
+        let array_value_arc = Arc::new(Mutex::new(Some(RVArrayValue(array_value))));
+        let any_value_array_value_wrapper = Some(RAnyValue {
+            value: array_value_arc.clone(),
+        });
+
+        let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
+
+        let key = Arc::new(Mutex::new("key".to_string()));
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_array_value_wrapper_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+        let attrs = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+
+        let resource = Resource {
+            attributes: attrs.clone(),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script(
+                "read_and_write_attributes_array_value_test.py",
+                py,
+                resource,
+            )
+        })
+        .unwrap();
+
+        let attrs = Arc::into_inner(attrs).unwrap();
+        let mut attrs = attrs.into_inner().unwrap();
+        let attr = Arc::into_inner(attrs.pop().unwrap()).unwrap();
+        let attr = attr.into_inner().unwrap();
+        let key = attr.key.lock().unwrap();
+        assert_eq!("my_array", *key);
+        let value = attr.value.lock().unwrap();
+        assert!(value.is_some());
+        let v = value.clone().unwrap();
+        let v = v.value.lock().unwrap();
+        assert!(v.is_some());
+        let v = v.clone().unwrap();
+        match v {
+            RVArrayValue(av) => {
+                println!("{:?}", av);
+                let mut vals = av.values.lock().unwrap();
+                let vv = vals.pop().unwrap();
+                let v = vv.lock().unwrap();
+                let v = v.clone().unwrap();
+                let v = v.value.clone().lock().unwrap().clone().unwrap();
+                match v {
+                    IntValue(v) => {
+                        assert_eq!(v, 123456789)
+                    }
+                    _ => panic!("wrong value type"),
+                }
+            }
+            _ => panic!("wrong value type"),
+        }
+    }
+
+    #[test]
+    fn read_and_write_attributes_key_value_list_value() {
+        initialize();
+
+        let value = Some(StringValue("foo".to_string()));
+        let any_value = Some(RAnyValue {
+            value: Arc::new(Mutex::new(value)),
+        });
+        let any_value_arc = Arc::new(Mutex::new(any_value));
+        let arc_key = Arc::new(Mutex::new("inner_key".to_string()));
+
+        let kev_value = RKeyValue {
+            key: arc_key.clone(),
+            value: any_value_arc.clone(),
+        };
+
+        let kv_list = crate::model::common::RKeyValueList {
+            values: Arc::new(Mutex::new(vec![kev_value])),
+        };
+
+        let array_value_arc = Arc::new(Mutex::new(Some(KvListValue(kv_list))));
+        let any_value_array_value_wrapper = Some(RAnyValue {
+            value: array_value_arc.clone(),
+        });
+
+        let any_value_array_value_wrapper_arc = Arc::new(Mutex::new(any_value_array_value_wrapper));
+
+        let key = Arc::new(Mutex::new("key".to_string()));
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_array_value_wrapper_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+
+        let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+        let resource = Resource {
+            attributes: attrs_arc.clone(),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script(
+                "read_and_write_attributes_key_value_list_test.py",
+                py,
+                resource,
+            )
+        })
+        .unwrap();
+
+        let mut value = attrs_arc.lock().unwrap();
+        let value = value.pop().unwrap();
+        let value = Arc::into_inner(value).unwrap().into_inner().unwrap();
+        let value = Arc::into_inner(value.value).unwrap().into_inner().unwrap();
+        let value = value.unwrap().value;
+        let value = Arc::into_inner(value)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+            .unwrap();
+        match value {
+            KvListValue(k) => {
+                let mut value = k.values.lock().unwrap().clone();
+                let value = value.pop();
+                match value {
+                    None => {
+                        panic!("wrong type")
+                    }
+                    Some(v) => {
+                        let v = v.value.lock().unwrap().clone();
+                        match v {
+                            None => {
+                                panic!("wrong type")
+                            }
+                            Some(v) => {
+                                let value = v.value.lock().unwrap().clone().unwrap();
+                                match value {
+                                    IntValue(i) => assert_eq!(100, i),
+                                    _ => panic!("wrong type"),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => panic!("wrong type"),
+        }
+    }
+
+    #[test]
+    fn write_resource_attributes_key_value_key() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+
+        let resource = Resource {
+            attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script(
+                "write_resource_attributes_key_value_key_test.py",
+                py,
+                resource,
+            )
+        })
+        .unwrap();
+        let av = key.clone().lock().unwrap().clone();
+        assert_eq!(av, "new_key".to_string());
+        println!("{:?}", av);
+    }
+
+    #[test]
+    fn write_resource_attributes_key_value_value() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+
+        let resource = Resource {
+            attributes: Arc::new(Mutex::new(vec![kv_arc.clone()])),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script(
+                "write_resource_attributes_key_value_value_test.py",
+                py,
+                resource,
+            )
+        })
+        .unwrap();
+        match arc_value.lock().unwrap().clone().unwrap() {
+            StringValue(s) => {
+                assert_eq!(s, "changed");
+            }
+            _ => panic!("wrong type"),
+        }
+        println!("{:?}", any_value_arc.lock().unwrap().clone().unwrap());
+    }
+
+    #[test]
+    fn resource_attributes_append_attribute() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+        let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+        let resource = Resource {
+            attributes: attrs_arc.clone(),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("resource_attributes_append_attribute.py", py, resource)
+        })
+        .unwrap();
+        println!("{:#?}", attrs_arc.lock().unwrap());
+    }
+
+    #[test]
+    fn resource_attributes_set_attributes() {
+        initialize();
+        let arc_value = Arc::new(Mutex::new(Some(StringValue("foo".to_string()))));
+        let any_value_arc = Arc::new(Mutex::new(Some(RAnyValue {
+            value: arc_value.clone(),
+        })));
+        let key = Arc::new(Mutex::new("key".to_string()));
+
+        let kv = RKeyValue {
+            key: key.clone(),
+            value: any_value_arc.clone(),
+        };
+
+        let kv_arc = Arc::new(Mutex::new(kv));
+        let attrs_arc = Arc::new(Mutex::new(vec![kv_arc.clone()]));
+        let resource = Resource {
+            attributes: attrs_arc.clone(),
+            dropped_attributes_count: Arc::new(Mutex::new(0)),
+        };
+
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("resource_attributes_set_attributes.py", py, resource)
+        })
+        .unwrap();
+        println!("{:#?}", attrs_arc.lock().unwrap());
+        let attrs = attrs_arc.lock().unwrap();
+        assert_eq!(2, attrs.len());
+        for kv in attrs.iter() {
+            let guard = kv.lock();
+            let kv_guard = guard.unwrap();
+            let key = kv_guard.key.lock().unwrap().to_string();
+            let value = kv_guard.value.lock().unwrap();
+            assert_ne!(key, "key");
+            assert!(key == "double.value" || key == "os.version");
+            assert!(value.is_some());
+            let av = value.clone().unwrap();
+            let value = av.value.lock().unwrap();
+            assert!(value.is_some());
+        }
+    }
+
+    #[test]
+    fn resource_spans_append_attributes() {
+        initialize();
+        let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: Arc::new(Mutex::new(vec![])),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("resource_spans_append_attribute.py", py, py_resource_spans)
+        })
+        .unwrap();
+        println!("{:#?}", resource_spans.resource.lock().unwrap());
+    }
+
+    #[test]
+    fn resource_spans_iterate_spans() {
+        initialize();
+        let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("resource_spans_iterate_spans.py", py, py_resource_spans)
+        })
+        .unwrap();
+        println!("{:#?}", resource_spans.resource.lock().unwrap());
+    }
+
+    #[test]
+    fn read_and_write_instrumentation_scope() {
+        initialize();
+        let export_req = utilities::otlp::FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script(
+                "read_and_write_instrumentation_scope_test.py",
+                py,
+                py_resource_spans,
+            )
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let scope_spans = scope_spans.pop().unwrap();
+        let scope = scope_spans.scope.unwrap();
+        assert_eq!("name_changed", scope.name);
+        assert_eq!("0.0.2", scope.version);
+        assert_eq!(100, scope.dropped_attributes_count);
+        assert_eq!(scope.attributes.len(), 2);
+        for attr in &scope.attributes {
+            let value = attr.value.clone().unwrap();
+            let value = value.value.unwrap();
+            match attr.key.as_str() {
+                "key_changed" => match value {
+                    opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(i) => {
+                        assert_eq!(i, 200);
+                    }
+                    _ => {
+                        panic!("wrong type for key_changed: {:?}", value);
+                    }
+                },
+                "severity" => match value {
+                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s) => {
+                        assert_eq!(s, "WARN");
+                    }
+                    _ => {
+                        panic!("wrong type for severity: {:?}", value);
+                    }
+                },
+                _ => {
+                    panic!("unexpected key")
+                }
+            }
+        }
+    }
+    #[test]
+    fn set_instrumentation_scope() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("set_instrumentation_scope_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let scope_spans = scope_spans.pop().unwrap();
+        let scope = scope_spans.scope.unwrap();
+        assert_eq!("name_changed", scope.name);
+        assert_eq!("0.0.2", scope.version);
+        assert_eq!(100, scope.dropped_attributes_count);
+        assert_eq!(scope.attributes.len(), 1);
+        for attr in &scope.attributes {
+            let value = attr.value.clone().unwrap();
+            let value = value.value.unwrap();
+            match attr.key.as_str() {
+                "severity" => match value {
+                    Value::StringValue(s) => {
+                        assert_eq!(s, "WARN");
+                    }
+                    _ => {
+                        panic!("wrong type for severity: {:?}", value);
+                    }
+                },
+                _ => {
+                    panic!("unexpected key")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn read_and_write_spans() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("read_and_write_spans_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let resource = Arc::into_inner(resource_spans.resource);
+        let resource = resource.unwrap().into_inner().unwrap().unwrap();
+        let dropped = Arc::into_inner(resource.dropped_attributes_count);
+        let dropped = dropped.unwrap().into_inner().unwrap();
+
+        assert_eq!(15, dropped);
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let mut scope_spans = scope_spans.pop().unwrap();
+        let mut span = scope_spans.spans.pop().unwrap();
+        assert_eq!(b"5555555555".to_vec(), span.trace_id);
+        assert_eq!(b"6666666666".to_vec(), span.span_id);
+        assert_eq!("test=1234567890", span.trace_state);
+        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+        assert_eq!(1, span.flags);
+        assert_eq!("py_processed_span", span.name);
+        assert_eq!(4, span.kind);
+        assert_eq!(1234567890, span.start_time_unix_nano);
+        assert_eq!(1234567890, span.end_time_unix_nano);
+        assert_eq!(100, span.dropped_attributes_count);
+        assert_eq!(200, span.dropped_events_count);
+        assert_eq!(300, span.dropped_links_count);
+        assert_eq!("error message", span.status.clone().unwrap().message);
+        assert_eq!(2, span.status.unwrap().code);
+        assert_eq!(1, span.events.len());
+        assert_eq!("py_processed_event", span.events[0].name);
+        assert_eq!(1234567890, span.events[0].time_unix_nano);
+        assert_eq!(400, span.events[0].dropped_attributes_count);
+        assert_eq!(1, span.events[0].attributes.len());
+        assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
+        let value = span.events[0].attributes[0]
+            .value
+            .clone()
+            .unwrap()
+            .value
+            .unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("event_attr_value", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert_eq!(2, span.links.len());
+        // get the newly added link
+        let new_link = span.links.remove(1);
+        assert_eq!(b"88888888".to_vec(), new_link.trace_id);
+        assert_eq!(b"99999999".to_vec(), new_link.span_id);
+        assert_eq!("test=1234567890", new_link.trace_state);
+        assert_eq!(300, new_link.dropped_attributes_count);
+        assert_eq!(1, new_link.flags);
+        assert_eq!(1, new_link.attributes.len());
+        let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("link_attr_value", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert_eq!(3, span.attributes.len());
+        let new_attr = span.attributes.remove(2);
+        assert_eq!("span_attr_key2", new_attr.key);
+        let value = new_attr.value.clone().unwrap().value.unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("span_attr_value2", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+    }
+    #[test]
+    fn set_scope_spans_span_test() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("set_scope_spans_span_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let mut scope_spans = scope_spans.pop().unwrap();
+        let mut span = scope_spans.spans.pop().unwrap();
+        assert_eq!(b"5555555555".to_vec(), span.trace_id);
+        assert_eq!(b"6666666666".to_vec(), span.span_id);
+        assert_eq!("test=1234567890", span.trace_state);
+        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+        assert_eq!(1, span.flags);
+        assert_eq!("py_processed_span", span.name);
+        assert_eq!(4, span.kind);
+        assert_eq!(1234567890, span.start_time_unix_nano);
+        assert_eq!(1234567890, span.end_time_unix_nano);
+        assert_eq!(100, span.dropped_attributes_count);
+        assert_eq!(200, span.dropped_events_count);
+        assert_eq!(300, span.dropped_links_count);
+        assert_eq!("error message", span.status.clone().unwrap().message);
+        assert_eq!(2, span.status.unwrap().code);
+        assert_eq!(1, span.events.len());
+        assert_eq!("py_processed_event", span.events[0].name);
+        assert_eq!(1234567890, span.events[0].time_unix_nano);
+        assert_eq!(400, span.events[0].dropped_attributes_count);
+        assert_eq!(1, span.events[0].attributes.len());
+        assert_eq!("event_attr_key", &span.events[0].attributes[0].key);
+        let value = span.events[0].attributes[0]
+            .value
+            .clone()
+            .unwrap()
+            .value
+            .unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("event_attr_value", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert_eq!(1, span.links.len());
+        // get the newly added link
+        let new_link = span.links.remove(0);
+        assert_eq!(b"88888888".to_vec(), new_link.trace_id);
+        assert_eq!(b"99999999".to_vec(), new_link.span_id);
+        assert_eq!("test=1234567890", new_link.trace_state);
+        assert_eq!(300, new_link.dropped_attributes_count);
+        assert_eq!(1, new_link.flags);
+        assert_eq!(1, new_link.attributes.len());
+        let value = new_link.attributes[0].value.clone().unwrap().value.unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("link_attr_value", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert_eq!(1, span.attributes.len());
+        let new_attr = span.attributes.remove(0);
+        assert_eq!("span_attr_key", new_attr.key);
+        let value = new_attr.value.clone().unwrap().value.unwrap();
+        match value {
+            Value::StringValue(s) => {
+                assert_eq!("span_attr_value", s)
+            }
+            _ => panic!("unexpected type"),
+        }
+    }
+    #[test]
+    fn set_resource_spans_resource() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script(
+                "write_resource_spans_resource_test.py",
+                py,
+                py_resource_spans,
+            )
+        })
+        .unwrap();
+
+        let resource = Arc::into_inner(resource_spans.resource).unwrap();
+        let resource = resource.into_inner().unwrap().unwrap();
+        let resource = crate::model::py_transform::transform_resource(resource).unwrap();
+        assert_eq!(2, resource.attributes.len());
+        assert_eq!(35, resource.dropped_attributes_count);
+        for attr in &resource.attributes {
+            match attr.key.as_str() {
+                "key" => assert_eq!(
+                    Value::StringValue("value".to_string()),
+                    attr.value.clone().unwrap().value.unwrap()
+                ),
+                "boolean" => assert_eq!(
+                    Value::BoolValue(true),
+                    attr.value.clone().unwrap().value.unwrap()
+                ),
+                _ => panic!("unexpected attribute key"),
+            }
+        }
+    }
+    #[test]
+    fn set_span_events() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("write_span_events_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let mut scope_spans = scope_spans.pop().unwrap();
+        let span = scope_spans.spans.pop().unwrap();
+
+        assert_eq!(2, span.events.len());
+        let event = &span.events[0];
+        assert_eq!("first_event", event.name);
+        assert_eq!(123, event.time_unix_nano);
+        assert_eq!(1, event.dropped_attributes_count);
+        assert_eq!(1, event.attributes.len());
+        let attr = &event.attributes[0];
+        assert_eq!("first_event_attr_key", attr.key);
+        assert_eq!(
+            Value::StringValue("first_event_attr_value".to_string()),
+            attr.value.clone().unwrap().value.unwrap()
+        );
+
+        let event = &span.events[1];
+        assert_eq!("second_event", event.name);
+        assert_eq!(456, event.time_unix_nano);
+        assert_eq!(2, event.dropped_attributes_count);
+        assert_eq!(1, event.attributes.len());
+        let attr = &event.attributes[0];
+        assert_eq!("second_event_attr_key", attr.key);
+        assert_eq!(
+            Value::StringValue("second_event_attr_value".to_string()),
+            attr.value.clone().unwrap().value.unwrap()
+        )
+    }
+    #[test]
+    fn set_scope_spans() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("write_scope_spans_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let mut scope_spans = scope_spans.pop().unwrap();
+        assert_eq!(
+            "https://github.com/streamfold/rotel",
+            scope_spans.schema_url
+        );
+        let inst_scope = scope_spans.scope.unwrap();
+        assert_eq!("rotel-sdk-new", inst_scope.name);
+        assert_eq!("v1.0.1", inst_scope.version);
+        let attr = &inst_scope.attributes[0];
+        assert_eq!("rotel-sdk", attr.key);
+        assert_eq!(
+            Value::StringValue("v1.0.0".to_string()),
+            attr.value.clone().unwrap().value.unwrap()
+        );
+
+        let span = scope_spans.spans.pop().unwrap();
+        assert_eq!(b"5555555555".to_vec(), span.trace_id);
+        assert_eq!(b"6666666666".to_vec(), span.span_id);
+        assert_eq!("test=1234567890", span.trace_state);
+        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+        assert_eq!(1, span.flags);
+        assert_eq!("py_processed_span", span.name);
+        assert_eq!(4, span.kind);
+        assert_eq!(1234567890, span.start_time_unix_nano);
+        assert_eq!(1234567890, span.end_time_unix_nano);
+        let attr = &span.attributes[0];
+        assert_eq!("span_attr_key", attr.key);
+        assert_eq!(
+            Value::StringValue("span_attr_value".to_string()),
+            attr.value.clone().unwrap().value.unwrap()
+        );
+    }
+
+    #[test]
+    fn set_spans() {
+        initialize();
+        let export_req = FakeOTLP::trace_service_request_with_spans(1, 1);
+        let resource_spans = crate::model::otel_transform::transform_resource_spans(
+            export_req.resource_spans[0].clone(),
+        );
+        let py_resource_spans = ResourceSpans {
+            resource: resource_spans.resource.clone(),
+            scope_spans: resource_spans.scope_spans.clone(),
+            schema_url: resource_spans.schema_url,
+        };
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("write_spans_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(resource_spans.scope_spans).unwrap();
+        let scope_spans_vec = scope_spans_vec.into_inner().unwrap();
+
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+        let mut scope_spans = scope_spans.pop().unwrap();
+        let span = scope_spans.spans.pop().unwrap();
+        assert_eq!(b"5555555555".to_vec(), span.trace_id);
+        assert_eq!(b"6666666666".to_vec(), span.span_id);
+        assert_eq!("test=1234567890", span.trace_state);
+        assert_eq!(b"7777777777".to_vec(), span.parent_span_id);
+        assert_eq!(1, span.flags);
+        assert_eq!("py_processed_span", span.name);
+        assert_eq!(4, span.kind);
+        assert_eq!(1234567890, span.start_time_unix_nano);
+        assert_eq!(1234567890, span.end_time_unix_nano);
+        let attr = &span.attributes[0];
+        assert_eq!("span_attr_key", attr.key);
+        assert_eq!(
+            Value::StringValue("span_attr_value".to_string()),
+            attr.value.clone().unwrap().value.unwrap()
+        );
+    }
+
+    #[test]
+    fn read_and_write_log_record() {
+        initialize();
+
+        // Create a mock ResourceLogs protobuf object for testing
+        // In a real scenario, you might use a utility like FakeOTLP if available for logs.
+        let initial_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
+            time_unix_nano: 1000000000,
+            observed_time_unix_nano: 1000000001,
+            severity_number: 9, // INFO
+            severity_text: "INFO".to_string(),
+            body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                value: Some(Value::StringValue("initial log message".to_string())),
+            }),
+            attributes: vec![
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "log.source".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::StringValue("my_app".to_string())),
+                    }),
+                },
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "component".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::StringValue("backend".to_string())),
+                    }),
+                },
+            ],
+            dropped_attributes_count: 0,
+            flags: 0,
+            trace_id: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            span_id: vec![17, 18, 19, 20, 21, 22, 23, 24],
+            event_name: "".to_string(),
+        };
+
+        let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
+            scope: Some(
+                opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+                    name: "test-instrumentation-scope".to_string(),
+                    version: "1.0.0".to_string(),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                },
+            ),
+            log_records: vec![initial_log_record],
+            schema_url: "http://example.com/logs-schema".to_string(),
+        };
+
+        let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+            resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
+                attributes: vec![],
+                dropped_attributes_count: 0,
+            }),
+            scope_logs: vec![initial_scope_logs],
+            schema_url: "http://example.com/resource-logs-schema".to_string(),
+        };
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs =
+            crate::model::otel_transform::transform_resource_logs(export_req.clone());
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("read_and_write_logs_test.py", py, py_resource_logs)
+        })
+        .unwrap();
+
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+
+        // Assert the changes made by the Python script
+        assert_eq!(transformed_scope_logs.len(), 1);
+        let mut scope_log = transformed_scope_logs.remove(0);
+        assert_eq!(scope_log.log_records.len(), 1);
+        let log_record = scope_log.log_records.remove(0);
+
+        assert_eq!(log_record.time_unix_nano, 2000000000);
+        assert_eq!(log_record.observed_time_unix_nano, 2000000001);
+        assert_eq!(log_record.severity_number, 13);
+        assert_eq!(log_record.severity_text, "ERROR");
+
+        let body_value = log_record.body.unwrap().value.unwrap();
+        match body_value {
+            Value::StringValue(s) => {
+                assert_eq!(s, "processed log message");
+            }
+            _ => panic!("Body value is not a string"),
+        }
+
+        assert_eq!(log_record.dropped_attributes_count, 5);
+        assert_eq!(log_record.flags, 1);
+        assert_eq!(log_record.trace_id, b"abcdefghijklmnop".to_vec());
+        assert_eq!(log_record.span_id, b"qrstuvwx".to_vec());
+
+        assert_eq!(log_record.attributes.len(), 3);
+        // Verify the new attribute
+        let new_attr = &log_record.attributes[2];
+        assert_eq!(new_attr.key, "new_log_attr");
+        assert_eq!(
+            new_attr.value.clone().unwrap().value.unwrap(),
+            Value::StringValue("new_log_value".to_string())
+        );
+
+        // Verify the modified attribute
+        let modified_attr = &log_record.attributes[1];
+        assert_eq!(modified_attr.key, "component");
+        assert_eq!(
+            modified_attr.value.clone().unwrap().value.unwrap(),
+            Value::StringValue("modified_component_value".to_string())
+        );
+    }
+
+    #[test]
+    fn add_new_log_record() {
+        initialize();
+
+        // Create a mock ResourceLogs protobuf object with an empty ScopeLogs initially
+        let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
+            scope: Some(
+                opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+                    name: "test-instrumentation-scope".to_string(),
+                    version: "1.0.0".to_string(),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                },
+            ),
+            log_records: vec![], // Start with no log records
+            schema_url: "http://example.com/logs-schema".to_string(),
+        };
+
+        let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+            resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
+                attributes: vec![],
+                dropped_attributes_count: 0,
+            }),
+            scope_logs: vec![initial_scope_logs],
+            schema_url: "http://example.com/resource-logs-schema".to_string(),
+        };
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs =
+            crate::model::otel_transform::transform_resource_logs(export_req.clone());
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script that adds a new log record
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("add_log_record_test.py", py, py_resource_logs)
+        })
+        .unwrap();
+
+        // Transform the modified RResourceLogs back into protobuf format
+        let mut resource = r_resource_logs.resource.lock().unwrap();
+        let _resource_proto = resource
+            .take()
+            .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
+
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+
+        // Assert the changes made by the Python script
+        assert_eq!(transformed_scope_logs.len(), 1);
+        let mut scope_log = transformed_scope_logs.remove(0);
+        assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
+        let log_record = scope_log.log_records.remove(0);
+
+        assert_eq!(log_record.time_unix_nano, 9876543210);
+        assert_eq!(log_record.observed_time_unix_nano, 9876543211);
+        assert_eq!(log_record.severity_number, 17); // FATAL
+        assert_eq!(log_record.severity_text, "FATAL");
+
+        let body_value = log_record.body.unwrap().value.unwrap();
+        match body_value {
+            Value::StringValue(s) => {
+                assert_eq!(s, "This is a newly added log message.");
+            }
+            _ => panic!("Body value is not a string"),
+        }
+
+        assert_eq!(log_record.attributes.len(), 1);
+        let new_attr = &log_record.attributes[0];
+        assert_eq!(new_attr.key, "new_log_key");
+        assert_eq!(
+            new_attr.value.clone().unwrap().value.unwrap(),
+            Value::StringValue("new_log_value".to_string())
+        );
+
+        assert_eq!(log_record.dropped_attributes_count, 2);
+        assert_eq!(log_record.flags, 4);
+        assert_eq!(log_record.trace_id, b"fedcba9876543210".to_vec());
+        assert_eq!(log_record.span_id, b"fedcba98".to_vec());
+    }
+
+    #[test]
+    fn remove_log_record_test() {
+        initialize();
+
+        // Create a mock ResourceLogs protobuf object with two initial LogRecords
+        let first_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
+            time_unix_nano: 1000000000,
+            observed_time_unix_nano: 1000000001,
+            severity_number: 9, // INFO
+            severity_text: "INFO".to_string(),
+            body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                value: Some(
+                    opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                        "first log message".to_string(),
+                    ),
+                ),
+            }),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            flags: 0,
+            trace_id: vec![],
+            span_id: vec![],
+            event_name: "first_event".to_string(),
+        };
+
+        let second_log_record = opentelemetry_proto::tonic::logs::v1::LogRecord {
+            time_unix_nano: 2000000000,
+            observed_time_unix_nano: 2000000001,
+            severity_number: 13, // ERROR
+            severity_text: "ERROR".to_string(),
+            body: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                value: Some(Value::StringValue("second log message".to_string())),
+            }),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            flags: 0,
+            trace_id: vec![],
+            span_id: vec![],
+            event_name: "second_event".to_string(),
+        };
+
+        let initial_scope_logs = opentelemetry_proto::tonic::logs::v1::ScopeLogs {
+            scope: Some(
+                opentelemetry_proto::tonic::common::v1::InstrumentationScope {
+                    name: "test-instrumentation-scope".to_string(),
+                    version: "1.0.0".to_string(),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                },
+            ),
+            log_records: vec![first_log_record, second_log_record], // Two log records
+            schema_url: "http://example.com/logs-schema".to_string(),
+        };
+
+        let export_req = opentelemetry_proto::tonic::logs::v1::ResourceLogs {
+            resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
+                attributes: vec![],
+                dropped_attributes_count: 0,
+            }),
+            scope_logs: vec![initial_scope_logs],
+            schema_url: "http://example.com/resource-logs-schema".to_string(),
+        };
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs =
+            crate::model::otel_transform::transform_resource_logs(export_req.clone());
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("remove_log_record_test.py", py, py_resource_logs)
+        })
+        .unwrap();
+
+        // Transform the modified RResourceLogs back into protobuf format
+        let mut resource = r_resource_logs.resource.lock().unwrap();
+        let _resource_proto = resource
+            .take()
+            .map(|r| crate::model::py_transform::transform_resource(r).unwrap());
+
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut transformed_scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+
+        // Assert the changes made by the Python script
+        assert_eq!(transformed_scope_logs.len(), 1);
+        let mut scope_log = transformed_scope_logs.remove(0);
+        assert_eq!(scope_log.log_records.len(), 1); // Expecting one log record now
+        let log_record = scope_log.log_records.remove(0);
+
+        // Verify that the correct log record remains
+        let body_value = log_record.body.unwrap().value.unwrap();
+        match body_value {
+            Value::StringValue(s) => {
+                assert_eq!(s, "first log message");
+            }
+            _ => panic!("Body value is not the expected string"),
+        }
+    }
+
+    #[test]
+    fn traces_delitem_test() {
+        initialize();
+        let av = opentelemetry_proto::tonic::common::v1::ArrayValue {
+            values: vec![
+                opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("first value".to_string())),
+                },
+                opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("second value".to_string())),
+                },
+            ],
+        };
+        let kvlist = opentelemetry_proto::tonic::common::v1::KeyValueList {
+            values: vec![
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "first_key".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::BoolValue(true)),
+                    }),
+                },
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "second_key".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::StringValue("second_value".to_string())),
+                    }),
+                },
+            ],
+        };
+        let resource = opentelemetry_proto::tonic::resource::v1::Resource {
+            attributes: vec![
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "first_attr".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::KvlistValue(kvlist)),
+                    }),
+                },
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "second_attr".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::ArrayValue(av)),
+                    }),
+                },
+                opentelemetry_proto::tonic::common::v1::KeyValue {
+                    key: "third_attr".to_string(),
+                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                        value: Some(Value::StringValue("to_remove_value".to_string())),
+                    }),
+                },
+            ],
+            dropped_attributes_count: 0,
+        };
+
+        let mut spans = FakeOTLP::trace_spans(2);
+        let now_ns = Utc::now().timestamp_nanos_opt().unwrap();
+
+        // Adding additional data here to test __delitem__
+        spans[0].events.push(v1::span::Event {
+            time_unix_nano: now_ns as u64,
+            name: "second test event".to_string(),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+        });
+
+        spans[0].links.push(v1::span::Link {
+            trace_id: vec![5, 5, 5, 5, 5, 5, 5, 5],
+            span_id: vec![6, 6, 6, 6, 6, 6, 6, 6],
+            trace_state: "secondtrace=00f067aa0ba902b7".to_string(),
+            attributes: vec![],
+            dropped_attributes_count: 0,
+            flags: 0,
+        });
+
+        let first_scope_spans = v1::ScopeSpans {
+            scope: None,
+            spans,
+            schema_url: "".to_string(),
+        };
+
+        let second_scope_spans = v1::ScopeSpans {
+            scope: None,
+            spans: vec![],
+            schema_url: "".to_string(),
+        };
+
+        let resource_spans = v1::ResourceSpans {
+            resource: Some(resource),
+            scope_spans: vec![first_scope_spans, second_scope_spans],
+            schema_url: "".to_string(),
+        };
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_spans =
+            crate::model::otel_transform::transform_resource_spans(resource_spans);
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_spans = ResourceSpans {
+            resource: r_resource_spans.resource.clone(),
+            scope_spans: r_resource_spans.scope_spans.clone(),
+            schema_url: r_resource_spans.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            run_script("traces_delitem_test.py", py, py_resource_spans)
+        })
+        .unwrap();
+
+        let mut resource = r_resource_spans.resource.lock().unwrap();
+        let mut resource_p = resource
+            .take()
+            .map(|r| crate::model::py_transform::transform_resource(r).unwrap())
+            .unwrap();
+
+        assert_eq!(2, resource_p.attributes.len());
+        // Assert the kvlist only has one item now
+        let kvlist = resource_p
+            .attributes
+            .remove(0)
+            .value
+            .unwrap()
+            .value
+            .unwrap();
+        match kvlist {
+            Value::KvlistValue(mut kvl) => {
+                assert_eq!(1, kvl.values.len());
+                let value = kvl.values.remove(0);
+                assert_eq!(value.key, "second_key");
+                let value = value.value.clone().unwrap().value.unwrap();
+                match value {
+                    Value::StringValue(s) => {
+                        assert_eq!(s, "second_value");
+                    }
+                    _ => {
+                        panic!("expected StringValue")
+                    }
+                }
+            }
+            _ => {
+                panic!("expected kvlist")
+            }
+        }
+
+        let arvalue = resource_p
+            .attributes
+            .remove(0)
+            .value
+            .unwrap()
+            .value
+            .unwrap();
+        match arvalue {
+            Value::ArrayValue(mut av) => {
+                assert_eq!(1, av.values.len());
+                let value = av.values.remove(0).value.unwrap();
+                match value {
+                    Value::StringValue(s) => {
+                        assert_eq!(s, "first value")
+                    }
+                    _ => {
+                        panic!("expected StringValue");
+                    }
+                }
+            }
+            _ => {
+                panic!("expected ArrayValue");
+            }
+        }
+
+        // Verify the second scope span has been removed
+        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_spans_vec = crate::model::py_transform::transform_spans(scope_spans_vec);
+        assert_eq!(1, scope_spans_vec.len());
+        let scope_spans = scope_spans_vec.remove(0);
+        let mut spans = scope_spans.spans;
+        assert_eq!(1, spans.len());
+        let span = spans.remove(0);
+        assert_eq!(1, span.events.len());
+        assert_eq!(span.events[0].name, "second test event");
+        assert_eq!(1, span.links.len());
+        assert_eq!(span.links[0].trace_state, "secondtrace=00f067aa0ba902b7")
+    }
+
+    #[test]
+    fn attributes_processor_test() {
+        initialize();
+        let mut log_request = FakeOTLP::logs_service_request();
+
+        let attrs = vec![
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "http.status_code".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::IntValue(200)),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "user.id".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("abc-123".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "user.email".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("test@example.com".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "request.id".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("req-456".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "message".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("User login successful.".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "raw_data".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("id:123,name:Alice,age:30".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "temp_str_int".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("123".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "temp_str_bool".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("true".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "temp_str_float".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::DoubleValue(10.0)),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "path".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("https://rotel.dev/blog".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "super.secret".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("don't tell anyone".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "trace.id".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("12345678".to_string())),
+                }),
+            },
+        ];
+        log_request.resource_logs[0].scope_logs[0].log_records[0].attributes = attrs.clone();
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+            log_request.resource_logs[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "attributes_processor_test.py",
+                py,
+                py_resource_logs,
+                Some("process_logs".to_string()),
+            )
+        })
+        .unwrap();
+
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+
+        let log_record = scope_logs.pop().unwrap().log_records.pop().unwrap();
+        let attrs_to_verify: HashMap<
+            String,
+            Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+        > = log_record
+            .attributes
+            .into_iter()
+            .map(|kv| (kv.key, kv.value))
+            .collect();
+
+        let verify_attrs = |mut attrs: HashMap<
+            String,
+            Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+        >| {
+            let host_name = attrs.remove("host.name").unwrap();
+            match host_name.unwrap().value.unwrap() {
+                Value::StringValue(h) => {
+                    assert_eq!(h, "my-server-1");
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let http_status_code = attrs.remove("http.status_code").unwrap();
+            match http_status_code.unwrap().value.unwrap() {
+                Value::StringValue(c) => {
+                    assert_eq!(c, "OK");
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let env = attrs.remove("env").unwrap();
+            match env.unwrap().value.unwrap() {
+                Value::StringValue(e) => {
+                    assert_eq!(e, "production");
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let email = attrs.remove("email").unwrap();
+            match email.unwrap().value.unwrap() {
+                Value::StringValue(h) => {
+                    assert_eq!(h, "test@example.com");
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let user_id = attrs.remove("user.id").unwrap();
+            match user_id.unwrap().value.unwrap() {
+                Value::StringValue(s) => {
+                    assert_eq!(
+                        s,
+                        "5942d94f524882e0f29bf0a1e5a6dcc952eea1c0c21dd3588a3fc7db9716db0c"
+                    );
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let trace_id = attrs.remove("trace.id").unwrap();
+            match trace_id.unwrap().value.unwrap() {
+                Value::StringValue(s) => {
+                    assert_eq!(
+                        s,
+                        "ef797c8118f02dfb649607dd5d3f8c7623048c9c063d532cc95c5ed7a898a64f"
+                    );
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let id = attrs.remove("extracted_id").unwrap();
+            match id.unwrap().value.unwrap() {
+                Value::StringValue(s) => {
+                    assert_eq!(s, "123");
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let temp_str_int = attrs.remove("temp_str_int").unwrap();
+            match temp_str_int.unwrap().value.unwrap() {
+                Value::IntValue(i) => {
+                    assert_eq!(i, 123);
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let temp_str_bool = attrs.remove("temp_str_bool").unwrap();
+            match temp_str_bool.unwrap().value.unwrap() {
+                Value::BoolValue(b) => {
+                    assert_eq!(b, true);
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let temp_str_float = attrs.remove("temp_str_float").unwrap();
+            match temp_str_float.unwrap().value.unwrap() {
+                Value::DoubleValue(d) => {
+                    assert_eq!(d, 10.0);
+                }
+                _ => panic!("Unexpected value type"),
+            }
+            let path = attrs.remove("path");
+            assert_eq!(path, None);
+            let super_secret = attrs.remove("super.secret");
+            assert_eq!(super_secret, None);
+        };
+
+        verify_attrs(attrs_to_verify);
+
+        let mut trace_request = FakeOTLP::trace_service_request();
+        trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = attrs.clone();
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
+            trace_request.resource_spans[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_spans = ResourceSpans {
+            resource: r_resource_spans.resource.clone(),
+            scope_spans: r_resource_spans.scope_spans.clone(),
+            schema_url: r_resource_spans.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "attributes_processor_test.py",
+                py,
+                py_resource_spans,
+                Some("process_spans".to_string()),
+            )
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+
+        let span = scope_spans.pop().unwrap().spans.pop().unwrap();
+        let attrs_to_verify: HashMap<
+            String,
+            Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+        > = span
+            .attributes
+            .into_iter()
+            .map(|kv| (kv.key, kv.value))
+            .collect();
+
+        verify_attrs(attrs_to_verify);
+    }
+    #[test]
+    fn redaction_processor_restrictive_test() {
+        initialize();
+        let resource_attrs = vec![
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "host.arch".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("amd64".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "os.type".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("linux".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "region".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("us-east-1".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "service.name".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("my-service".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "unallowed_resource_key".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("some_value".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "deployment.environment".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("prod".to_string())),
+                }),
+            },
+        ];
+
+        let span_attrs = vec![
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "user.email".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("test@example.com".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "http.url".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue(
+                        "https://example.com/sensitive/path".to_string(),
+                    )),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "db.statement".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue(
+                        "SELECT * FROM users WHERE id = 1".to_string(),
+                    )),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "operation".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("get_data".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "some_token".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("abcdef123".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "api_key_header".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("xyz789".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "safe_attribute".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("this should remain".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "unallowed_span_key".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("should_be_deleted".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "my_company_email".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("user@mycompany.com".to_string())),
+                }),
+            },
+        ];
+
+        let mut trace_request = FakeOTLP::trace_service_request();
+        trace_request.resource_spans[0].resource =
+            Some(opentelemetry_proto::tonic::resource::v1::Resource {
+                attributes: resource_attrs.clone(),
+                dropped_attributes_count: 0,
+            });
+        trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
+            trace_request.resource_spans[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_spans = ResourceSpans {
+            resource: r_resource_spans.resource.clone(),
+            scope_spans: r_resource_spans.scope_spans.clone(),
+            schema_url: r_resource_spans.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "redaction_processor_restrictive_test.py",
+                py,
+                py_resource_spans,
+                Some("process_spans".to_string()),
+            )
+        })
+        .unwrap();
+
+        let resource = Arc::into_inner(r_resource_spans.resource)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+            .unwrap();
+        let resource = crate::model::py_transform::transform_resource(resource).unwrap();
+        assert_eq!(9, resource.attributes.len());
+        let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
+            resource
+                .attributes
+                .into_iter()
+                .map(|kv| (kv.key.clone(), kv.value.clone()))
+                .collect();
+
+        let expected_attributes = HashMap::from([
+            ("host.arch", "amd64"),
+            ("os.type", "linux"),
+            ("region", "us-east-1"),
+            ("service.name", "my-service"),
+            ("deployment.environment", "prod"),
+            (
+                "redaction.resource.redacted_keys.names",
+                "unallowed_resource_key",
+            ),
+            (
+                "redaction.resource.allowed_keys.names",
+                "deployment.environment,host.arch,os.type,region,service.name",
+            ),
+            ("redaction.resource.redacted_keys.count", "1"),
+            ("redaction.resource.allowed_keys.count", "5"),
+        ]);
+
+        let validate =
+            |kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>>,
+             expected_attributes: HashMap<&str, &str>| {
+                for (key, value) in kv_map {
+                    let ev = expected_attributes.get(key.as_str());
+                    match ev {
+                        None => {
+                            panic!("key {:?} not found in expected attributes", key)
+                        }
+                        Some(v) => match value.unwrap().value.unwrap() {
+                            Value::StringValue(sv) => {
+                                assert_eq!(v.to_string(), sv.to_string());
+                            }
+                            Value::IntValue(i) => {
+                                let v: i64 = v.parse().expect("can't convert to int");
+                                assert_eq!(v, i);
+                            }
+                            _ => {
+                                panic!("expected string value")
+                            }
+                        },
+                    }
+                }
+            };
+
+        validate(kv_map, expected_attributes);
+
+        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+
+        let span = scope_spans.pop().unwrap().spans.pop().unwrap();
+        println!("span is {:?}", span);
+        assert_eq!(7, span.attributes.len());
+
+        let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
+            span.attributes
+                .into_iter()
+                .map(|kv| (kv.key.clone(), kv.value.clone()))
+                .collect();
+
+        let expected_attributes = HashMap::from([
+            ("operation", "get_data"),
+            ("safe_attribute", "this should remain"),
+            ("redaction.span.redacted_keys.count", "7"),
+            ("redaction.span.allowed_keys.names", "operation"),
+            ("redaction.span.allowed_keys.count", "1"),
+            ("redaction.span.redacted_keys.names", "api_key_header,db.statement,http.url,my_company_email,some_token,unallowed_span_key,user.email"),
+            ("redaction.span.ignored_keys.count", "1"),
+        ]);
+
+        validate(kv_map, expected_attributes)
+    }
+
+    #[test]
+    fn redaction_processor_blocking_test() {
+        initialize();
+        let span_attrs = vec![
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "session_token".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("foo".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "api_key".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("bar".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "password_hash".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("xyz123".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "visa".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("4123456789012".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "mastercard".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("5234567890123456".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "bl_email".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("foo@bar.com".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "allowed_email".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("test@mycompany.com".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "ip".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("10.0.1.100".to_string())),
+                }),
+            },
+            opentelemetry_proto::tonic::common::v1::KeyValue {
+                key: "query".to_string(),
+                value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                    value: Some(Value::StringValue("SELECT * FROM USERS".to_string())),
+                }),
+            },
+        ];
+
+        let mut trace_request = FakeOTLP::trace_service_request();
+        trace_request.resource_spans[0].scope_spans[0].spans[0].attributes = span_attrs.clone();
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_spans = crate::model::otel_transform::transform_resource_spans(
+            trace_request.resource_spans[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_spans = ResourceSpans {
+            resource: r_resource_spans.resource.clone(),
+            scope_spans: r_resource_spans.scope_spans.clone(),
+            schema_url: r_resource_spans.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "redaction_processor_blocking_test.py",
+                py,
+                py_resource_spans,
+                Some("process_spans".to_string()),
+            )
+        })
+        .unwrap();
+
+        let scope_spans_vec = Arc::into_inner(r_resource_spans.scope_spans)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_spans = crate::model::py_transform::transform_spans(scope_spans_vec);
+
+        let span = scope_spans.pop().unwrap().spans.pop().unwrap();
+        assert_eq!(13, span.attributes.len());
+
+        let kv_map: HashMap<String, Option<opentelemetry_proto::tonic::common::v1::AnyValue>> =
+            span.attributes
+                .into_iter()
+                .map(|kv| (kv.key.clone(), kv.value.clone()))
+                .collect();
+
+        let expected_attributes = HashMap::from([
+            ("visa", "8d9e470bdd9f6e6e18023938497857dc"),
+            ("mastercard", "aad9ce9b62a1f697745fcd81314b877f"),
+            ("ip", "f5c45dc3c8fb04f638ad27a711910390"),
+            ("query", "06c445f7ade97a964f7c466575f8b508"),
+            ("bl_email", "f3ada405ce890b6f8204094deb12d8a8"),
+            ("session_token", "acbd18db4cc2f85cedef654fccc4a4d8"),
+            ("allowed_email", "test@mycompany.com"),
+            ("api_key", "37b51d194a7513e45b56f6524f2d51f2"),
+            ("password_hash", "613d3b9c91e9445abaeca02f2342e5a6"),
+            ("redaction.span.allowed_keys.names", "allowed_email,api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
+            ("redaction.span.allowed_keys.count", "9"),
+            ("redaction.span.masked_keys.names", "api_key,bl_email,ip,mastercard,password_hash,query,session_token,visa"),
+            ("redaction.span.masked_keys.count", "8"),
+        ]);
+
+        for (key, value) in kv_map {
+            let ev = expected_attributes.get(key.as_str());
+            match ev {
+                None => {
+                    panic!("key {:?} not found in expected attributes", key)
+                }
+                Some(v) => match value.unwrap().value.unwrap() {
+                    Value::StringValue(sv) => {
+                        assert_eq!(v.to_string(), sv.to_string());
+                    }
+                    Value::IntValue(i) => {
+                        let v: i64 = v.parse().expect("can't convert to int");
+                        assert_eq!(v, i);
+                    }
+                    _ => {
+                        panic!("expected string value")
+                    }
+                },
+            }
+        }
+    }
+
+    #[test]
+    fn redaction_processor_log_body_test() {
+        initialize();
+        let mut logs_request = FakeOTLP::logs_service_request();
+        let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
+            value: Some(Value::StringValue(
+                "Login successful: password=1234567890".to_string(),
+            )),
+        };
+        logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+            logs_request.resource_logs[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "redaction_processor_log_body_test.py",
+                py,
+                py_resource_logs,
+                Some("process_logs".to_string()),
+            )
+        })
+        .unwrap();
+
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+        let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
+        let body = log.body.unwrap().value.unwrap();
+        match body {
+            Value::StringValue(b) => {
+                assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
+            }
+            _ => panic!("Unexpected log record value type"),
+        }
+
+        let mut logs_request = FakeOTLP::logs_service_request();
+        let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
+            value: Some(Value::KvlistValue(
+                opentelemetry_proto::tonic::common::v1::KeyValueList {
+                    values: vec![opentelemetry_proto::tonic::common::v1::KeyValue {
+                        key: "another_body".to_string(),
+                        value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                            value: Some(Value::StringValue(
+                                "Login successful: password=1234567890".to_string(),
+                            )),
+                        }),
+                    }],
+                },
+            )),
+        };
+        logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+            logs_request.resource_logs[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "redaction_processor_log_body_test.py",
+                py,
+                py_resource_logs,
+                Some("process_logs".to_string()),
+            )
+        })
+        .unwrap();
+
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+        let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
+        let body = log.body.unwrap().value.unwrap();
+        match body {
+            Value::KvlistValue(mut kvl) => {
+                let v = kvl.values.pop().unwrap();
+                match v.value.unwrap().value.unwrap() {
+                    Value::StringValue(b) => {
+                        assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
+                    }
+                    _ => {
+                        panic!("Unexpected log record value type");
+                    }
+                }
+            }
+            _ => panic!("Unexpected log record value type"),
+        }
+
+        let mut logs_request = FakeOTLP::logs_service_request();
+        let log_body = opentelemetry_proto::tonic::common::v1::AnyValue {
+            value: Some(Value::ArrayValue(
+                opentelemetry_proto::tonic::common::v1::ArrayValue {
+                    values: vec![
+                        opentelemetry_proto::tonic::common::v1::AnyValue {
+                            value: Some(Value::StringValue(
+                                "Login failed: password=1234567890".to_string(),
+                            )),
+                        },
+                        opentelemetry_proto::tonic::common::v1::AnyValue {
+                            value: Some(Value::KvlistValue(
+                                opentelemetry_proto::tonic::common::v1::KeyValueList {
+                                    values: vec![
+                                        opentelemetry_proto::tonic::common::v1::KeyValue {
+                                            key: "another_body".to_string(),
+                                            value: Some(
+                                                opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                    value: Some(Value::StringValue(
+                                                        "Login successful: password=1234567890"
+                                                            .to_string(),
+                                                    )),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            )),
+                        },
+                    ],
+                },
+            )),
+        };
+        logs_request.resource_logs[0].scope_logs[0].log_records[0].body = Some(log_body);
+
+        // Transform the protobuf ResourceLogs into our internal RResourceLogs
+        let r_resource_logs = crate::model::otel_transform::transform_resource_logs(
+            logs_request.resource_logs[0].clone(),
+        );
+
+        // Create the Python-exposed ResourceLogs object
+        let py_resource_logs = ResourceLogs {
+            resource: r_resource_logs.resource.clone(),
+            scope_logs: r_resource_logs.scope_logs.clone(),
+            schema_url: r_resource_logs.schema_url.clone(),
+        };
+
+        // Execute the Python script that removes a log record
+        Python::with_gil(|py| -> PyResult<()> {
+            _run_script(
+                "redaction_processor_log_body_test.py",
+                py,
+                py_resource_logs,
+                Some("process_logs".to_string()),
+            )
+        })
+        .unwrap();
+        let scope_logs_vec = Arc::into_inner(r_resource_logs.scope_logs)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        let mut scope_logs = crate::model::py_transform::transform_logs(scope_logs_vec);
+        let log = scope_logs.pop().unwrap().log_records.pop().unwrap();
+        let body = log.body.unwrap().value.unwrap();
+        match body {
+            Value::ArrayValue(mut av) => {
+                assert_eq!(av.values.len(), 2);
+                while !av.values.is_empty() {
+                    let v = av.values.pop().unwrap();
+                    match v.value.unwrap() {
+                        Value::StringValue(b) => {
+                            assert_eq!(b, "34c37eb5ba287d52490cc8c2e3ebc231");
+                        }
+                        Value::KvlistValue(mut kvl) => {
+                            let v = kvl.values.pop().unwrap();
+                            match v.value.unwrap().value.unwrap() {
+                                Value::StringValue(b) => {
+                                    assert_eq!(b, "6a3840901d0f07c768b96a0fad2cabe2");
+                                }
+                                _ => {
+                                    panic!("Unexpected log record value type");
+                                }
+                            }
+                        }
+                        _ => {
+                            panic!("Unexpected log record value type");
+                        }
+                    }
+                }
+            }
+            _ => {
+                panic!("Unexpected log record value type");
+            }
+        }
+    }
+
+    #[test]
+    fn read_and_write_metrics_comprehensive() {
+        initialize();
+
+        // Create comprehensive initial OpenTelemetry protobuf with ALL metric types
         let resource_metrics = opentelemetry_proto::tonic::metrics::v1::ResourceMetrics {
             resource: Some(opentelemetry_proto::tonic::resource::v1::Resource {
                 attributes: vec![
                     opentelemetry_proto::tonic::common::v1::KeyValue {
-                        key: "resource_key".to_string(),
+                        key: "initial_resource_key".to_string(),
                         value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("resource_value".to_string())),
+                            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("initial_resource_value".to_string())),
                         }),
                     },
                 ],
-                dropped_attributes_count: 0,
+                dropped_attributes_count: 10,
             }),
             scope_metrics: vec![
                 opentelemetry_proto::tonic::metrics::v1::ScopeMetrics {
@@ -2662,18 +2618,19 @@ mod tests {
                                 }),
                             },
                         ],
-                        dropped_attributes_count: 0,
+                        dropped_attributes_count: 5,
                     }),
                     metrics: vec![
+                        // 1. Gauge metric
                         opentelemetry_proto::tonic::metrics::v1::Metric {
-                            name: "initial_metric_name".to_string(),
-                            description: "initial_description".to_string(),
-                            unit: "initial_unit".to_string(),
+                            name: "initial_gauge_metric".to_string(),
+                            description: "initial_gauge_description".to_string(),
+                            unit: "initial_gauge_unit".to_string(),
                             metadata: vec![
                                 opentelemetry_proto::tonic::common::v1::KeyValue {
-                                    key: "initial_metadata_key".to_string(),
+                                    key: "gauge_metadata_key".to_string(),
                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("initial_metadata_value".to_string())),
+                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("gauge_metadata_value".to_string())),
                                     }),
                                 },
                             ],
@@ -2683,17 +2640,232 @@ mod tests {
                                         opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
                                             attributes: vec![
                                                 opentelemetry_proto::tonic::common::v1::KeyValue {
-                                                    key: "dp_key".to_string(),
+                                                    key: "gauge_dp_key".to_string(),
                                                     value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
-                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("dp_value".to_string())),
+                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("gauge_dp_value".to_string())),
                                                     }),
                                                 },
                                             ],
                                             start_time_unix_nano: 1000,
                                             time_unix_nano: 2000,
-                                            exemplars: vec![],
+                                            exemplars: vec![
+                                                opentelemetry_proto::tonic::metrics::v1::Exemplar {
+                                                    filtered_attributes: vec![
+                                                        opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                            key: "gauge_exemplar_key".to_string(),
+                                                            value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                                value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("gauge_exemplar_value".to_string())),
+                                                            }),
+                                                        },
+                                                    ],
+                                                    time_unix_nano: 1500,
+                                                    span_id: b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec(),
+                                                    trace_id: b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01".to_vec(),
+                                                    value: Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsDouble(15.5)),
+                                                },
+                                            ],
                                             flags: 0,
                                             value: Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsDouble(123.45)),
+                                        },
+                                    ],
+                                },
+                            )),
+                        },
+                        // 2. Sum metric
+                        opentelemetry_proto::tonic::metrics::v1::Metric {
+                            name: "initial_sum_metric".to_string(),
+                            description: "initial_sum_description".to_string(),
+                            unit: "initial_sum_unit".to_string(),
+                            metadata: vec![
+                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                    key: "sum_metadata_key".to_string(),
+                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(42)),
+                                    }),
+                                },
+                            ],
+                            data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                                opentelemetry_proto::tonic::metrics::v1::Sum {
+                                    data_points: vec![
+                                        opentelemetry_proto::tonic::metrics::v1::NumberDataPoint {
+                                            attributes: vec![
+                                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                    key: "sum_dp_key".to_string(),
+                                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("sum_dp_value".to_string())),
+                                                    }),
+                                                },
+                                            ],
+                                            start_time_unix_nano: 3000,
+                                            time_unix_nano: 4000,
+                                            exemplars: vec![],
+                                            flags: 0,
+                                            value: Some(opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(100)),
+                                        },
+                                    ],
+                                    aggregation_temporality: opentelemetry_proto::tonic::metrics::v1::AggregationTemporality::Delta as i32,
+                                    is_monotonic: true,
+                                },
+                            )),
+                        },
+                        // 3. Histogram metric
+                        opentelemetry_proto::tonic::metrics::v1::Metric {
+                            name: "initial_histogram_metric".to_string(),
+                            description: "initial_histogram_description".to_string(),
+                            unit: "initial_histogram_unit".to_string(),
+                            metadata: vec![
+                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                    key: "histogram_metadata_key".to_string(),
+                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(false)),
+                                    }),
+                                },
+                            ],
+                            data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(
+                                opentelemetry_proto::tonic::metrics::v1::Histogram {
+                                    data_points: vec![
+                                        opentelemetry_proto::tonic::metrics::v1::HistogramDataPoint {
+                                            attributes: vec![
+                                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                    key: "histogram_dp_key".to_string(),
+                                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("histogram_dp_value".to_string())),
+                                                    }),
+                                                },
+                                            ],
+                                            start_time_unix_nano: 5000,
+                                            time_unix_nano: 6000,
+                                            count: 50,
+                                            sum: Some(500.0),
+                                            bucket_counts: vec![5, 10, 15, 20],
+                                            explicit_bounds: vec![1.0, 5.0, 10.0],
+                                            exemplars: vec![
+                                                opentelemetry_proto::tonic::metrics::v1::Exemplar {
+                                                    filtered_attributes: vec![],
+                                                    time_unix_nano: 5500,
+                                                    span_id: b"\x11\x12\x13\x14\x15\x16\x17\x18".to_vec(),
+                                                    trace_id: b"\x18\x17\x16\x15\x14\x13\x12\x11\x18\x17\x16\x15\x14\x13\x12\x11".to_vec(),
+                                                    value: Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsInt(25)),
+                                                },
+                                            ],
+                                            flags: 1,
+                                            min: Some(0.1),
+                                            max: Some(20.0),
+                                        },
+                                    ],
+                                    aggregation_temporality: opentelemetry_proto::tonic::metrics::v1::AggregationTemporality::Cumulative as i32,
+                                },
+                            )),
+                        },
+                        // 4. ExponentialHistogram metric
+                        opentelemetry_proto::tonic::metrics::v1::Metric {
+                            name: "initial_exp_histogram_metric".to_string(),
+                            description: "initial_exp_histogram_description".to_string(),
+                            unit: "initial_exp_histogram_unit".to_string(),
+                            metadata: vec![
+                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                    key: "exp_histogram_metadata_key".to_string(),
+                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::DoubleValue(3.14)),
+                                    }),
+                                },
+                            ],
+                            data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::ExponentialHistogram(
+                                opentelemetry_proto::tonic::metrics::v1::ExponentialHistogram {
+                                    data_points: vec![
+                                        opentelemetry_proto::tonic::metrics::v1::ExponentialHistogramDataPoint {
+                                            attributes: vec![
+                                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                    key: "exp_histogram_dp_key".to_string(),
+                                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("exp_histogram_dp_value".to_string())),
+                                                    }),
+                                                },
+                                            ],
+                                            start_time_unix_nano: 7000,
+                                            time_unix_nano: 8000,
+                                            count: 75,
+                                            sum: Some(750.0),
+                                            scale: 1,
+                                            zero_count: 3,
+                                            positive: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
+                                                offset: 2,
+                                                bucket_counts: vec![2, 4, 6, 8],
+                                            }),
+                                            negative: Some(opentelemetry_proto::tonic::metrics::v1::exponential_histogram_data_point::Buckets {
+                                                offset: -1,
+                                                bucket_counts: vec![1, 2, 3],
+                                            }),
+                                            flags: 0,
+                                            exemplars: vec![
+                                                opentelemetry_proto::tonic::metrics::v1::Exemplar {
+                                                    filtered_attributes: vec![
+                                                        opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                            key: "exp_exemplar_key".to_string(),
+                                                            value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                                value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("exp_exemplar_value".to_string())),
+                                                            }),
+                                                        },
+                                                    ],
+                                                    time_unix_nano: 7500,
+                                                    span_id: b"\x21\x22\x23\x24\x25\x26\x27\x28".to_vec(),
+                                                    trace_id: b"\x28\x27\x26\x25\x24\x23\x22\x21\x28\x27\x26\x25\x24\x23\x22\x21".to_vec(),
+                                                    value: Some(opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsDouble(37.5)),
+                                                },
+                                            ],
+                                            min: Some(0.5),
+                                            max: Some(50.0),
+                                            zero_threshold: 0.01,
+                                        },
+                                    ],
+                                    aggregation_temporality: opentelemetry_proto::tonic::metrics::v1::AggregationTemporality::Delta as i32,
+                                },
+                            )),
+                        },
+                        // 5. Summary metric
+                        opentelemetry_proto::tonic::metrics::v1::Metric {
+                            name: "initial_summary_metric".to_string(),
+                            description: "initial_summary_description".to_string(),
+                            unit: "initial_summary_unit".to_string(),
+                            metadata: vec![
+                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                    key: "summary_metadata_key".to_string(),
+                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::BytesValue(b"summary_bytes".to_vec())),
+                                    }),
+                                },
+                            ],
+                            data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Summary(
+                                opentelemetry_proto::tonic::metrics::v1::Summary {
+                                    data_points: vec![
+                                        opentelemetry_proto::tonic::metrics::v1::SummaryDataPoint {
+                                            attributes: vec![
+                                                opentelemetry_proto::tonic::common::v1::KeyValue {
+                                                    key: "summary_dp_key".to_string(),
+                                                    value: Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                                                        value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue("summary_dp_value".to_string())),
+                                                    }),
+                                                },
+                                            ],
+                                            start_time_unix_nano: 9000,
+                                            time_unix_nano: 10000,
+                                            count: 25,
+                                            sum: 250.0,
+                                            quantile_values: vec![
+                                                opentelemetry_proto::tonic::metrics::v1::summary_data_point::ValueAtQuantile {
+                                                    quantile: 0.5,
+                                                    value: 10.0,
+                                                },
+                                                opentelemetry_proto::tonic::metrics::v1::summary_data_point::ValueAtQuantile {
+                                                    quantile: 0.95,
+                                                    value: 19.0,
+                                                },
+                                                opentelemetry_proto::tonic::metrics::v1::summary_data_point::ValueAtQuantile {
+                                                    quantile: 0.99,
+                                                    value: 19.8,
+                                                },
+                                            ],
+                                            flags: 1,
                                         },
                                     ],
                                 },
@@ -2706,16 +2878,15 @@ mod tests {
             schema_url: "initial_schema_url_resource".to_string(),
         };
 
-        // 2. Use otel_transform to turn it into our RMetricsData model
+        // Transform to our internal model
         let r_resource_metrics = otel_transform::transform_resource_metrics(resource_metrics);
-        // Create the Python-exposed ResourceLogs object
         let py_resource_metrics = ResourceMetrics {
             resource: r_resource_metrics.resource.clone(),
             scope_metrics: r_resource_metrics.scope_metrics.clone(),
             schema_url: r_resource_metrics.schema_url.clone(),
         };
 
-        // Execute the Python script that removes a log record
+        // Execute the Python script that will verify initial values and then mutate them
         Python::with_gil(|py| -> PyResult<()> {
             _run_script(
                 "read_and_write_metrics_test.py",
@@ -2726,182 +2897,188 @@ mod tests {
         })
         .unwrap();
 
+        // --- RUST VERIFICATION OF PYTHON MUTATIONS ---
+
+        // Transform back to protobuf for verification
         let scope_metrics_vec = Arc::into_inner(r_resource_metrics.scope_metrics)
             .unwrap()
             .into_inner()
             .unwrap();
         let mut scope_metrics = py_transform::transform_metrics(scope_metrics_vec);
-        println!("{:#?}", scope_metrics);
-        // let final_proto_metrics_data = scope_metrics.pop().unwrap();
-        // assert_eq!(final_proto_metrics_data.resource_metrics.len(), 1);
-        // let proto_resource_metrics = &final_proto_metrics_data.resource_metrics[0];
-        //
-        // assert_eq!(proto_resource_metrics.schema_url, "py_processed_schema_url_resource");
-        // assert!(proto_resource_metrics.resource.is_some());
-        // let proto_resource = proto_resource_metrics.resource.as_ref().unwrap();
-        // assert_eq!(proto_resource.dropped_attributes_count, 5);
 
         assert_eq!(scope_metrics.len(), 1);
-
         let proto_scope_metrics = &scope_metrics[0];
+
+        // Should still have 5 metrics after Python processing
+        assert_eq!(proto_scope_metrics.metrics.len(), 5);
+
+        // --- Verify ResourceMetrics mutations ---
+        let resource = Arc::into_inner(r_resource_metrics.resource)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+            .unwrap();
+        let resource_proto = py_transform::transform_resource(resource).unwrap();
+        assert_eq!(resource_proto.dropped_attributes_count, 25); // Changed from 10 to 25
+        assert_eq!(resource_proto.attributes.len(), 2); // Added one attribute
+        assert_eq!(
+            resource_proto.attributes[1].key,
+            "python_added_resource_key"
+        );
+
+        // --- Verify ScopeMetrics mutations ---
         assert_eq!(
             proto_scope_metrics.schema_url,
-            "py_processed_schema_url_scope"
+            "python_modified_schema_url_scope"
         );
-        assert!(proto_scope_metrics.scope.is_some());
         let proto_scope = proto_scope_metrics.scope.as_ref().unwrap();
-        assert_eq!(proto_scope.name, "py_processed_scope_name");
-        assert_eq!(proto_scope.version, "py_processed_scope_version");
-        assert_eq!(proto_scope.attributes.len(), 2);
-        assert_eq!(proto_scope.attributes[1].key, "scope_attr_py");
+        assert_eq!(proto_scope.name, "python_modified_scope_name");
+        assert_eq!(proto_scope.version, "python_modified_scope_version");
+        assert_eq!(proto_scope.dropped_attributes_count, 15); // Changed from 5 to 15
+        assert_eq!(proto_scope.attributes.len(), 2); // Added one attribute
+        assert_eq!(proto_scope.attributes[1].key, "python_added_scope_key");
+
+        // --- Verify Gauge metric mutations ---
+        let gauge_metric = &proto_scope_metrics.metrics[0];
+        assert_eq!(gauge_metric.name, "python_modified_gauge_metric");
         assert_eq!(
-            proto_scope.attributes[1]
-                .value
-                .as_ref()
-                .unwrap()
-                .value
-                .as_ref()
-                .unwrap(),
-            &opentelemetry_proto::tonic::common::v1::any_value::Value::BoolValue(true)
+            gauge_metric.description,
+            "python_modified_gauge_description"
         );
-        assert_eq!(proto_scope.dropped_attributes_count, 1);
+        assert_eq!(gauge_metric.unit, "python_modified_gauge_unit");
+        assert_eq!(gauge_metric.metadata.len(), 2); // Added one metadata
+        assert_eq!(gauge_metric.metadata[1].key, "python_added_gauge_metadata");
 
-        assert_eq!(proto_scope_metrics.metrics.len(), 2); // Original (now Sum) + new Histogram
+        match gauge_metric.data.as_ref().unwrap() {
+            opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(g) => {
+                assert_eq!(g.data_points.len(), 2); // Added one data point
+                let dp = &g.data_points[0];
+                assert_eq!(dp.start_time_unix_nano, 1100); // Changed from 1000
+                assert_eq!(dp.time_unix_nano, 2200); // Changed from 2000
+                assert_eq!(dp.flags, 1); // Changed from 0
+                assert_eq!(dp.attributes.len(), 2); // Added one attribute
+                assert_eq!(dp.exemplars.len(), 2); // Added one exemplar
+            }
+            _ => panic!("Expected Gauge metric data"),
+        }
 
-        // Assert the first metric (originally Gauge, now Sum)
-        let proto_sum_metric = &proto_scope_metrics.metrics[0];
-        assert_eq!(proto_sum_metric.name, "py_processed_metric_name");
-        assert_eq!(proto_sum_metric.description, "py_processed_description");
-        assert_eq!(proto_sum_metric.unit, "py_processed_unit");
-        assert_eq!(proto_sum_metric.metadata.len(), 2);
-        assert_eq!(proto_sum_metric.metadata[1].key, "metadata_py");
-        assert_eq!(
-            proto_sum_metric.metadata[1]
-                .value
-                .as_ref()
-                .unwrap()
-                .value
-                .as_ref()
-                .unwrap(),
-            &opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(999)
-        );
+        // --- Verify Sum metric mutations ---
+        let sum_metric = &proto_scope_metrics.metrics[1];
+        assert_eq!(sum_metric.name, "python_modified_sum_metric");
+        assert_eq!(sum_metric.description, "python_modified_sum_description");
+        assert_eq!(sum_metric.unit, "python_modified_sum_unit");
 
-        assert!(proto_sum_metric.data.is_some());
-        match proto_sum_metric.data.as_ref().unwrap() {
+        match sum_metric.data.as_ref().unwrap() {
             opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(s) => {
                 assert_eq!(
                     s.aggregation_temporality,
-                    AggregationTemporality::Cumulative as i32
-                );
-                assert!(s.is_monotonic);
-                assert_eq!(s.data_points.len(), 2);
-
-                let sum_dp1 = &s.data_points[0];
-                assert_eq!(sum_dp1.start_time_unix_nano, 3000);
-                assert_eq!(sum_dp1.time_unix_nano, 4000);
-                assert_eq!(
-                    sum_dp1.value.as_ref().unwrap(),
-                    &opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(10)
-                );
-                assert_eq!(sum_dp1.attributes[0].key, "sum_dp_key");
-                assert_eq!(
-                    sum_dp1.attributes[0]
-                        .value
-                        .as_ref()
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .unwrap(),
-                    &opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                        "sum_dp_value".to_string()
-                    )
-                );
-                assert_eq!(sum_dp1.exemplars.len(), 1);
-                assert_eq!(sum_dp1.exemplars[0].time_unix_nano, 3500);
-                assert_eq!(
-                    sum_dp1.exemplars[0].value.as_ref().unwrap(),
-                    &opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsDouble(10.5)
-                );
-                assert_eq!(
-                    sum_dp1.exemplars[0].span_id,
-                    b"\x01\x02\x03\x04\x05\x06\x07\x08"
-                );
-                assert_eq!(
-                    sum_dp1.exemplars[0].trace_id,
-                    b"\x08\x07\x06\x05\x04\x03\x02\x01\x08\x07\x06\x05\x04\x03\x02\x01"
-                );
-                assert_eq!(
-                    sum_dp1.exemplars[0].filtered_attributes[0].key,
-                    "filtered_key"
-                );
-                assert_eq!(
-                    sum_dp1.exemplars[0].filtered_attributes[0]
-                        .value
-                        .as_ref()
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .unwrap(),
-                    &opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                        "filtered_value".to_string()
-                    )
-                );
-
-                let sum_dp2 = &s.data_points[1];
-                assert_eq!(
-                    sum_dp2.value.as_ref().unwrap(),
-                    &opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(20)
-                );
-                assert_eq!(sum_dp2.flags, DataPointFlags::NoRecordedValueMask as u32);
+                    opentelemetry_proto::tonic::metrics::v1::AggregationTemporality::Cumulative
+                        as i32
+                ); // Changed from Delta
+                assert!(!s.is_monotonic); // Changed from true to false
+                assert_eq!(s.data_points.len(), 2); // Added one data point
+                let dp = &s.data_points[0];
+                assert_eq!(dp.start_time_unix_nano, 3300); // Changed from 3000
+                assert_eq!(dp.time_unix_nano, 4400); // Changed from 4000
             }
             _ => panic!("Expected Sum metric data"),
         }
 
-        // Assert the second metric (new Histogram)
-        let proto_hist_metric = &proto_scope_metrics.metrics[1];
-        assert_eq!(proto_hist_metric.name, "py_processed_histogram");
-        assert_eq!(proto_hist_metric.description, "A histogram from Python");
-        assert_eq!(proto_hist_metric.unit, "ms");
+        // --- Verify Histogram metric mutations ---
+        let hist_metric = &proto_scope_metrics.metrics[2];
+        assert_eq!(hist_metric.name, "python_modified_histogram_metric");
+        assert_eq!(
+            hist_metric.description,
+            "python_modified_histogram_description"
+        );
+        assert_eq!(hist_metric.unit, "python_modified_histogram_unit");
 
-        assert!(proto_hist_metric.data.is_some());
-        match proto_hist_metric.data.as_ref().unwrap() {
+        match hist_metric.data.as_ref().unwrap() {
             opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(h) => {
                 assert_eq!(
                     h.aggregation_temporality,
-                    AggregationTemporality::Delta as i32
-                );
-                assert_eq!(h.data_points.len(), 1);
-                let hist_dp = &h.data_points[0];
-                assert_eq!(hist_dp.start_time_unix_nano, 7000);
-                assert_eq!(hist_dp.time_unix_nano, 8000);
-                assert_eq!(hist_dp.count, 100);
-                assert_eq!(hist_dp.sum.unwrap(), 1000.0);
-                assert_eq!(hist_dp.bucket_counts, vec![10, 20, 30, 40]);
-                assert_eq!(hist_dp.explicit_bounds, vec![1.0, 5.0, 10.0]);
-                assert_eq!(hist_dp.min.unwrap(), 0.5);
-                assert_eq!(hist_dp.max.unwrap(), 12.0);
-                assert_eq!(hist_dp.attributes[0].key, "hist_attr");
-                assert_eq!(
-                    hist_dp.attributes[0]
-                        .value
-                        .as_ref()
-                        .unwrap()
-                        .value
-                        .as_ref()
-                        .unwrap(),
-                    &opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
-                        "hist_value".to_string()
-                    )
-                );
-
-                assert_eq!(hist_dp.exemplars.len(), 1);
-                assert_eq!(hist_dp.exemplars[0].time_unix_nano, 7500);
-                assert_eq!(
-                    hist_dp.exemplars[0].value.as_ref().unwrap(),
-                    &opentelemetry_proto::tonic::metrics::v1::exemplar::Value::AsInt(75)
-                );
+                    opentelemetry_proto::tonic::metrics::v1::AggregationTemporality::Delta as i32
+                ); // Changed from Cumulative
+                assert_eq!(h.data_points.len(), 2); // Added one data point
+                let dp = &h.data_points[0];
+                assert_eq!(dp.count, 75); // Changed from 50
+                assert_eq!(dp.sum.unwrap(), 750.0); // Changed from 500.0
+                assert_eq!(dp.bucket_counts, vec![10, 20, 30, 40]); // Changed values
+                assert_eq!(dp.explicit_bounds, vec![2.0, 10.0, 20.0]); // Changed values
+                assert_eq!(dp.min.unwrap(), 0.2); // Changed from 0.1
+                assert_eq!(dp.max.unwrap(), 25.0); // Changed from 20.0
             }
             _ => panic!("Expected Histogram metric data"),
         }
+
+        // --- Verify ExponentialHistogram metric mutations ---
+        let exp_hist_metric = &proto_scope_metrics.metrics[3];
+        assert_eq!(exp_hist_metric.name, "python_modified_exp_histogram_metric");
+        assert_eq!(
+            exp_hist_metric.description,
+            "python_modified_exp_histogram_description"
+        );
+        assert_eq!(exp_hist_metric.unit, "python_modified_exp_histogram_unit");
+
+        match exp_hist_metric.data.as_ref().unwrap() {
+            opentelemetry_proto::tonic::metrics::v1::metric::Data::ExponentialHistogram(eh) => {
+                assert_eq!(
+                    eh.aggregation_temporality,
+                    opentelemetry_proto::tonic::metrics::v1::AggregationTemporality::Cumulative
+                        as i32
+                ); // Changed from Delta
+                assert_eq!(eh.data_points.len(), 2); // Added one data point
+                let dp = &eh.data_points[0];
+                assert_eq!(dp.count, 100); // Changed from 75
+                assert_eq!(dp.sum.unwrap(), 1000.0); // Changed from 750.0
+                assert_eq!(dp.scale, 2); // Changed from 1
+                assert_eq!(dp.zero_count, 5); // Changed from 3
+                assert_eq!(dp.zero_threshold, 0.02); // Changed from 0.01
+
+                // Verify positive buckets were modified
+                let positive = dp.positive.as_ref().unwrap();
+                assert_eq!(positive.offset, 3); // Changed from 2
+                assert_eq!(positive.bucket_counts, vec![4, 8, 12, 16]); // Changed values
+
+                // Verify negative buckets were modified
+                let negative = dp.negative.as_ref().unwrap();
+                assert_eq!(negative.offset, -2); // Changed from -1
+                assert_eq!(negative.bucket_counts, vec![2, 4, 6]); // Changed values
+            }
+            _ => panic!("Expected ExponentialHistogram metric data"),
+        }
+
+        // --- Verify Summary metric mutations ---
+        let summary_metric = &proto_scope_metrics.metrics[4];
+        assert_eq!(summary_metric.name, "python_modified_summary_metric");
+        assert_eq!(
+            summary_metric.description,
+            "python_modified_summary_description"
+        );
+        assert_eq!(summary_metric.unit, "python_modified_summary_unit");
+
+        match summary_metric.data.as_ref().unwrap() {
+            opentelemetry_proto::tonic::metrics::v1::metric::Data::Summary(s) => {
+                assert_eq!(s.data_points.len(), 2); // Added one data point
+                let dp = &s.data_points[0];
+                assert_eq!(dp.count, 50); // Changed from 25
+                assert_eq!(dp.sum, 500.0); // Changed from 250.0
+                assert_eq!(dp.flags, 0); // Changed from 1
+
+                // Verify quantile values were modified
+                assert_eq!(dp.quantile_values.len(), 4); // Added one quantile
+                assert_eq!(dp.quantile_values[0].quantile, 0.5);
+                assert_eq!(dp.quantile_values[0].value, 20.0); // Changed from 10.0
+                assert_eq!(dp.quantile_values[1].quantile, 0.95);
+                assert_eq!(dp.quantile_values[1].value, 38.0); // Changed from 19.0
+                assert_eq!(dp.quantile_values[2].quantile, 0.99);
+                assert_eq!(dp.quantile_values[2].value, 39.6); // Changed from 19.8
+                assert_eq!(dp.quantile_values[3].quantile, 0.999); // New quantile
+                assert_eq!(dp.quantile_values[3].value, 39.96); // New value
+            }
+            _ => panic!("Expected Summary metric data"),
+        }
+
+        println!("All comprehensive metric mutation verifications passed!");
     }
 }


### PR DESCRIPTION
Completes: STR-3433

This PR adds support for OTel metrics in the Python processor SDK. We're following the existing architectural patterns for logs and traces so not too much new to mention on the design approach front. There is a significant amount of room here for lazy ArcMutex construction and desctruction optimization use the `_raw` approach as attributes are pervasive in the metrics model. Metrics also introduces metadata and exemplars which may often not be mutated. Further it's likely in many cases metric data itself may not need mutation as well so I expect we'll be able to greatly improve performance in a follow up change set. While on the note of performance, I haven't spent much time yet looking at the numbers, with the idea being landing the functionality first.

Considering https://github.com/streamfold/rotel/issues/114. This PR should provide support for these use cases and many others. 

Following up on the PR we expect to land the following:
* Updates to `rotel-sdk` for .pyi type data
* Additional unit tests for edge cases and mentioned use cases in issue 114
* Performance optimizations
* Out of the box processor support. 