### PR TITLE
Reduce clones in DD exporter

### DIFF
--- a/src/exporters/datadog/api_request.rs
+++ b/src/exporters/datadog/api_request.rs
@@ -34,7 +34,7 @@ impl ApiRequestBuilder {
         let trace_url = build_url(&uri, TRACES_PATH);
 
         let mut base_headers = HeaderMap::new();
-        base_headers.insert("DD-API-KEY", api_key.clone().parse()?);
+        base_headers.insert("DD-API-KEY", api_key.parse()?);
 
         // these might change with different routes in the future
         base_headers.insert(

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -148,13 +148,13 @@ impl DatadogExporterBuilder {
     ) -> Result<ExporterType<'a, ResourceSpans>, BoxError> {
         let client = HttpClient::build(tls::Config::default(), Default::default())?;
 
-        let transformer = Transformer::new(self.environment.clone(), self.hostname.clone());
+        let transformer = Transformer::new(self.environment, self.hostname);
 
         let req_builder = RequestBuilder::new(
             transformer,
             self.region,
-            self.custom_endpoint.clone(),
-            self.api_token.clone(),
+            self.custom_endpoint,
+            self.api_token,
         )?;
 
         let retry_layer = RetryPolicy::new(self.retry_config, None);

--- a/src/exporters/datadog/transform/attributes.rs
+++ b/src/exporters/datadog/transform/attributes.rs
@@ -71,7 +71,7 @@ fn find_with_span_precedence(
     }
 
     // lastly, check the resource attributes
-    res_attrs.as_ref().get(key).map(|cv| cv.clone())
+    res_attrs.as_ref().get(key).cloned()
 }
 
 /// Search for an attribute value by key names, starting at the highest level and moving
@@ -123,5 +123,5 @@ fn find_key_in_attrlist_anyvalue(key: &str, attributes: &Vec<KeyValue>) -> Optio
     attributes
         .iter()
         .find(|&attr| attr.key == *key && attr.value.is_some())
-        .map(|kv| kv.value.clone().unwrap())
+        .and_then(|kv| kv.value.clone())
 }

--- a/src/exporters/datadog/transform/mod.rs
+++ b/src/exporters/datadog/transform/mod.rs
@@ -24,10 +24,11 @@ pub struct Transformer {
 
 impl Transformer {
     pub fn new(environment: String, hostname: String) -> Self {
+        let transformer = TraceTransformer::new(environment.clone(), hostname.clone());
         Self {
-            environment: environment.clone(),
-            hostname: hostname.clone(),
-            transformer: TraceTransformer::new(environment, hostname),
+            environment,
+            hostname,
+            transformer,
         }
     }
 }

--- a/src/exporters/datadog/transform/otel_mapping/attributes.rs
+++ b/src/exporters/datadog/transform/otel_mapping/attributes.rs
@@ -86,6 +86,7 @@ pub fn container_tags_from_resource_attributes(
 
         if let Some(dd_key) = CONTAINER_MAPPINGS.get(k.as_str()).map(|s| s.to_string()) {
             dd_tags.insert(dd_key, vstr.clone());
+            continue;
         }
 
         if let Some(custom_key) = k
@@ -93,7 +94,7 @@ pub fn container_tags_from_resource_attributes(
             .map(|s| s.to_string())
         {
             if !custom_key.is_empty() && !dd_tags.contains_key(&custom_key) {
-                dd_tags.insert(custom_key.clone(), vstr);
+                dd_tags.insert(custom_key, vstr);
             }
         }
     }

--- a/src/exporters/datadog/transform/otel_util.rs
+++ b/src/exporters/datadog/transform/otel_util.rs
@@ -114,7 +114,7 @@ pub fn get_otel_operation_name_v2(span: &OTelSpan) -> String {
 
     // RPC & AWS
     let rpc_value = find_attr(&vec![attribute::RPC_SYSTEM], true).map(|cv| cv.to_string());
-    let is_aws = rpc_value.clone().is_some_and(|v| v == "aws-api");
+    let is_aws = rpc_value.as_ref().is_some_and(|v| v == "aws-api");
     if is_aws && is_client {
         if let Some(service) = find_attr(&vec![attribute::RPC_SERVICE], true) {
             return format!("aws.{}.request", service);

--- a/src/exporters/datadog/transform/source.rs
+++ b/src/exporters/datadog/transform/source.rs
@@ -61,7 +61,7 @@ fn hostname_from_attrs(attrs: &ConvertedAttrMap) -> Option<String> {
     let unchecked = unchecked_hostname_from_attrs(attrs)?;
 
     // Make sure we ignore localhost variants
-    match unchecked.clone().as_str() {
+    match unchecked.as_str() {
         "0.0.0.0" => None,
         "127.0.0.1" => None,
         "localhost" => None,

--- a/src/exporters/datadog/transform/transformer.rs
+++ b/src/exporters/datadog/transform/transformer.rs
@@ -69,7 +69,7 @@ impl TraceTransformer {
         );
 
         let source = source::from_attributes(&resource_attrs)
-            .unwrap_or(source::Source::from_hostname(self.hostname.clone()));
+            .unwrap_or_else(|| source::Source::from_hostname(self.hostname.clone()));
         let hostname = if source.kind == source::SourceKind::Hostname {
             source.identifier.clone()
         } else {


### PR DESCRIPTION
As an experiment, I had claude go through the DD exporter and find unnecessary clone calls. It found several, or chose lazier evaluation approaches to avoid them.

