### PR TITLE
Move exporter config loading out of agent

### DIFF
--- a/src/exporters/blackhole.rs
+++ b/src/exporters/blackhole.rs
@@ -1,38 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::bounded_channel::BoundedReceiver;
-use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
-use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
-use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
-pub struct BlackholeExporter {
-    traces_rx: BoundedReceiver<Vec<ResourceSpans>>,
-    metrics_rx: BoundedReceiver<Vec<ResourceMetrics>>,
-    logs_rx: BoundedReceiver<Vec<ResourceLogs>>,
+pub struct BlackholeExporter<Resource> {
+    rx: BoundedReceiver<Vec<Resource>>,
 }
 
-impl BlackholeExporter {
-    pub fn new(
-        traces_rx: BoundedReceiver<Vec<ResourceSpans>>,
-        metrics_rx: BoundedReceiver<Vec<ResourceMetrics>>,
-        logs_rx: BoundedReceiver<Vec<ResourceLogs>>,
-    ) -> Self {
-        BlackholeExporter {
-            traces_rx,
-            metrics_rx,
-            logs_rx,
-        }
+impl<Resource> BlackholeExporter<Resource> {
+    pub fn new(rx: BoundedReceiver<Vec<Resource>>) -> Self {
+        BlackholeExporter { rx }
     }
 
     pub async fn start(&mut self, cancel_token: CancellationToken) {
         loop {
             select! {
-                m = self.traces_rx.next() => if m.is_none() { break },
-                m = self.metrics_rx.next() => if m.is_none() { break },
-                m = self.logs_rx.next() => if m.is_none() { break },
+                m = self.rx.next() => if m.is_none() { break },
                 _ = cancel_token.cancelled() => break,
             }
         }
@@ -51,10 +36,8 @@ mod tests {
     #[tokio::test]
     async fn send_request() {
         let (tr_tx, tr_rx) = bounded(1);
-        let (met_tx, met_rx) = bounded(1);
-        let (logs_tx, logs_rx) = bounded(1);
 
-        let mut exp = BlackholeExporter::new(tr_rx, met_rx, logs_rx);
+        let mut exp = BlackholeExporter::new(tr_rx);
 
         let cancel_token = CancellationToken::new();
         let shut_token = cancel_token.clone();
@@ -62,18 +45,6 @@ mod tests {
 
         let res = tr_tx
             .send(From::from(FakeOTLP::trace_service_request().resource_spans))
-            .await;
-        assert!(&res.is_ok());
-
-        let res = met_tx
-            .send(From::from(
-                FakeOTLP::metrics_service_request().resource_metrics,
-            ))
-            .await;
-        assert!(&res.is_ok());
-
-        let res = logs_tx
-            .send(From::from(FakeOTLP::logs_service_request().resource_logs))
             .await;
         assert!(&res.is_ok());
 

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -55,7 +55,7 @@ pub enum Compression {
     Lz4,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ClickhouseExporterConfigBuilder {
     retry_config: RetryConfig,
     compression: Compression,
@@ -72,7 +72,7 @@ pub struct ClickhouseExporterConfigBuilder {
 type SvcType =
     TowerRetry<RetryPolicy<()>, Timeout<HttpClient<ClickhousePayload, (), ClickhouseRespDecoder>>>;
 
-type ExporterType<'a, Resource> = Exporter<
+pub type ExporterType<'a, Resource> = Exporter<
     RequestIterator<
         RequestBuilderMapper<
             RecvStream<'a, Vec<Resource>>,

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -34,7 +34,7 @@ pub(crate) mod errors;
 mod client;
 mod grpc_codec;
 mod http_codec;
-mod signer;
+pub mod signer;
 
 use crate::exporters::otlp::config::OTLPExporterConfig;
 use clap::ValueEnum;

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -415,6 +415,9 @@ impl Agent {
             }
         }
 
+        //
+        // LOGS
+        //
         if activation.logs == TelemetryState::Active {
             match exp_config.logs {
                 Some(ExporterConfig::Otlp(exp_config)) => {

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -2,18 +2,16 @@ use crate::aws_api::config::AwsConfig;
 use crate::bounded_channel::{BoundedReceiver, bounded};
 use crate::crypto::init_crypto_provider;
 use crate::exporters::blackhole::BlackholeExporter;
-use crate::exporters::clickhouse::ClickhouseExporterConfigBuilder;
-use crate::exporters::datadog::{DatadogTraceExporterBuilder, Region};
+use crate::exporters::datadog::Region;
 use crate::exporters::otlp;
-use crate::exporters::otlp::Endpoint;
-use crate::exporters::xray::XRayTraceExporterBuilder;
+use crate::exporters::otlp::signer::AwsSigv4RequestSigner;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
-use crate::init::args::{AgentRun, DebugLogParam, Exporter, parse_bool_value};
+use crate::init::args::{AgentRun, DebugLogParam, Exporter};
 use crate::init::batch::{
     build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config,
 };
+use crate::init::config::{ExporterConfig, get_exporters_config};
 use crate::init::datadog_exporter::DatadogRegion;
-use crate::init::otlp_exporter::{build_logs_config, build_metrics_config, build_traces_config};
 #[cfg(feature = "pprof")]
 use crate::init::pprof;
 use crate::init::wait;
@@ -21,10 +19,10 @@ use crate::listener::Listener;
 use crate::receivers::otlp_grpc::OTLPGrpcServer;
 use crate::receivers::otlp_http::OTLPHttpServer;
 use crate::receivers::otlp_output::OTLPOutput;
+use crate::topology::batch::BatchSizer;
 use crate::topology::debug::DebugLogger;
 use crate::topology::flush_control::FlushSubscriber;
 use crate::{telemetry, topology};
-use gethostname::gethostname;
 use opentelemetry::global;
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
 use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
@@ -248,280 +246,223 @@ impl Agent {
 
         global::set_meter_provider(meter_provider);
 
-        let token = exporters_cancel.clone();
-        match config.exporter {
-            Exporter::Blackhole => {
-                let mut exp = BlackholeExporter::new(
-                    trace_pipeline_out_rx,
-                    metrics_pipeline_out_rx,
-                    logs_pipeline_out_rx,
-                );
+        let exp_config = get_exporters_config(&config, &self.environment)?;
 
-                exporters_task_set.spawn(async move {
-                    exp.start(token).await;
-                    Ok(())
-                });
-            }
-            Exporter::Otlp => {
-                let endpoint = config.otlp_exporter.base.endpoint.as_ref();
-                if activation.traces == TelemetryState::Active {
-                    let endpoint = config
-                        .otlp_exporter
-                        .base
-                        .traces_endpoint
-                        .as_ref()
-                        .map(|e| Endpoint::Full(e.clone()))
-                        .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
-                    let traces_config = build_traces_config(config.otlp_exporter.clone());
-                    let mut traces = otlp::exporter::build_traces_exporter(
-                        traces_config.into_exporter_config("otlp_traces", endpoint),
+        //
+        // TRACES
+        //
+        if activation.traces == TelemetryState::Active {
+            match exp_config.traces {
+                Some(ExporterConfig::Otlp(exp_config)) => {
+                    let traces = otlp::exporter::build_traces_exporter(
+                        exp_config,
                         trace_pipeline_out_rx,
                         self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                     )?;
+
+                    start_otlp_exporter(
+                        &mut exporters_task_set,
+                        "otlp_traces",
+                        traces,
+                        exporters_cancel.clone(),
+                    );
+                }
+                Some(ExporterConfig::Clickhouse(cfg_builder)) => {
+                    let builder = cfg_builder.build()?;
+
+                    let exp = builder.build_traces_exporter(
+                        trace_pipeline_out_rx,
+                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                    )?;
+
                     let token = exporters_cancel.clone();
                     exporters_task_set.spawn(async move {
-                        let res = traces.start(token).await;
+                        let res = exp.start(token).await;
                         if let Err(e) = res {
                             error!(
-                                exporter_type = "otlp_traces",
                                 error = e,
-                                "OTLPExporter exporter returned from run loop with error."
+                                exporter_type = "clickhouse_traces",
+                                "Clickhouse exporter returned from run loop with error."
                             );
                         }
 
                         Ok(())
                     });
                 }
-                if activation.metrics == TelemetryState::Active {
-                    let endpoint = config
-                        .otlp_exporter
-                        .base
-                        .metrics_endpoint
-                        .as_ref()
-                        .map(|e| Endpoint::Full(e.clone()))
-                        .unwrap_or_else(|| Endpoint::Base(endpoint.clone().unwrap().clone()));
+                Some(ExporterConfig::Datadog(cfg_builder)) => {
+                    let builder = cfg_builder.build();
 
-                    let metrics_config = build_metrics_config(config.otlp_exporter.clone());
-                    let mut metrics = otlp::exporter::build_metrics_exporter(
-                        metrics_config
-                            .clone()
-                            .into_exporter_config("otlp_metrics", endpoint.clone()),
+                    let exp = builder.build(
+                        trace_pipeline_out_rx,
+                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                    )?;
+
+                    let token = exporters_cancel.clone();
+                    exporters_task_set.spawn(async move {
+                        let res = exp.start(token).await;
+                        if let Err(e) = res {
+                            error!(
+                                error = e,
+                                "Datadog exporter returned from run loop with error."
+                            );
+                        }
+
+                        Ok(())
+                    });
+                }
+                Some(ExporterConfig::Xray(cfg_builder)) => {
+                    let config = AwsConfig::from_env();
+                    let builder = cfg_builder.build();
+                    let exp = builder.build(
+                        trace_pipeline_out_rx,
+                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                        "production".to_string(),
+                        config,
+                    )?;
+
+                    let token = exporters_cancel.clone();
+                    exporters_task_set.spawn(async move {
+                        let res = exp.start(token).await;
+                        if let Err(e) = res {
+                            error!(
+                                error = e,
+                                "AWS X-Ray exporter returned from run loop with error."
+                            );
+                        }
+                        Ok(())
+                    });
+                }
+                Some(ExporterConfig::Blackhole) => {
+                    let mut exp = BlackholeExporter::new(trace_pipeline_out_rx);
+
+                    let token = exporters_cancel.clone();
+                    exporters_task_set.spawn(async move {
+                        exp.start(token).await;
+                        Ok(())
+                    });
+                }
+                None => {}
+            }
+        }
+
+        //
+        // METRICS
+        //
+        if activation.metrics == TelemetryState::Active {
+            match exp_config.metrics {
+                Some(ExporterConfig::Otlp(exp_config)) => {
+                    let metrics = otlp::exporter::build_metrics_exporter(
+                        exp_config.clone(),
                         metrics_pipeline_out_rx,
                         self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                     )?;
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = metrics.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                exporter_type = "otlp_metrics",
-                                error = e,
-                                "OTLPExporter returned from run loop with error."
-                            );
-                        }
 
-                        Ok(())
-                    });
+                    start_otlp_exporter(
+                        &mut exporters_task_set,
+                        "otlp_metrics",
+                        metrics,
+                        exporters_cancel.clone(),
+                    );
 
+                    // TODO: Allow internal metrics pipeline to be configured separately?
                     if config.enable_internal_telemetry {
-                        let mut internal_metrics = otlp::exporter::build_internal_metrics_exporter(
-                            metrics_config.into_exporter_config("otlp_metrics", endpoint),
+                        let internal_metrics = otlp::exporter::build_internal_metrics_exporter(
+                            exp_config,
                             internal_metrics_pipeline_out_rx,
                             self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                         )?;
-                        let token = exporters_cancel.clone();
-                        exporters_task_set.spawn(async move {
-                            let res = internal_metrics.start(token).await;
-                            if let Err(e) = res {
-                                error!(
-                                    exporter_type = "internal_otlp_metrics",
-                                    error = e,
-                                    "OTLPExporter returned from run loop with error."
-                                );
-                            }
 
-                            Ok(())
-                        });
+                        start_otlp_exporter(
+                            &mut exporters_task_set,
+                            "otlp_internal_metrics",
+                            internal_metrics,
+                            exporters_cancel.clone(),
+                        );
                     }
                 }
-                if activation.logs == TelemetryState::Active {
-                    let endpoint = config
-                        .otlp_exporter
-                        .base
-                        .logs_endpoint
-                        .as_ref()
-                        .map(|e| Endpoint::Full(e.clone()))
-                        .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+                Some(ExporterConfig::Clickhouse(cfg_builder)) => {
+                    let builder = cfg_builder.build()?;
 
-                    let logs_config = build_logs_config(config.otlp_exporter.clone());
-                    let mut logs = otlp::exporter::build_logs_exporter(
-                        logs_config.into_exporter_config("otlp_logs", endpoint),
-                        logs_pipeline_out_rx.clone(),
+                    let exp = builder.build_metrics_exporter(
+                        metrics_pipeline_out_rx,
                         self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                     )?;
+
                     let token = exporters_cancel.clone();
                     exporters_task_set.spawn(async move {
-                        let res = logs.start(token).await;
+                        let res = exp.start(token).await;
                         if let Err(e) = res {
                             error!(
-                                exporter_type = "otlp_logs",
                                 error = e,
-                                "OTLPExporter returned from run loop with error."
+                                exporter_type = "clickhouse_metrics",
+                                "Clickhouse exporter returned from run loop with error."
                             );
                         }
 
                         Ok(())
                     });
                 }
+                Some(ExporterConfig::Blackhole) => {
+                    let mut exp = BlackholeExporter::new(metrics_pipeline_out_rx);
+
+                    let token = exporters_cancel.clone();
+                    exporters_task_set.spawn(async move {
+                        exp.start(token).await;
+                        Ok(())
+                    });
+                }
+                _ => {}
             }
+        }
 
-            Exporter::Datadog => {
-                if config.datadog_exporter.api_key.is_none() {
-                    // todo: is there a way to make this config required with the exporter mode?
-                    return Err("must specify Datadog exporter API key".into());
+        if activation.logs == TelemetryState::Active {
+            match exp_config.logs {
+                Some(ExporterConfig::Otlp(exp_config)) => {
+                    let logs = otlp::exporter::build_logs_exporter(
+                        exp_config,
+                        logs_pipeline_out_rx,
+                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                    )?;
+
+                    start_otlp_exporter(
+                        &mut exporters_task_set,
+                        "otlp_logs",
+                        logs,
+                        exporters_cancel.clone(),
+                    );
                 }
-                let api_key = config.datadog_exporter.api_key.unwrap();
+                Some(ExporterConfig::Clickhouse(cfg_builder)) => {
+                    let builder = cfg_builder.build()?;
 
-                let hostname = get_hostname();
+                    let exp = builder.build_logs_exporter(
+                        logs_pipeline_out_rx,
+                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                    )?;
 
-                let mut builder = DatadogTraceExporterBuilder::new(
-                    config.datadog_exporter.region.into(),
-                    config.datadog_exporter.custom_endpoint.clone(),
-                    api_key,
-                )
-                .with_environment(self.environment.clone());
+                    let token = exporters_cancel.clone();
+                    exporters_task_set.spawn(async move {
+                        let res = exp.start(token).await;
+                        if let Err(e) = res {
+                            error!(
+                                error = e,
+                                exporter_type = "clickhouse_logs",
+                                "Clickhouse exporter returned from run loop with error."
+                            );
+                        }
 
-                if let Some(hostname) = hostname {
-                    builder = builder.with_hostname(hostname);
+                        Ok(())
+                    });
                 }
+                Some(ExporterConfig::Blackhole) => {
+                    let mut exp = BlackholeExporter::new(logs_pipeline_out_rx);
 
-                let exp = builder.build(
-                    trace_pipeline_out_rx,
-                    self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                )?;
-
-                exporters_task_set.spawn(async move {
-                    let res = exp.start(token).await;
-                    if let Err(e) = res {
-                        error!(
-                            error = e,
-                            "Datadog exporter returned from run loop with error."
-                        );
-                    }
-
-                    Ok(())
-                });
-            }
-
-            Exporter::AwsXray => {
-                let builder = XRayTraceExporterBuilder::new(
-                    config.aws_xray_exporter.region,
-                    config.aws_xray_exporter.custom_endpoint,
-                );
-                let config = AwsConfig::from_env();
-                let exp = builder.build(
-                    trace_pipeline_out_rx,
-                    self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    "production".to_string(),
-                    config,
-                )?;
-
-                let token = exporters_cancel.clone();
-                exporters_task_set.spawn(async move {
-                    let res = exp.start(token).await;
-                    if let Err(e) = res {
-                        error!(
-                            error = e,
-                            "AWS X-Ray exporter returned from run loop with error."
-                        );
-                    }
-                    Ok(())
-                });
-            }
-
-            Exporter::Clickhouse => {
-                if config.clickhouse_exporter.endpoint.is_none() {
-                    return Err("must specify a Clickhouse exporter endpoint".into());
+                    let token = exporters_cancel.clone();
+                    exporters_task_set.spawn(async move {
+                        exp.start(token).await;
+                        Ok(())
+                    });
                 }
-
-                let async_insert = parse_bool_value(config.clickhouse_exporter.async_insert)?;
-
-                let mut cfg_builder = ClickhouseExporterConfigBuilder::new(
-                    config.clickhouse_exporter.endpoint.unwrap(),
-                    config.clickhouse_exporter.database,
-                    config.clickhouse_exporter.table_prefix,
-                )
-                .with_compression(config.clickhouse_exporter.compression)
-                .with_async_insert(async_insert)
-                .with_json(config.clickhouse_exporter.enable_json)
-                .with_json_underscore(config.clickhouse_exporter.json_underscore);
-
-                if let Some(user) = config.clickhouse_exporter.user {
-                    cfg_builder = cfg_builder.with_user(user);
-                }
-
-                if let Some(password) = config.clickhouse_exporter.password {
-                    cfg_builder = cfg_builder.with_password(password);
-                }
-
-                let builder = cfg_builder.build()?;
-
-                // Trace spans
-                let exp = builder.build_traces_exporter(
-                    trace_pipeline_out_rx,
-                    self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                )?;
-
-                let token = exporters_cancel.clone();
-                exporters_task_set.spawn(async move {
-                    let res = exp.start(token).await;
-                    if let Err(e) = res {
-                        error!(
-                            error = e,
-                            "Clickhouse traces exporter returned from run loop with error."
-                        );
-                    }
-
-                    Ok(())
-                });
-
-                // Log records
-                let exp = builder.build_logs_exporter(
-                    logs_pipeline_out_rx,
-                    self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                )?;
-
-                let token = exporters_cancel.clone();
-                exporters_task_set.spawn(async move {
-                    let res = exp.start(token).await;
-                    if let Err(e) = res {
-                        error!(
-                            error = e,
-                            "Clickhouse logs exporter returned from run loop with error."
-                        );
-                    }
-
-                    Ok(())
-                });
-
-                // Metrics
-                let exp = builder.build_metrics_exporter(
-                    metrics_pipeline_out_rx,
-                    self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                )?;
-
-                let token = exporters_cancel.clone();
-                exporters_task_set.spawn(async move {
-                    let res = exp.start(token).await;
-                    if let Err(e) = res {
-                        error!(
-                            error = e,
-                            "Clickhouse metrics exporter returned from run loop with error."
-                        );
-                    }
-
-                    Ok(())
-                });
+                _ => {}
             }
         }
 
@@ -793,6 +734,33 @@ impl Agent {
     }
 }
 
+fn start_otlp_exporter<Resource, Request, Response>(
+    exporters_task_set: &mut JoinSet<Result<(), Box<dyn Error + Send + Sync>>>,
+    telemetry_type: &'static str,
+    exporter: otlp::exporter::Exporter<Resource, Request, AwsSigv4RequestSigner, Response>,
+    cancel_token: CancellationToken,
+) where
+    Request: prost::Message + topology::payload::OTLPFrom<Vec<Resource>> + Clone,
+    Resource: prost::Message + Clone,
+    [Resource]: BatchSizer,
+    Response: prost::Message + Default + Clone,
+{
+    let mut exporter = exporter;
+
+    exporters_task_set.spawn(async move {
+        let res = exporter.start(cancel_token).await;
+        if let Err(e) = res {
+            error!(
+                exporter_type = telemetry_type,
+                error = e,
+                "OTLPExporter exporter returned from run loop with error."
+            );
+        }
+
+        Ok(())
+    });
+}
+
 impl From<DatadogRegion> for Region {
     fn from(value: DatadogRegion) -> Self {
         match value {
@@ -801,16 +769,6 @@ impl From<DatadogRegion> for Region {
             DatadogRegion::US5 => Region::US5,
             DatadogRegion::EU => Region::EU,
             DatadogRegion::AP1 => Region::AP1,
-        }
-    }
-}
-
-fn get_hostname() -> Option<String> {
-    match gethostname().into_string() {
-        Ok(s) => Some(s),
-        Err(e) => {
-            error!(error = ?e, "Unable to lookup hostname");
-            None
         }
     }
 }

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -257,7 +257,7 @@ mod test {
     }
 }
 
-pub(crate) fn parse_bool_value(val: String) -> Result<bool, BoxError> {
+pub(crate) fn parse_bool_value(val: &String) -> Result<bool, BoxError> {
     match val.to_lowercase().as_str() {
         "0" | "false" => Ok(false),
         "1" | "true" => Ok(true),

--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -76,7 +76,7 @@ pub struct ClickhouseExporterArgs {
     pub json_underscore: bool,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, Copy, ValueEnum)]
 pub enum Compression {
     None,
     Lz4,

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -1,0 +1,159 @@
+use crate::exporters::clickhouse::ClickhouseExporterConfigBuilder;
+use crate::exporters::datadog::DatadogExporterConfigBuilder;
+use crate::exporters::otlp::Endpoint;
+use crate::exporters::otlp::config::OTLPExporterConfig;
+use crate::exporters::xray::XRayExporterConfigBuilder;
+use crate::init::args::{AgentRun, Exporter, parse_bool_value};
+use crate::init::otlp_exporter::{build_logs_config, build_metrics_config, build_traces_config};
+use gethostname::gethostname;
+use tower::BoxError;
+use tracing::error;
+
+pub(crate) struct ExporterConfigs {
+    pub(crate) metrics: Option<ExporterConfig>,
+    pub(crate) logs: Option<ExporterConfig>,
+    pub(crate) traces: Option<ExporterConfig>,
+}
+
+pub(crate) enum ExporterConfig {
+    Blackhole,
+    Otlp(OTLPExporterConfig),
+    Datadog(DatadogExporterConfigBuilder),
+    Clickhouse(ClickhouseExporterConfigBuilder),
+    Xray(XRayExporterConfigBuilder),
+}
+
+pub(crate) fn get_exporters_config(
+    config: &AgentRun,
+    environment: &str,
+) -> Result<ExporterConfigs, BoxError> {
+    let mut cfg = ExporterConfigs {
+        metrics: None,
+        logs: None,
+        traces: None,
+    };
+
+    match config.exporter {
+        Exporter::Otlp => {
+            let endpoint = config.otlp_exporter.base.endpoint.as_ref();
+            cfg.traces = Some(ExporterConfig::Otlp({
+                let endpoint = config
+                    .otlp_exporter
+                    .base
+                    .traces_endpoint
+                    .as_ref()
+                    .map(|e| Endpoint::Full(e.clone()))
+                    .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+                let traces_config = build_traces_config(config.otlp_exporter.clone());
+                traces_config.into_exporter_config("otlp_traces", endpoint)
+            }));
+            cfg.metrics = Some(ExporterConfig::Otlp({
+                let endpoint = config
+                    .otlp_exporter
+                    .base
+                    .metrics_endpoint
+                    .as_ref()
+                    .map(|e| Endpoint::Full(e.clone()))
+                    .unwrap_or_else(|| Endpoint::Base(endpoint.clone().unwrap().clone()));
+
+                let metrics_config = build_metrics_config(config.otlp_exporter.clone());
+                metrics_config
+                    .clone()
+                    .into_exporter_config("otlp_metrics", endpoint.clone())
+            }));
+            cfg.logs = Some(ExporterConfig::Otlp({
+                let endpoint = config
+                    .otlp_exporter
+                    .base
+                    .logs_endpoint
+                    .as_ref()
+                    .map(|e| Endpoint::Full(e.clone()))
+                    .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+
+                let logs_config = build_logs_config(config.otlp_exporter.clone());
+                logs_config.into_exporter_config("otlp_logs", endpoint)
+            }));
+        }
+        Exporter::Blackhole => {
+            cfg.traces = Some(ExporterConfig::Blackhole {});
+            cfg.metrics = Some(ExporterConfig::Blackhole {});
+            cfg.logs = Some(ExporterConfig::Blackhole {});
+        }
+        Exporter::Datadog => {
+            if config.datadog_exporter.api_key.is_none() {
+                // todo: is there a way to make this config required with the exporter mode?
+                return Err("must specify Datadog exporter API key".into());
+            }
+            let api_key = config.datadog_exporter.api_key.as_ref().unwrap();
+
+            let hostname = get_hostname();
+
+            let mut builder = DatadogExporterConfigBuilder::new(
+                config.datadog_exporter.region.into(),
+                config.datadog_exporter.custom_endpoint.clone(),
+                api_key.clone(),
+            )
+            .with_environment(environment.to_string());
+
+            if let Some(hostname) = hostname {
+                builder = builder.with_hostname(hostname);
+            }
+
+            cfg.traces = Some(ExporterConfig::Datadog(builder))
+        }
+        Exporter::Clickhouse => {
+            if config.clickhouse_exporter.endpoint.is_none() {
+                return Err("must specify a Clickhouse exporter endpoint".into());
+            }
+
+            let async_insert = parse_bool_value(&config.clickhouse_exporter.async_insert)?;
+
+            let mut cfg_builder = ClickhouseExporterConfigBuilder::new(
+                config
+                    .clickhouse_exporter
+                    .endpoint
+                    .as_ref()
+                    .unwrap()
+                    .clone(),
+                config.clickhouse_exporter.database.clone(),
+                config.clickhouse_exporter.table_prefix.clone(),
+            )
+            .with_compression(config.clickhouse_exporter.compression)
+            .with_async_insert(async_insert)
+            .with_json(config.clickhouse_exporter.enable_json)
+            .with_json_underscore(config.clickhouse_exporter.json_underscore);
+
+            if let Some(user) = &config.clickhouse_exporter.user {
+                cfg_builder = cfg_builder.with_user(user.clone());
+            }
+
+            if let Some(password) = &config.clickhouse_exporter.password {
+                cfg_builder = cfg_builder.with_password(password.clone());
+            }
+
+            cfg.traces = Some(ExporterConfig::Clickhouse(cfg_builder.clone()));
+            cfg.metrics = Some(ExporterConfig::Clickhouse(cfg_builder.clone()));
+            cfg.logs = Some(ExporterConfig::Clickhouse(cfg_builder));
+        }
+        Exporter::AwsXray => {
+            let builder = XRayExporterConfigBuilder::new(
+                config.aws_xray_exporter.region,
+                config.aws_xray_exporter.custom_endpoint.clone(),
+            );
+
+            cfg.traces = Some(ExporterConfig::Xray(builder))
+        }
+    }
+
+    Ok(cfg)
+}
+
+fn get_hostname() -> Option<String> {
+    match gethostname().into_string() {
+        Ok(s) => Some(s),
+        Err(e) => {
+            error!(error = ?e, "Unable to lookup hostname");
+            None
+        }
+    }
+}

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -10,5 +10,6 @@ mod otlp_exporter;
 mod xray_exporter;
 
 mod batch;
+mod config;
 #[cfg(feature = "pprof")]
 pub mod pprof;


### PR DESCRIPTION
This is the second round of refactoring to make it a bit easier to incorporate multiple exporter support. With this PR we decouple the parsing, loading and verification of exporter configuration from the main agent startup. The agent gets back a typed structure with the exporter configuration per each pipeline type: metrics, logs and traces. It then matches on each pipeline and finishes the startup of the configured exporter. This will allow us to return different exporter configs per-pipeline in the future, decoupling the agent code from handling it.

Ideally the core agent code wouldn't need to know about each exporter type, which telemetry types they support, and how to start its exporter. In a perfect world the configs for each exporter type would support a `into_exporter()` method that transformed the config into a running exporter. However, we aren't at that level just yet and it requires some further work. We may take that up after multiple exporters are in place.

Completes: STR-3470