### PR TITLE
Add result finalizer

### DIFF
--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -6,11 +6,10 @@ use crate::exporters::datadog::transform::Transformer;
 use crate::exporters::http::retry::{RetryConfig, RetryPolicy};
 
 use crate::exporters::http::client::ResponseDecode;
-use crate::exporters::http::exporter::{Exporter, ResultLogger};
+use crate::exporters::http::exporter::Exporter;
 use crate::exporters::http::http_client::HttpClient;
 use crate::exporters::http::request_builder_mapper::RequestBuilderMapper;
 use crate::exporters::http::request_iter::RequestIterator;
-use crate::exporters::http::response::Response;
 use crate::exporters::http::tls;
 use crate::exporters::http::types::ContentEncoding;
 use crate::topology::flush_control::FlushReceiver;
@@ -23,7 +22,8 @@ use std::time::Duration;
 use tower::retry::Retry as TowerRetry;
 use tower::timeout::Timeout;
 use tower::{BoxError, ServiceBuilder};
-use tracing::error;
+
+use super::http::finalizer::SuccessStatusFinalizer;
 
 mod api_request;
 mod request_builder;
@@ -46,7 +46,7 @@ type ExporterType<'a, Resource> = Exporter<
     >,
     SvcType,
     Full<Bytes>,
-    DatadogResultLogger,
+    SuccessStatusFinalizer,
 >;
 
 #[derive(Copy, Clone)]
@@ -173,9 +173,7 @@ impl DatadogExporterBuilder {
             "traces",
             enc_stream,
             svc,
-            DatadogResultLogger {
-                telemetry_type: "traces".to_string(),
-            },
+            SuccessStatusFinalizer::default(),
             flush_receiver,
             retry_broadcast,
             Duration::from_secs(1),
@@ -198,7 +196,7 @@ mod tests {
     use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
     use std::time::Duration;
     use tokio::join;
-    use tokio_test::assert_ok;
+    use tokio_test::{assert_err, assert_ok};
     use tokio_util::sync::CancellationToken;
     use utilities::otlp::FakeOTLP;
 
@@ -247,13 +245,13 @@ mod tests {
         let cancellation_token = CancellationToken::new();
 
         let cancel_clone = cancellation_token.clone();
-        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await.unwrap() });
+        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await });
 
         let traces = FakeOTLP::trace_service_request();
         btx.send(traces.resource_spans).await.unwrap();
         drop(btx);
         let res = join!(jh);
-        assert_ok!(res.0);
+        assert_err!(res.0.unwrap()); // failed to drain
 
         assert!(hello_mock.hits() >= 3); // somewhat timing dependent
     }
@@ -281,21 +279,5 @@ impl ResponseDecode<()> for DatadogTraceDecoder {
     // todo: look at response
     fn decode(&self, _: Bytes, _: ContentEncoding) -> Result<(), BoxError> {
         Ok(())
-    }
-}
-
-pub struct DatadogResultLogger {
-    telemetry_type: String,
-}
-
-impl ResultLogger<Response<()>> for DatadogResultLogger {
-    fn handle(&self, resp: Response<()>) {
-        match resp.status_code().as_u16() {
-            200..=202 => {}
-            _ => error!(
-                telemetry_type = self.telemetry_type,
-                "Failed to export to Datadog: {:?}", resp
-            ),
-        };
     }
 }

--- a/src/exporters/http/finalizer.rs
+++ b/src/exporters/http/finalizer.rs
@@ -1,0 +1,52 @@
+use http::StatusCode;
+use tonic::Status;
+use tower::BoxError;
+
+use super::response::Response;
+
+pub trait ResultFinalizer<Res> {
+    fn finalize(&self, result: Res) -> Result<(), BoxError>;
+}
+
+// Basic finalizer that respects HTTP or GRPC success status codes
+#[derive(Default, Clone)]
+pub struct SuccessStatusFinalizer;
+
+pub enum FinalizerError {
+    HttpStatus(StatusCode),
+
+    GrpcStatus(Status),
+}
+
+impl From<FinalizerError> for BoxError {
+    fn from(err: FinalizerError) -> Self {
+        match err {
+            FinalizerError::HttpStatus(status) => format!("Invalid HTTP status: {}", status).into(),
+            FinalizerError::GrpcStatus(status) => format!("Invalid gRPC status: {}", status).into(),
+        }
+    }
+}
+
+impl<T, Err> ResultFinalizer<Result<Response<T>, Err>> for SuccessStatusFinalizer
+where
+    Err: Into<BoxError>,
+{
+    fn finalize(&self, result: Result<Response<T>, Err>) -> Result<(), BoxError> {
+        match result {
+            Ok(r) => match r {
+                Response::Http(parts, _) => match parts.status.as_u16() {
+                    200..=202 => Ok(()),
+                    _ => Err(FinalizerError::HttpStatus(parts.status).into()),
+                },
+                Response::Grpc(status, _) => {
+                    if status.code() == tonic::Code::Ok {
+                        Ok(())
+                    } else {
+                        Err(FinalizerError::GrpcStatus(status).into())
+                    }
+                }
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/src/exporters/http/mod.rs
+++ b/src/exporters/http/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod client;
 pub mod exporter;
+pub mod finalizer;
 pub mod grpc_client;
 pub mod http_client;
 pub mod request;


### PR DESCRIPTION
This PR brings in the concept of a result finalizer which transforms the final service's `Result<Response, Error>` into a `Result<(), Error>` that the exporter can handle, replacing the result logger. The idea is that a specific exporter can define what success or failure means for the given response status codes, allowing the generic exporter code to handle just success/fail without knowing about Response. If a specific exporter wants to include logging of certain conditions, it can do that in the finalizer.

Includes a generic SuccessFinalizer that treats known HTTP and gRPC success codes as success and everything else as a failure.

This broke a couple of tests that weren't capturing drain errors due to 429 response codes.

Completes: #154 

