### PR TITLE
Immediately retry on a flush request

### DIFF
--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -206,6 +206,7 @@ impl ClickhouseExporterBuilder {
         let req_builder = RequestBuilder::new(transformer, self.request_mapper.clone())?;
 
         let retry_layer = RetryPolicy::new(self.retry_config.clone(), None);
+        let retry_broadcast = retry_layer.retry_broadcast();
 
         let svc = ServiceBuilder::new()
             .retry(retry_layer)
@@ -224,6 +225,7 @@ impl ClickhouseExporterBuilder {
                 telemetry_type: telemetry_type.to_string(),
             },
             flush_receiver,
+            retry_broadcast,
             Duration::from_secs(1),
             Duration::from_secs(2),
         );

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -158,6 +158,7 @@ impl DatadogExporterBuilder {
         )?;
 
         let retry_layer = RetryPolicy::new(self.retry_config, None);
+        let retry_broadcast = retry_layer.retry_broadcast();
 
         let svc = ServiceBuilder::new()
             .retry(retry_layer)
@@ -176,6 +177,7 @@ impl DatadogExporterBuilder {
                 telemetry_type: "traces".to_string(),
             },
             flush_receiver,
+            retry_broadcast,
             Duration::from_secs(1),
             Duration::from_secs(2),
         );

--- a/src/exporters/http/retry.rs
+++ b/src/exporters/http/retry.rs
@@ -89,8 +89,8 @@ impl<Resp> RetryPolicy<Resp> {
 
     pub fn new(retry_config: RetryConfig, is_retryable: Option<RetryableFn<Resp>>) -> Self {
         // We immediately drop the receiver channel and only keep receivers open for
-        // active retries
-        let (tx, _) = broadcast::channel(100);
+        // active retries. Size mostly needs to be >0.
+        let (tx, _) = broadcast::channel(16);
 
         Self {
             current_backoff: retry_config.initial_backoff,

--- a/src/exporters/retry.rs
+++ b/src/exporters/retry.rs
@@ -73,8 +73,8 @@ impl<T> RetryPolicy<T> {
 
     pub fn new(retry_config: RetryConfig, is_retryable: fn(&ExporterError) -> bool) -> Self {
         // We immediately drop the receiver channel and only keep receivers open for
-        // active retries
-        let (tx, _) = broadcast::channel(100);
+        // active retries. Size mostly needs to be >0.
+        let (tx, _) = broadcast::channel(16);
 
         Self {
             current_backoff: retry_config.initial_backoff,

--- a/src/exporters/retry.rs
+++ b/src/exporters/retry.rs
@@ -8,7 +8,11 @@ use std::marker::PhantomData;
 use std::ops::Sub;
 use std::pin::Pin;
 use std::time::Duration;
-use tokio::{select, sync::broadcast::{self, Sender}, time::Instant};
+use tokio::{
+    select,
+    sync::broadcast::{self, Sender},
+    time::Instant,
+};
 use tower::BoxError;
 use tower::retry::Policy;
 use tracing::info;
@@ -82,7 +86,7 @@ impl<T> RetryPolicy<T> {
             _phantom: PhantomData,
         }
     }
-    
+
     pub fn retry_broadcast(&self) -> Sender<bool> {
         self.retry_broadcast.clone()
     }
@@ -138,7 +142,7 @@ impl<T: Debug + Clone + Send + 'static> Policy<EncodedRequest, T, BoxError> for 
                     status = ?result,
                     "Exporting failed, will retry again after delay.",
                 );
-                
+
                 let mut rx = self.retry_broadcast.subscribe();
                 let fut = async move {
                     let delay_fut = tokio::time::sleep(sleep_duration);

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -232,6 +232,7 @@ impl XRayExporterBuilder {
         )?;
 
         let retry_layer = RetryPolicy::new(self.retry_config, None);
+        let retry_broadcast = retry_layer.retry_broadcast();
 
         let svc = ServiceBuilder::new()
             .retry(retry_layer)
@@ -250,6 +251,7 @@ impl XRayExporterBuilder {
                 telemetry_type: "traces".to_string(),
             },
             flush_receiver,
+            retry_broadcast,
             Duration::from_secs(1),
             Duration::from_secs(2),
         );

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -2,6 +2,7 @@ pub mod activation;
 pub mod agent;
 pub mod args;
 pub mod misc;
+pub mod parse;
 pub mod wait;
 
 mod clickhouse_exporter;
@@ -11,6 +12,5 @@ mod xray_exporter;
 
 mod batch;
 mod config;
-mod parse;
 #[cfg(feature = "pprof")]
 pub mod pprof;


### PR DESCRIPTION
When we get a flush request, typically from the Lambda Extension, trigger all pending retries to immediately retry. In many cases we want to flush because the Lambda may be frozen indefinitely, so it's better to retry then wait for the exponential backoff. It's possible the backoff occurred due to a transient issue on the exporter destination, so better to retry immediately.

In the future we want to differentiate between an opportunistic flush and a required end-of-function flush. In the opportunistic case it may be fine to leave the retries until their scheduled backoff time.
