### PR TITLE
ClickHouse DDL Schema Improvements for Observability

### DIFF
--- a/src/bin/clickhouse-ddl/ddl_metrics.rs
+++ b/src/bin/clickhouse-ddl/ddl_metrics.rs
@@ -51,7 +51,7 @@ pub(crate) fn get_metrics_ddl(
                     ("MAP_INDICES", map_indices),
                     (
                         "TTL_EXPR",
-                        build_ttl_string(ttl, "toDateTime(TimeUnix)").as_str(),
+                        build_ttl_string(ttl, "TimeUnix").as_str(),
                     ),
                     ("JSON_SETTING", json_setting),
                 ]),

--- a/src/bin/clickhouse-ddl/ddl_traces.rs
+++ b/src/bin/clickhouse-ddl/ddl_traces.rs
@@ -35,7 +35,7 @@ pub(crate) fn get_traces_ddl(
             ("MAP_INDICES", map_indices),
             (
                 "TTL_EXPR",
-                build_ttl_string(ttl, "toDateTime(Timestamp)").as_str(),
+                build_ttl_string(ttl, "Timestamp").as_str(),
             ),
             ("JSON_SETTING", json_setting),
         ]),
@@ -52,7 +52,7 @@ pub(crate) fn get_traces_ddl(
             ("ENGINE", engine),
             (
                 "TTL_EXPR",
-                build_ttl_string(ttl, "toDateTime(Start)").as_str(),
+                build_ttl_string(ttl, "Start").as_str(),
             ),
         ]),
     );
@@ -114,7 +114,7 @@ CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
 	INDEX idx_duration Duration TYPE minmax GRANULARITY 1
 ) ENGINE = %%ENGINE%%
 PARTITION BY toDate(Timestamp)
-ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+ORDER BY (ServiceName, SpanName, Timestamp)
 %%TTL_EXPR%%
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1 %%JSON_SETTING%%
 ;
@@ -130,8 +130,8 @@ const TRACES_TABLE_MAP_INDICES_SQL: &str = r#"
 const TRACES_TABLE_ID_TS_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS %%TABLE%% %%CLUSTER%% (
      TraceId String CODEC(ZSTD(1)),
-     Start DateTime CODEC(Delta, ZSTD(1)),
-     End DateTime CODEC(Delta, ZSTD(1)),
+     Start DateTime64(9) CODEC(Delta, ZSTD(1)),
+     End DateTime64(9) CODEC(Delta, ZSTD(1)),
      INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
 ) ENGINE = %%ENGINE%%
 PARTITION BY toDate(Start)


### PR DESCRIPTION
# ClickHouse DDL Schema Improvements for Observability

## Summary

This PR aligns ClickHouse DDL schema with [official observability best practices](https://clickhouse.com/docs/use-cases/observability/schema-design) by fixing inconsistencies in timestamp handling and removing unnecessary type conversions.

## Changes Made

### 1. Fixed DateTime Precision Inconsistency

**Issue**: `traces_trace_id_ts` table used `DateTime` while main `traces` table uses `DateTime64(9)`, causing precision loss in materialized view aggregations.

```sql
-- ❌ Before: Inconsistent precision
Start DateTime CODEC(Delta, ZSTD(1)),
End DateTime CODEC(Delta, ZSTD(1)),

-- ✅ After: Consistent precision  
Start DateTime64(9) CODEC(Delta, ZSTD(1)),
End DateTime64(9) CODEC(Delta, ZSTD(1)),
```

*Reference: [ClickHouse DateTime64 Documentation](https://clickhouse.com/docs/sql-reference/data-types/datetime64)*

### 2. Removed Unnecessary Type Conversions

**Issue**: TTL expressions and ordering keys used `toDateTime()` conversions that add overhead and reduce performance.

```rust
// ❌ Before: Unnecessary conversions
build_ttl_string(ttl, "toDateTime(Timestamp)")
ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))

// ✅ After: Direct column usage
build_ttl_string(ttl, "Timestamp")  
ORDER BY (ServiceName, SpanName, Timestamp)
```

*Reference: [ClickHouse TTL Documentation](https://clickhouse.com/docs/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl)*

### 3. Performance Issues with Ordering Keys

**Issue**: Using `toDateTime()` in ORDER BY clauses causes slow query performance with DateTime64 as noted in ClickHouse documentation.

```sql
-- ❌ Before: Function overhead in ordering
ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))

-- ✅ After: Direct column usage for better performance
ORDER BY (ServiceName, SpanName, Timestamp)
```

*Reference: [ClickHouse Primary Keys and Ordering](https://clickhouse.com/docs/guides/best-practices/sparse-primary-indexes)*

### 4. Metrics Schema Using `toUnixTimestamp64Nano()`

**Note**: The metrics schema uses `toUnixTimestamp64Nano(TimeUnix)` in ORDER BY clauses, which may need future evaluation for performance impact:

```sql
ORDER BY (ServiceName, MetricName, toUnixTimestamp64Nano(TimeUnix))
```

*Reference: [ClickHouse Observability Schema Design](https://clickhouse.com/docs/use-cases/observability/schema-design)*

## Impact

- **Performance**: Faster queries due to removed function overhead
- **Consistency**: Uniform timestamp precision across trace tables
- **Compliance**: Alignment with ClickHouse observability best practices

## Files Modified

- `src/bin/clickhouse-ddl/ddl_traces.rs`
- `src/bin/clickhouse-ddl/ddl_metrics.rs`

## Migration Notes

For existing deployments, the DateTime precision change requires data migration. TTL and ordering key changes are backward compatible.
