### PR TITLE
Support exporting to multiple destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1050,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +1491,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1800,12 @@ dependencies = [
  "rgb",
  "str_stack",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inventory"
@@ -2342,6 +2380,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2598,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2946,6 +3020,7 @@ dependencies = [
  "clap",
  "criterion",
  "daemonize",
+ "figment",
  "flate2",
  "flume",
  "futures",
@@ -2957,6 +3032,7 @@ dependencies = [
  "http-body-util",
  "httpmock",
  "humantime",
+ "humantime-serde",
  "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
@@ -3912,6 +3988,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,6 +4365,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ indexmap = "2.9.0"
 hmac = "0.12"
 sha2 = "0.10"
 regex = "1.11.1"
+figment = {  version = "0.10.19", default-features = false, features = ["env"] }
+humantime-serde = "1.1.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Any option above that does not contain a default is considered false or unset by
 
 The PID and LOG files are only used when run in `--daemon` mode.
 
+See the section for [Multiple Exporters](#multiple-exporters) for how to configure multiple exporters
+
 ### OTLP exporter configuration
 
 The OTLP exporter is the default, or can be explicitly selected with `--exporter otlp`.
@@ -294,6 +296,58 @@ that you have configured.
 
 **NOTE**: Internal telemetry is not sent to any outside sources and you are in full control of where this data is
 exported to.
+
+### Multiple exporters
+
+Rotel can be configured to support exporting to multiple destinations across multiple exporter types.
+
+The following additional configuration parameters set up support for multiple exporters. Similar to the options above, all
+CLI arguments can be passed as environment variables as well. It is not possible to set `--exporter` and `--exporters`
+at the same time.
+
+| Option              | Default | Options                          |
+|---------------------|---------|----------------------------------|
+| --exporters         |         | name:type pairs, comma-separated |
+| --exporters-traces  |         | exporter name                    |
+| --exporters-metrics |         | exporter name                    |
+| --exporters-logs    |         | exporter name                    |
+
+First start by defining the set of exporters that you would like to use, optionally specifying a custom name for them
+to differentiate their configuration options. For example, to export logs and metrics to two separate Clickhouse nodes
+while exporting traces to Datadog, we'll use the following `--exporters` argument (or `ROTEL_EXPORTERS` envvar):
+```shell
+--exporters logging:clickhouse,stats:clickhouse,datadog
+```
+The argument form of `--exporters` takes `name:type` pairs separated by commas, where the first part is a custom name and
+the second part is the type of exporter. You can exclude the name if there is a single exporter by that name, which means
+the name is the same as the exporter type.
+
+Second, you then must set environment variables of the form `ROTEL_EXPORTER_{NAME}_{PARAMETER}` to configure the multiple
+exporters. These variable names are dynamic and use the custom name to differentiate settings for similar exporter types.
+Therefore, there are no CLI argument alternatives for them at the moment. The `{PARAMETER}` fields match the configuration
+options for the given exporter type.
+
+Using our example above, the user must set, at a minimum, the following environment variables. (For Clickhouse Cloud you
+would need to include a username/password, but we are skipping those for brevity.)
+
+* `ROTEL_EXPORTER_LOGGING_ENDPOINT=https://xxxxxxx.us-east-1.aws.clickhouse.cloud:8443`
+* `ROTEL_EXPORTER_STATS_ENDPOINT=https://xxxxxxx.us-west-1.aws.clickhouse.cloud:8443`
+* `ROTEL_EXPORTER_DATADOG_API_KEY=dd-abcd1234`
+
+Lastly, the user would need to connect these exporters to the telemetry types. Using the requirements above, the user
+would specify the following:
+
+```shell
+--exporters-traces datadog --exporters-metrics stats --exporters-logs logging
+```
+
+Alternatively, the following environment variables would do the same:
+* `ROTEL_EXPORTERS_TRACES=datadog`
+* `ROTEL_EXPORTERS_METRICS=stats`
+* `ROTEL_EXPORTERS_LOGS=logging`
+
+_NOTE: At the moment, only a single exporter can be set for any telemetry type. This constraint will be relaxed in the
+future._
 
 ### Full example
 

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -40,13 +40,14 @@ use crate::exporters::otlp::config::OTLPExporterConfig;
 use clap::ValueEnum;
 use opentelemetry::global;
 use opentelemetry::metrics::Meter;
+use serde::Deserialize;
 use std::time::Duration;
 
 /// Default timeout duration for OTLP requests
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Supported compression encodings for OTLP data
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Debug, Deserialize, ValueEnum)]
 pub enum CompressionEncoding {
     Gzip,
     None,

--- a/src/exporters/otlp/mod.rs
+++ b/src/exporters/otlp/mod.rs
@@ -48,6 +48,7 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Supported compression encodings for OTLP data
 #[derive(Clone, Debug, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
 pub enum CompressionEncoding {
     Gzip,
     None,
@@ -67,7 +68,7 @@ pub enum Authenticator {
 }
 
 /// OTLP endpoint configuration
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Endpoint {
     Base(String),
     Full(String),

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -21,6 +21,7 @@ use flume::r#async::RecvStream;
 use http::Request;
 use http_body_util::Full;
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+use serde::Deserialize;
 use std::time::Duration;
 use tower::retry::Retry as TowerRetry;
 use tower::timeout::Timeout;
@@ -49,7 +50,7 @@ type ExporterType<'a, Resource> = Exporter<
     XRayResultLogger,
 >;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub enum Region {
     UsEast1,
     UsEast2,

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -51,6 +51,7 @@ type ExporterType<'a, Resource> = Exporter<
 >;
 
 #[derive(Copy, Clone, Debug, Deserialize)]
+#[serde(from = "String")]
 pub enum Region {
     UsEast1,
     UsEast2,

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -6,7 +6,7 @@ use crate::exporters::datadog::Region;
 use crate::exporters::otlp;
 use crate::exporters::otlp::signer::AwsSigv4RequestSigner;
 use crate::init::activation::{TelemetryActivation, TelemetryState};
-use crate::init::args::{AgentRun, DebugLogParam, Exporter};
+use crate::init::args::{AgentRun, DebugLogParam};
 use crate::init::batch::{
     build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config,
 };
@@ -109,30 +109,6 @@ impl Agent {
         let pipeline_cancel = CancellationToken::new();
         let exporters_cancel = CancellationToken::new();
 
-        let activation = TelemetryActivation::from_config(&config);
-
-        // If there are no listeners, suggest the blackhole exporter
-        if activation.traces == TelemetryState::NoListeners
-            && activation.metrics == TelemetryState::NoListeners
-            && activation.logs == TelemetryState::NoListeners
-        {
-            return Err(
-                "no exporter endpoints specified, perhaps you meant to use --exporter blackhole instead"
-                    .into(),
-            );
-        }
-
-        // If no active type exists, nothing to do. Exit here before errors later
-        if !(activation.traces == TelemetryState::Active
-            || activation.metrics == TelemetryState::Active
-            || activation.logs == TelemetryState::Active)
-        {
-            return Err(
-                "there are no active telemetry types, exiting because there is nothing to do"
-                    .into(),
-            );
-        }
-
         let (trace_pipeline_in_tx, trace_pipeline_in_rx) =
             bounded::<Vec<ResourceSpans>>(max(4, num_cpus));
         let (trace_pipeline_out_tx, trace_pipeline_out_rx) =
@@ -156,6 +132,32 @@ impl Agent {
         let (internal_metrics_pipeline_out_tx, internal_metrics_pipeline_out_rx) =
             bounded::<Vec<ResourceMetrics>>(self.sending_queue_size);
         let internal_metrics_otlp_output = OTLPOutput::new(internal_metrics_pipeline_in_tx);
+
+        let exp_config = get_exporters_config(&config, &self.environment)?;
+
+        let activation = TelemetryActivation::from_config(&config, &exp_config);
+
+        // If there are no listeners, suggest the blackhole exporter
+        if activation.traces == TelemetryState::NoListeners
+            && activation.metrics == TelemetryState::NoListeners
+            && activation.logs == TelemetryState::NoListeners
+        {
+            return Err(
+                "no exporter endpoints specified, perhaps you meant to use --exporter blackhole instead"
+                    .into(),
+            );
+        }
+
+        // If no active type exists, nothing to do. Exit here before errors later
+        if !(activation.traces == TelemetryState::Active
+            || activation.metrics == TelemetryState::Active
+            || activation.logs == TelemetryState::Active)
+        {
+            return Err(
+                "there are no active telemetry types, exiting because there is nothing to do"
+                    .into(),
+            );
+        }
 
         let mut traces_output = None;
         let mut metrics_output = None;
@@ -215,11 +217,13 @@ impl Agent {
 
         // AWS-XRay only supports a batch size of 50 segments
         let mut trace_batch_config = build_traces_batch_config(config.batch.clone());
-        if config.exporter == Exporter::AwsXray && trace_batch_config.max_size > 50 {
-            info!(
-                "AWS X-Ray only supports a batch size of 50 segments, setting batch max size to 50"
-            );
-            trace_batch_config.max_size = 50;
+        if let Some(ExporterConfig::Xray(_)) = exp_config.traces {
+            if trace_batch_config.max_size > 50 {
+                info!(
+                    "AWS X-Ray only supports a batch size of 50 segments, setting batch max size to 50"
+                );
+                trace_batch_config.max_size = 50;
+            }
         }
 
         // Internal metrics
@@ -246,7 +250,9 @@ impl Agent {
 
         global::set_meter_provider(meter_provider);
 
-        let exp_config = get_exporters_config(&config, &self.environment)?;
+        //
+        // Build the exporters now
+        //
 
         //
         // TRACES

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -117,13 +117,25 @@ pub struct AgentRun {
     #[command(flatten)]
     pub batch: BatchArgs,
 
-    /// Exporter
+    /// Single exporter (type)
     #[arg(value_enum, long, env = "ROTEL_EXPORTER")]
     pub exporter: Option<Exporter>,
 
-    /// Exporters
+    /// Multiple exporters (name:type,...)
     #[arg(value_enum, long, env = "ROTEL_EXPORTERS")]
     pub exporters: Option<String>,
+
+    /// Traces exporters
+    #[arg(long, env = "ROTEL_EXPORTERS_TRACES")]
+    pub exporters_traces: Option<String>,
+
+    /// Metrics exporters
+    #[arg(long, env = "ROTEL_EXPORTERS_METRICS")]
+    pub exporters_metrics: Option<String>,
+
+    /// Logs exporters
+    #[arg(long, env = "ROTEL_EXPORTERS_LOGS")]
+    pub exporters_logs: Option<String>,
 
     #[command(flatten)]
     pub otlp_exporter: OTLPExporterArgs,

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -154,6 +154,47 @@ pub struct AgentRun {
     pub profile_group: ProfileGroup,
 }
 
+impl Default for AgentRun {
+    fn default() -> Self {
+        AgentRun {
+            daemon: false,
+            pid_file: "/tmp/rotel-agent.pid".to_string(),
+            log_file: "/tmp/rotel-agent.log".to_string(),
+            debug_log: vec![DebugLogParam::None],
+            debug_log_verbosity: DebugLogVerbosity::Basic,
+            otlp_grpc_endpoint: "127.0.0.1:4317".parse().unwrap(),
+            otlp_http_endpoint: "127.0.0.1:4318".parse().unwrap(),
+            otlp_grpc_max_recv_msg_size_mib: 4,
+            otlp_receiver_traces_disabled: false,
+            otlp_receiver_metrics_disabled: false,
+            otlp_receiver_logs_disabled: false,
+            otlp_receiver_traces_http_path: "/v1/traces".to_string(),
+            otlp_receiver_metrics_http_path: "/v1/metrics".to_string(),
+            otlp_receiver_logs_http_path: "/v1/logs".to_string(),
+            otlp_with_trace_processor: Vec::new(),
+            otlp_with_logs_processor: Vec::new(),
+            otlp_with_metrics_processor: Vec::new(),
+            otel_resource_attributes: Vec::new(),
+            enable_internal_telemetry: false,
+            batch: BatchArgs::default(),
+            exporter: None,
+            exporters: None,
+            exporters_traces: None,
+            exporters_metrics: None,
+            exporters_logs: None,
+            otlp_exporter: OTLPExporterArgs::default(),
+            datadog_exporter: DatadogExporterArgs::default(),
+            clickhouse_exporter: ClickhouseExporterArgs::default(),
+            aws_xray_exporter: XRayExporterArgs::default(),
+            #[cfg(feature = "pprof")]
+            profile_group: ProfileGroup {
+                pprof_flame_graph: false,
+                pprof_call_graph: false,
+            },
+        }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Debug, ValueEnum)]
 pub enum DebugLogParam {
     None,
@@ -163,12 +204,14 @@ pub enum DebugLogParam {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
 pub enum OTLPExporterProtocol {
     Grpc,
     Http,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
 pub enum OTLPExporterAuthenticator {
     Sigv4auth,
 }

--- a/src/init/batch.rs
+++ b/src/init/batch.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::topology::batch::BatchConfig;
 use clap::Args;
 
@@ -9,8 +11,8 @@ pub struct BatchArgs {
     pub batch_max_size: usize,
 
     /// OTLP batch timeout - Used as default for all OTLP data types unless more specific flag specified.
-    #[arg(long, env = "ROTEL_BATCH_TIMEOUT", default_value = "200ms")]
-    pub batch_timeout: humantime::Duration,
+    #[arg(long, env = "ROTEL_BATCH_TIMEOUT", default_value = "200ms", value_parser = humantime::parse_duration)]
+    pub batch_timeout: std::time::Duration,
 
     /// OTLP traces max batch size in number of spans - Overrides batch_max_size for OTLP traces if specified.
     #[arg(long, env = "ROTEL_TRACES_BATCH_MAX_SIZE")]
@@ -25,20 +27,36 @@ pub struct BatchArgs {
     pub logs_batch_max_size: Option<usize>,
 
     /// OTLP traces batch timeout - Overrides batch_timeout for OTLP traces if specified.
-    #[arg(long, env = "ROTEL_TRACES_BATCH_TIMEOUT")]
-    pub traces_batch_timeout: Option<humantime::Duration>,
+    #[arg(long, env = "ROTEL_TRACES_BATCH_TIMEOUT", value_parser = humantime::parse_duration)]
+    pub traces_batch_timeout: Option<std::time::Duration>,
 
     /// OTLP metrics batch timeout - Overrides batch_timeout for OTLP metrics if specified.
-    #[arg(long, env = "ROTEL_METRICS_BATCH_TIMEOUT")]
-    pub metrics_batch_timeout: Option<humantime::Duration>,
+    #[arg(long, env = "ROTEL_METRICS_BATCH_TIMEOUT", value_parser = humantime::parse_duration)]
+    pub metrics_batch_timeout: Option<std::time::Duration>,
 
     /// OTLP logs batch timeout - Overrides batch_timeout for OTLP logs if specified.
-    #[arg(long, env = "ROTEL_LOGS_BATCH_TIMEOUT")]
-    pub logs_batch_timeout: Option<humantime::Duration>,
+    #[arg(long, env = "ROTEL_LOGS_BATCH_TIMEOUT", value_parser = humantime::parse_duration)]
+    pub logs_batch_timeout: Option<std::time::Duration>,
 
     /// Disable batching, incoming messages are immediately exported (not recommended)
     #[arg(long, env = "ROTEL_DISABLE_BATCHING", default_value = "false")]
     pub disable_batching: bool,
+}
+
+impl Default for BatchArgs {
+    fn default() -> Self {
+        Self {
+            batch_max_size: 8192,
+            batch_timeout: Duration::from_millis(250),
+            traces_batch_max_size: None,
+            metrics_batch_max_size: None,
+            logs_batch_max_size: None,
+            traces_batch_timeout: None,
+            metrics_batch_timeout: None,
+            logs_batch_timeout: None,
+            disable_batching: false,
+        }
+    }
 }
 
 // todo: add these as impl functions of the exporter args?

--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -95,6 +95,7 @@ impl Default for ClickhouseExporterArgs {
 }
 
 #[derive(Clone, Debug, Copy, ValueEnum, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Compression {
     None,
     Lz4,

--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -1,7 +1,9 @@
 use crate::exporters::clickhouse;
 use clap::{Args, ValueEnum};
+use serde::Deserialize;
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Deserialize)]
+#[serde(default)]
 pub struct ClickhouseExporterArgs {
     /// Clickhouse Exporter endpoint
     #[arg(
@@ -76,7 +78,23 @@ pub struct ClickhouseExporterArgs {
     pub json_underscore: bool,
 }
 
-#[derive(Clone, Debug, Copy, ValueEnum)]
+impl Default for ClickhouseExporterArgs {
+    fn default() -> Self {
+        Self {
+            endpoint: None,
+            database: "otel".to_string(),
+            table_prefix: "otel".to_string(),
+            compression: Compression::Lz4,
+            user: None,
+            password: None,
+            async_insert: "true".to_string(),
+            enable_json: false,
+            json_underscore: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Copy, ValueEnum, Deserialize)]
 pub enum Compression {
     None,
     Lz4,

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -364,7 +364,7 @@ fn get_multi_exporter_config(
 
 fn args_from_env_prefix(exporter_type: &str, prefix: &str) -> Result<ExporterArgs, BoxError> {
     let figment = Figment::new().merge(Env::prefixed(
-        format!("ROTEL_EXPORTER_{}", prefix.to_uppercase()).as_str(),
+        format!("ROTEL_EXPORTER_{}_", prefix.to_uppercase()).as_str(),
     ));
     match exporter_type {
         "blackhole" => Ok(ExporterArgs::Blackhole),

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -3,16 +3,100 @@ use crate::exporters::datadog::DatadogExporterConfigBuilder;
 use crate::exporters::otlp::Endpoint;
 use crate::exporters::otlp::config::OTLPExporterConfig;
 use crate::exporters::xray::XRayExporterConfigBuilder;
-use crate::init::args::{AgentRun, Exporter, parse_bool_value};
-use crate::init::otlp_exporter::{build_logs_config, build_metrics_config, build_traces_config};
+use crate::init::args::{AgentRun, Exporter};
+use crate::init::clickhouse_exporter::ClickhouseExporterArgs;
+use crate::init::datadog_exporter::DatadogExporterArgs;
+use crate::init::otlp_exporter::{
+    OTLPExporterBaseArgs, build_logs_config, build_metrics_config, build_traces_config,
+};
+use crate::init::parse::parse_bool_value;
+use crate::init::xray_exporter::XRayExporterArgs;
+use figment::{Figment, providers::Env};
 use gethostname::gethostname;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 use tower::BoxError;
 use tracing::error;
+
+struct ExporterMap {
+    exporters: HashMap<String, ExporterArgs>,
+}
+
+impl FromStr for ExporterMap {
+    type Err = BoxError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let exporters: HashMap<String, ExporterArgs> = s
+            .split(",")
+            .map(|exporter| {
+                let sp: Vec<&str> = exporter.split(":").collect();
+                if sp.len() > 2 {
+                    return Err(format!("invalid exporter config: {}", exporter).into());
+                }
+
+                let (name, exporter_type) = if sp.len() == 1 {
+                    (sp[0], sp[0])
+                } else {
+                    (sp[0], sp[1])
+                };
+
+                let args = match args_from_env_prefix(exporter_type, name) {
+                    Ok(args) => args,
+                    Err(e) => return Err(e),
+                };
+
+                Ok((name.to_string(), args))
+            })
+            .collect::<Result<HashMap<String, ExporterArgs>, BoxError>>()?;
+
+        Ok(ExporterMap { exporters })
+    }
+}
+
+impl ExporterMap {
+    fn get(&self, name: &String) -> Option<&ExporterArgs> {
+        self.exporters.get(name)
+    }
+}
 
 pub(crate) struct ExporterConfigs {
     pub(crate) metrics: Option<ExporterConfig>,
     pub(crate) logs: Option<ExporterConfig>,
     pub(crate) traces: Option<ExporterConfig>,
+}
+
+pub(crate) enum ExporterArgs {
+    Blackhole,
+    Otlp(OTLPExporterBaseArgs),
+    Datadog(DatadogExporterArgs),
+    Clickhouse(ClickhouseExporterArgs),
+    Xray(XRayExporterArgs),
+}
+
+#[derive(PartialEq)]
+enum PipelineType {
+    Metrics,
+    Logs,
+    Traces,
+}
+
+impl Display for PipelineType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PipelineType::Metrics => write!(f, "metrics"),
+            PipelineType::Logs => write!(f, "logs"),
+            PipelineType::Traces => write!(f, "traces"),
+        }
+    }
+}
+
+trait TryIntoConfig {
+    fn try_into_config(
+        &self,
+        pipeline_type: PipelineType,
+        environment: &str,
+    ) -> Result<ExporterConfig, BoxError>;
 }
 
 pub(crate) enum ExporterConfig {
@@ -23,8 +107,273 @@ pub(crate) enum ExporterConfig {
     Xray(XRayExporterConfigBuilder),
 }
 
+impl TryIntoConfig for ExporterArgs {
+    fn try_into_config(
+        &self,
+        pipeline_type: PipelineType,
+        environment: &str,
+    ) -> Result<ExporterConfig, BoxError> {
+        match self {
+            ExporterArgs::Blackhole => Ok(ExporterConfig::Blackhole),
+            ExporterArgs::Otlp(otlp) => {
+                let otlp = otlp.clone();
+
+                let endpoint = otlp.endpoint.as_ref();
+                match pipeline_type {
+                    PipelineType::Metrics => {
+                        let endpoint = otlp
+                            .metrics_endpoint
+                            .as_ref()
+                            .map(|e| Endpoint::Full(e.clone()))
+                            .unwrap_or_else(|| Endpoint::Base(endpoint.clone().unwrap().clone()));
+
+                        Ok(ExporterConfig::Otlp(
+                            otlp.into_exporter_config("otlp_metrics", endpoint),
+                        ))
+                    }
+                    PipelineType::Logs => {
+                        let endpoint = otlp
+                            .logs_endpoint
+                            .as_ref()
+                            .map(|e| Endpoint::Full(e.clone()))
+                            .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+
+                        Ok(ExporterConfig::Otlp(
+                            otlp.into_exporter_config("otlp_logs", endpoint),
+                        ))
+                    }
+                    PipelineType::Traces => {
+                        let endpoint = otlp
+                            .traces_endpoint
+                            .as_ref()
+                            .map(|e| Endpoint::Full(e.clone()))
+                            .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+
+                        Ok(ExporterConfig::Otlp(
+                            otlp.into_exporter_config("otlp_traces", endpoint),
+                        ))
+                    }
+                }
+            }
+            ExporterArgs::Datadog(dd) => {
+                if pipeline_type != PipelineType::Traces {
+                    return Err(format!(
+                        "Datadog exporter not supported for pipeline type {}",
+                        pipeline_type
+                    )
+                    .into());
+                }
+
+                if dd.api_key.is_none() {
+                    // todo: is there a way to make this dd.g required with the exporter mode?
+                    return Err("must specify Datadog exporter API key".into());
+                }
+                let api_key = dd.api_key.as_ref().unwrap();
+
+                let hostname = get_hostname();
+
+                let mut builder = DatadogExporterConfigBuilder::new(
+                    dd.region.into(),
+                    dd.custom_endpoint.clone(),
+                    api_key.clone(),
+                )
+                .with_environment(environment.to_string());
+
+                if let Some(hostname) = hostname {
+                    builder = builder.with_hostname(hostname);
+                }
+
+                Ok(ExporterConfig::Datadog(builder))
+            }
+            ExporterArgs::Clickhouse(ch) => {
+                if ch.endpoint.is_none() {
+                    return Err("must specify a Clickhouse exporter endpoint".into());
+                }
+
+                let async_insert = parse_bool_value(&ch.async_insert)?;
+
+                let mut cfg_builder = ClickhouseExporterConfigBuilder::new(
+                    ch.endpoint.as_ref().unwrap().clone(),
+                    ch.database.clone(),
+                    ch.table_prefix.clone(),
+                )
+                .with_compression(ch.compression)
+                .with_async_insert(async_insert)
+                .with_json(ch.enable_json)
+                .with_json_underscore(ch.json_underscore);
+
+                if let Some(user) = &ch.user {
+                    cfg_builder = cfg_builder.with_user(user.clone());
+                }
+
+                if let Some(password) = &ch.password {
+                    cfg_builder = cfg_builder.with_password(password.clone());
+                }
+
+                Ok(ExporterConfig::Clickhouse(cfg_builder))
+            }
+            ExporterArgs::Xray(xray) => {
+                if pipeline_type != PipelineType::Traces {
+                    return Err(format!(
+                        "XRay exporter not supported for pipeline type {}",
+                        pipeline_type
+                    )
+                    .into());
+                }
+
+                let builder =
+                    XRayExporterConfigBuilder::new(xray.region, xray.custom_endpoint.clone());
+
+                Ok(ExporterConfig::Xray(builder))
+            }
+        }
+    }
+}
+
 pub(crate) fn get_exporters_config(
     config: &AgentRun,
+    environment: &str,
+) -> Result<ExporterConfigs, BoxError> {
+    // Default to OTLP exporter
+    if config.exporters.is_none() && config.exporter.is_none() {
+        return get_single_exporter_config(config, Exporter::Otlp, environment);
+    }
+
+    if config.exporters.is_some() && config.exporter.is_some() {
+        return Err("Can not use --exporter and --exporters".into());
+    }
+
+    if let Some(exporter) = config.exporter {
+        return get_single_exporter_config(config, exporter, environment);
+    }
+
+    get_multi_exporter_config(config.exporters.as_ref().unwrap().clone(), environment)
+}
+
+fn get_multi_exporter_config(
+    exporters: String,
+    environment: &str,
+) -> Result<ExporterConfigs, BoxError> {
+    let exporter_map = exporters.parse::<ExporterMap>()?;
+
+    let mut cfg = ExporterConfigs {
+        metrics: None,
+        logs: None,
+        traces: None,
+    };
+
+    if let Ok(traces_exps) = std::env::var("ROTEL_EXPORTERS_TRACES") {
+        let sp: Vec<&str> = traces_exps.split(",").collect();
+        if sp.len() != 1 {
+            return Err(format!(
+                "Only one exporter supported for ROTEL_EXPORTERS_TRACES: {}",
+                traces_exps
+            )
+            .into());
+        }
+
+        let args = match exporter_map.get(&sp[0].to_string()) {
+            Some(args) => args,
+            None => {
+                return Err(format!("Can not find exporter {} for traces exporters", sp[0]).into());
+            }
+        };
+
+        cfg.traces = Some(args.try_into_config(PipelineType::Traces, environment)?);
+    }
+
+    if let Ok(metrics_exps) = std::env::var("ROTEL_EXPORTERS_METRICS") {
+        let sp: Vec<&str> = metrics_exps.split(",").collect();
+        if sp.len() != 1 {
+            return Err(format!(
+                "Only one exporter supported for ROTEL_EXPORTERS_METRICS: {}",
+                metrics_exps
+            )
+            .into());
+        }
+
+        let args = match exporter_map.get(&sp[0].to_string()) {
+            Some(args) => args,
+            None => {
+                return Err(
+                    format!("Can not find exporter {} for metrics exporters", sp[0]).into(),
+                );
+            }
+        };
+
+        cfg.metrics = Some(args.try_into_config(PipelineType::Metrics, environment)?);
+    }
+
+    if let Ok(logs_exps) = std::env::var("ROTEL_EXPORTERS_LOGS") {
+        let sp: Vec<&str> = logs_exps.split(",").collect();
+        if sp.len() != 1 {
+            return Err(format!(
+                "Only one exporter supported for ROTEL_EXPORTERS_LOGS: {}",
+                logs_exps
+            )
+            .into());
+        }
+
+        let args = match exporter_map.get(&sp[0].to_string()) {
+            Some(args) => args,
+            None => {
+                return Err(format!("Can not find exporter {} for logs exporters", sp[0]).into());
+            }
+        };
+
+        cfg.metrics = Some(args.try_into_config(PipelineType::Logs, environment)?);
+    }
+
+    Ok(cfg)
+}
+
+fn args_from_env_prefix(exporter_type: &str, prefix: &str) -> Result<ExporterArgs, BoxError> {
+    let figment = Figment::new().merge(Env::prefixed(
+        format!("ROTEL_{}_EXPORTER", prefix.to_uppercase()).as_str(),
+    ));
+    match exporter_type {
+        "blackhole" => Ok(ExporterArgs::Blackhole),
+        "otlp" => {
+            let args: OTLPExporterBaseArgs = match figment.extract() {
+                Ok(args) => args,
+                Err(e) => return Err(format!("failed to parse OTLP config: {}", e).into()),
+            };
+
+            Ok(ExporterArgs::Otlp(args))
+        }
+        "datadog" => {
+            let args: DatadogExporterArgs = match figment.extract() {
+                Ok(args) => args,
+                Err(e) => return Err(format!("failed to parse Datadog config: {}", e).into()),
+            };
+
+            Ok(ExporterArgs::Datadog(args))
+        }
+        "clickhouse" => {
+            let args: ClickhouseExporterArgs = match figment.extract() {
+                Ok(args) => args,
+                Err(e) => {
+                    return Err(format!("failed to parse Clickhouse config: {}", e).into());
+                }
+            };
+
+            Ok(ExporterArgs::Clickhouse(args))
+        }
+        "xray" => {
+            let args: XRayExporterArgs = match figment.extract() {
+                Ok(args) => args,
+                Err(e) => return Err(format!("failed to parse X-Ray config: {}", e).into()),
+            };
+
+            Ok(ExporterArgs::Xray(args))
+        }
+        _ => Err(format!("unknown exporter type: {}", exporter_type).into()),
+    }
+}
+
+fn get_single_exporter_config(
+    config: &AgentRun,
+    exporter: Exporter,
     environment: &str,
 ) -> Result<ExporterConfigs, BoxError> {
     let mut cfg = ExporterConfigs {
@@ -33,46 +382,53 @@ pub(crate) fn get_exporters_config(
         traces: None,
     };
 
-    match config.exporter {
+    match exporter {
         Exporter::Otlp => {
             let endpoint = config.otlp_exporter.base.endpoint.as_ref();
-            cfg.traces = Some(ExporterConfig::Otlp({
-                let endpoint = config
-                    .otlp_exporter
-                    .base
-                    .traces_endpoint
-                    .as_ref()
-                    .map(|e| Endpoint::Full(e.clone()))
-                    .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
-                let traces_config = build_traces_config(config.otlp_exporter.clone());
-                traces_config.into_exporter_config("otlp_traces", endpoint)
-            }));
-            cfg.metrics = Some(ExporterConfig::Otlp({
-                let endpoint = config
-                    .otlp_exporter
-                    .base
-                    .metrics_endpoint
-                    .as_ref()
-                    .map(|e| Endpoint::Full(e.clone()))
-                    .unwrap_or_else(|| Endpoint::Base(endpoint.clone().unwrap().clone()));
 
-                let metrics_config = build_metrics_config(config.otlp_exporter.clone());
-                metrics_config
-                    .clone()
-                    .into_exporter_config("otlp_metrics", endpoint.clone())
-            }));
-            cfg.logs = Some(ExporterConfig::Otlp({
-                let endpoint = config
-                    .otlp_exporter
-                    .base
-                    .logs_endpoint
-                    .as_ref()
-                    .map(|e| Endpoint::Full(e.clone()))
-                    .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+            if endpoint.is_some() || config.otlp_exporter.base.traces_endpoint.is_some() {
+                cfg.traces = Some(ExporterConfig::Otlp({
+                    let endpoint = config
+                        .otlp_exporter
+                        .base
+                        .traces_endpoint
+                        .as_ref()
+                        .map(|e| Endpoint::Full(e.clone()))
+                        .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+                    let traces_config = build_traces_config(config.otlp_exporter.clone());
+                    traces_config.into_exporter_config("otlp_traces", endpoint)
+                }));
+            }
+            if endpoint.is_some() || config.otlp_exporter.base.metrics_endpoint.is_some() {
+                cfg.metrics = Some(ExporterConfig::Otlp({
+                    let endpoint = config
+                        .otlp_exporter
+                        .base
+                        .metrics_endpoint
+                        .as_ref()
+                        .map(|e| Endpoint::Full(e.clone()))
+                        .unwrap_or_else(|| Endpoint::Base(endpoint.clone().unwrap().clone()));
 
-                let logs_config = build_logs_config(config.otlp_exporter.clone());
-                logs_config.into_exporter_config("otlp_logs", endpoint)
-            }));
+                    let metrics_config = build_metrics_config(config.otlp_exporter.clone());
+                    metrics_config
+                        .clone()
+                        .into_exporter_config("otlp_metrics", endpoint.clone())
+                }));
+            }
+            if endpoint.is_some() || config.otlp_exporter.base.logs_endpoint.is_some() {
+                cfg.logs = Some(ExporterConfig::Otlp({
+                    let endpoint = config
+                        .otlp_exporter
+                        .base
+                        .logs_endpoint
+                        .as_ref()
+                        .map(|e| Endpoint::Full(e.clone()))
+                        .unwrap_or_else(|| Endpoint::Base(endpoint.unwrap().clone()));
+
+                    let logs_config = build_logs_config(config.otlp_exporter.clone());
+                    logs_config.into_exporter_config("otlp_logs", endpoint)
+                }));
+            }
         }
         Exporter::Blackhole => {
             cfg.traces = Some(ExporterConfig::Blackhole {});

--- a/src/init/datadog_exporter.rs
+++ b/src/init/datadog_exporter.rs
@@ -41,6 +41,7 @@ impl Default for DatadogExporterArgs {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Deserialize, ValueEnum)]
+#[serde(rename_all = "lowercase")]
 pub enum DatadogRegion {
     US1,
     US3,

--- a/src/init/datadog_exporter.rs
+++ b/src/init/datadog_exporter.rs
@@ -1,6 +1,8 @@
 use clap::{Args, ValueEnum};
+use serde::Deserialize;
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Deserialize)]
+#[serde(default)]
 pub struct DatadogExporterArgs {
     /// Datadog Exporter Region
     #[arg(
@@ -28,7 +30,17 @@ pub struct DatadogExporterArgs {
     pub api_key: Option<String>,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum)]
+impl Default for DatadogExporterArgs {
+    fn default() -> Self {
+        Self {
+            region: DatadogRegion::US1,
+            custom_endpoint: None,
+            api_key: None,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, Deserialize, ValueEnum)]
 pub enum DatadogRegion {
     US1,
     US3,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -11,5 +11,6 @@ mod xray_exporter;
 
 mod batch;
 mod config;
+mod parse;
 #[cfg(feature = "pprof")]
 pub mod pprof;

--- a/src/init/otlp_exporter.rs
+++ b/src/init/otlp_exporter.rs
@@ -306,6 +306,74 @@ pub struct OTLPExporterArgs {
     pub otlp_exporter_logs_retry_max_elapsed_time: Option<std::time::Duration>,
 }
 
+impl Default for OTLPExporterArgs {
+    fn default() -> Self {
+        Self {
+            base: OTLPExporterBaseArgs::default(),
+            otlp_exporter_traces_protocol: None,
+            otlp_exporter_metrics_protocol: None,
+            otlp_exporter_logs_protocol: None,
+            otlp_exporter_traces_custom_headers: None,
+            otlp_exporter_metrics_custom_headers: None,
+            otlp_exporter_logs_custom_headers: None,
+            otlp_exporter_traces_compression: None,
+            otlp_exporter_metrics_compression: None,
+            otlp_exporter_logs_compression: None,
+            otlp_exporter_traces_cert_group: TracesCertGroup {
+                otlp_exporter_traces_tls_cert_file: None,
+                otlp_exporter_traces_tls_cert_pem: None,
+            },
+            otlp_exporter_traces_key_group: TracesKeyGroup {
+                otlp_exporter_traces_tls_key_file: None,
+                otlp_exporter_traces_tls_key_pem: None,
+            },
+            otlp_exporter_traces_ca_group: TracesCaGroup {
+                otlp_exporter_traces_tls_ca_file: None,
+                otlp_exporter_traces_tls_ca_pem: None,
+            },
+            otlp_exporter_metrics_cert_group: MetricsCertGroup {
+                otlp_exporter_metrics_tls_cert_file: None,
+                otlp_exporter_metrics_tls_cert_pem: None,
+            },
+            otlp_exporter_metrics_key_group: MetricsKeyGroup {
+                otlp_exporter_metrics_tls_key_file: None,
+                otlp_exporter_metrics_tls_key_pem: None,
+            },
+            otlp_exporter_metrics_ca_group: MetricsCaGroup {
+                otlp_exporter_metrics_tls_ca_file: None,
+                otlp_exporter_metrics_tls_ca_pem: None,
+            },
+            otlp_exporter_logs_cert_group: LogsCertGroup {
+                otlp_exporter_logs_tls_cert_file: None,
+                otlp_exporter_logs_tls_cert_pem: None,
+            },
+            otlp_exporter_logs_key_group: LogsKeyGroup {
+                otlp_exporter_logs_tls_key_file: None,
+                otlp_exporter_logs_tls_key_pem: None,
+            },
+            otlp_exporter_logs_ca_group: LogsCaGroup {
+                otlp_exporter_logs_tls_ca_file: None,
+                otlp_exporter_logs_tls_ca_pem: None,
+            },
+            otlp_exporter_traces_tls_skip_verify: None,
+            otlp_exporter_metrics_tls_skip_verify: None,
+            otlp_exporter_logs_tls_skip_verify: None,
+            otlp_exporter_traces_request_timeout: None,
+            otlp_exporter_metrics_request_timeout: None,
+            otlp_exporter_logs_request_timeout: None,
+            otlp_exporter_traces_retry_initial_backoff: None,
+            otlp_exporter_metrics_retry_initial_backoff: None,
+            otlp_exporter_logs_retry_initial_backoff: None,
+            otlp_exporter_traces_retry_max_backoff: None,
+            otlp_exporter_metrics_retry_max_backoff: None,
+            otlp_exporter_logs_retry_max_backoff: None,
+            otlp_exporter_traces_retry_max_elapsed_time: None,
+            otlp_exporter_metrics_retry_max_elapsed_time: None,
+            otlp_exporter_logs_retry_max_elapsed_time: None,
+        }
+    }
+}
+
 impl From<OTLPExporterProtocol> for Protocol {
     fn from(value: OTLPExporterProtocol) -> Protocol {
         match value {

--- a/src/init/parse.rs
+++ b/src/init/parse.rs
@@ -1,0 +1,249 @@
+use serde::{
+    Deserializer,
+    de::{self, Visitor},
+};
+use std::error::Error;
+use std::fmt;
+use std::net::SocketAddr;
+use tower::BoxError;
+
+/// Parse a single key-value pair
+pub(crate) fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
+
+// Parse comma-separated, key value pairs: apple=orange,dog=cat
+pub(crate) fn deserialize_key_value_pairs<'de, D>(
+    deserializer: D,
+) -> Result<Vec<(String, String)>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct KeyValueVisitor;
+
+    impl<'de> Visitor<'de> for KeyValueVisitor {
+        type Value = Vec<(String, String)>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string containing comma-separated key=value pairs")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let mut pairs = Vec::new();
+
+            if value.is_empty() {
+                return Ok(pairs);
+            }
+
+            for pair in value.split(',') {
+                let pair = pair.trim();
+
+                if pair.is_empty() {
+                    continue;
+                }
+
+                // Check if the pair contains exactly one '='
+                let parts: Vec<&str> = pair.split('=').collect();
+                if parts.len() != 2 {
+                    return Err(E::custom(format!(
+                        "Invalid key=value pair: '{}'. Expected format: key=value",
+                        pair
+                    )));
+                }
+
+                let key = parts[0].trim().to_string();
+                let value = parts[1].trim().to_string();
+
+                if key.is_empty() {
+                    return Err(E::custom(format!("Empty key in pair: '{}'", pair)));
+                }
+
+                pairs.push((key, value));
+            }
+
+            Ok(pairs)
+        }
+    }
+
+    deserializer.deserialize_str(KeyValueVisitor)
+}
+
+/// Parse an endpoint
+pub fn parse_endpoint(s: &str) -> Result<SocketAddr, Box<dyn Error + Send + Sync + 'static>> {
+    // Use actual localhost address instead of localhost name
+    let s = if s.starts_with("localhost:") {
+        s.replace("localhost:", "127.0.0.1:")
+    } else {
+        s.to_string()
+    };
+    let sa: SocketAddr = s.parse()?;
+    Ok(sa)
+}
+
+pub(crate) fn parse_bool_value(val: &String) -> Result<bool, BoxError> {
+    match val.to_lowercase().as_str() {
+        "0" | "false" => Ok(false),
+        "1" | "true" => Ok(true),
+        _ => Err(format!("Unable to parse bool value: {}", val).into()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde::Deserialize;
+    use serde_json;
+    use tokio_test::assert_ok;
+
+    #[test]
+    fn endpoint_parse() {
+        let sa = parse_endpoint("localhost:4317");
+        assert_ok!(sa);
+        let sa = sa.unwrap();
+        assert!(sa.is_ipv4());
+        assert_eq!("127.0.0.1", sa.ip().to_string());
+        assert_eq!(4317, sa.port());
+
+        let sa = parse_endpoint("[::1]:4317");
+        assert_ok!(sa);
+        let sa = sa.unwrap();
+        assert!(sa.is_ipv6());
+        assert_eq!("::1", sa.ip().to_string());
+
+        let sa = parse_endpoint("0.0.0.0:1234");
+        assert_ok!(sa);
+        let sa = sa.unwrap();
+        assert_eq!("0.0.0.0", sa.ip().to_string());
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        #[serde(deserialize_with = "deserialize_key_value_pairs")]
+        properties: Vec<(String, String)>,
+    }
+
+    #[test]
+    fn test_valid_key_value_pairs() {
+        let json = r#"{"properties": "apple=orange,dog=cat"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            config.properties,
+            vec![
+                ("apple".to_string(), "orange".to_string()),
+                ("dog".to_string(), "cat".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let json = r#"{"properties": ""}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+
+        assert!(config.properties.is_empty());
+    }
+
+    #[test]
+    fn test_single_pair() {
+        let json = r#"{"properties": "key=value"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            config.properties,
+            vec![("key".to_string(), "value".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_whitespace_handling() {
+        let json = r#"{"properties": " key1 = value1 , key2 = value2 "}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            config.properties,
+            vec![
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_preserves_order() {
+        let json = r#"{"properties": "first=1,second=2,third=3"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            config.properties,
+            vec![
+                ("first".to_string(), "1".to_string()),
+                ("second".to_string(), "2".to_string()),
+                ("third".to_string(), "3".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_allows_duplicate_keys() {
+        let json = r#"{"properties": "key=value1,key=value2"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            config.properties,
+            vec![
+                ("key".to_string(), "value1".to_string()),
+                ("key".to_string(), "value2".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_invalid_no_equals() {
+        let json = r#"{"properties": "apple=orange,dog"}"#;
+        let result: Result<Config, _> = serde_json::from_str(json);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid key=value pair: 'dog'")
+        );
+    }
+
+    #[test]
+    fn test_invalid_multiple_equals() {
+        let json = r#"{"properties": "apple=orange=fruit"}"#;
+        let result: Result<Config, _> = serde_json::from_str(json);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Invalid key=value pair")
+        );
+    }
+
+    #[test]
+    fn test_empty_key() {
+        let json = r#"{"properties": "=value"}"#;
+        let result: Result<Config, _> = serde_json::from_str(json);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Empty key"));
+    }
+}

--- a/src/init/xray_exporter.rs
+++ b/src/init/xray_exporter.rs
@@ -1,6 +1,9 @@
+use crate::exporters::xray::Region;
 use clap::Args;
+use serde::Deserialize;
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, Deserialize)]
+#[serde(default)]
 pub struct XRayExporterArgs {
     /// X-Ray Exporter Region
     #[arg(
@@ -9,7 +12,7 @@ pub struct XRayExporterArgs {
         env = "ROTEL_XRAY_EXPORTER_REGION",
         default_value = "us-east-1"
     )]
-    pub region: crate::exporters::xray::Region,
+    pub region: Region,
 
     /// X-Ray Exporter custom endpoint override
     #[arg(
@@ -17,4 +20,13 @@ pub struct XRayExporterArgs {
         env = "ROTEL_XRAY_EXPORTER_CUSTOM_ENDPOINT"
     )]
     pub custom_endpoint: Option<String>,
+}
+
+impl Default for XRayExporterArgs {
+    fn default() -> Self {
+        Self {
+            region: Region::UsEast1,
+            custom_endpoint: None,
+        }
+    }
 }


### PR DESCRIPTION
This PR brings in support for exporting to multiple destinations across multiple exporter types. You can emit traces to Datadog while writing metrics and logs to Clickhouse. This follows the spec outlined in the [RFC discussion](https://github.com/streamfold/rotel/discussions/104).

For initial simplicity we limit the number of exporters per telemetry type to one. We'll be able to relax this in the future when we have support for fan-out.

Some of the config parsing/loading is duplicated, but we should be able to reduce this in a future PR. It may require some generics/traits, so tried to keep this small.

Completes: STR-3396