### PR TITLE
AWSEMF: Filter dimensions to reduce cardinality costs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,6 +3187,7 @@ dependencies = [
  "tracing-test",
  "url",
  "utilities",
+ "wildcard",
 ]
 
 [[package]]
@@ -4324,6 +4325,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "wildcard"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b0540e91e49de3817c314da0dd3bc518093ceacc6ea5327cb0e1eb073e5189"
+dependencies = [
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ sha2 = "0.10"
 regex = "1.11.1"
 rdkafka = { version = "0.36", features = ["tokio", "libz-static", "ssl-vendored", "zstd", "cmake-build"], optional = true }
 figment = { version = "0.10.19", default-features = false, features = ["env"] }
+wildcard = "0.3.0"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ are automatically sourced from Rotel's environment on startup.
 | --awsemf-exporter-custom-endpoint                      |                  |                  |
 | --awsemf-exporter-log-group-name                       | /metrics/default |                  |
 | --awsemf-exporter-log-stream-name                      | otel-stream      |                  |
+| --awsemf-exporter-log-retention                        | 0                |                  |
 | --awsemf-exporter-namespace                            |                  |                  |
 | --awsemf-exporter-retain-initial-value-of-delta-metric | false            |                  |
 | --awsemf-exporter-include-dimensions                   |                  |                  |
@@ -293,13 +294,15 @@ With these options, here's how the following attributes would be handled:
 - `http.internal`: excluded
 - `telemetry.sdk.language`: excluded
 
-
 **NOTE**:
 
-- At the moment the log group and log stream must exist or the exporter will fail to send logs.
+- If the log stream or log group do not exist, the exporter will attempt to create them automatically. Make sure that the credentials have the
+  right IAM permissions.
 - If `--awsemf-exporter-retain-initial-value-of-delta-metric` is true, then the initial value of a delta metric is retained when calculating deltas.
 - If the namespace is not specified, Rotel will look for `service.namespace` and `service.name` in the resource attributes and use those. If those
   don't exist, it will fall back to a namespace of _default_.
+- Log retention is specified in days, with zero meaning never expire. Valid values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545,
+  731, 1827, 2192, 2557, 2922, 3288, or 3653.
 
 ### Kafka exporter configuration (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,36 @@ are automatically sourced from Rotel's environment on startup.
 | --awsemf-exporter-log-stream-name                      | otel-stream      |                  |
 | --awsemf-exporter-namespace                            |                  |                  |
 | --awsemf-exporter-retain-initial-value-of-delta-metric | false            |                  |
+| --awsemf-exporter-include-dimensions                   |                  |                  |
+| --awsemf-exporter-exclude-dimensions                   |                  |                  |
+
+**DIMENSION FILTERING**:
+
+By default all resource and metric data point attributes will be included as dimensions in the Cloudwatch Metric. You
+can use the `include-dimensions` and `exclude-dimensions` options to selectively filter which dimensions are included
+in the generated metric. This can be useful to include a high-cardinality dimension in the log output, but not set
+it on the metric. The Cloudwatch Metric will represent the aggregation across all values without incurring the cost
+of the excessive high-cardinality.
+In the scenario that you want to examine the data based on the high-cardinality dimension, you can use Logs Insights
+to query that dimension from the logs.
+
+Both `include-dimensions` and `exclude-dimensions` take comma-separated wildcard patterns to match against the attribute
+names from the metrics. The `*` character can be used to match zero-or-more characters. Matching is case insensitive.
+By default all dimensions are included (`include-dimensions=*`), but you can also selectively filter which to include.
+The `exclude-dimensions` takes precedence, so any dimension that matches an exclude pattern will be excluded.
+
+Example:
+
+- `--awsemf-exporter-include-dimensions service.*,http.*`
+- `--awsemf-exporter-exclude-dimensions *.internal`
+
+With these options, here's how the following attributes would be handled:
+
+- `service.name`: included
+- `http.method`: included
+- `http.internal`: excluded
+- `telemetry.sdk.language`: excluded
+
 
 **NOTE**:
 

--- a/src/exporters/awsemf/cloudwatch.rs
+++ b/src/exporters/awsemf/cloudwatch.rs
@@ -1,0 +1,287 @@
+use crate::aws_api::auth::{AwsRequestSigner, SystemClock};
+use crate::aws_api::config::AwsConfig;
+use crate::exporters::http::client::{ResponseDecode, build_hyper_client};
+use crate::exporters::http::tls::Config;
+use crate::exporters::http::types::ContentEncoding;
+use bytes::Bytes;
+use flate2::Compression;
+use flate2::bufread::GzEncoder;
+use http::header::{CONTENT_ENCODING, CONTENT_TYPE};
+use http::{HeaderMap, HeaderValue, Method, Request, Uri};
+use http_body_util::{BodyExt, Full};
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::Client as HyperClient;
+use hyper_util::client::legacy::connect::HttpConnector;
+use serde_json::json;
+use std::io::Read;
+use tower::BoxError;
+use tracing::{debug, error, warn};
+
+use super::{AwsEmfDecoder, AwsEmfResponse};
+
+pub(crate) struct Cloudwatch {
+    signer: AwsRequestSigner<SystemClock>,
+    endpoint: Uri,
+    base_headers: HeaderMap,
+    log_group: String,
+    log_stream: String,
+    log_retention: u16,
+    client: HyperClient<HttpsConnector<HttpConnector>, Full<Bytes>>,
+}
+
+impl Cloudwatch {
+    pub(crate) fn new(
+        aws_config: AwsConfig,
+        endpoint: Option<String>,
+        log_group: String,
+        log_stream: String,
+        log_retention: u16,
+    ) -> Result<Self, BoxError> {
+        let endpoint_url =
+            endpoint.unwrap_or_else(|| format!("https://logs.{}.amazonaws.com", aws_config.region));
+
+        let endpoint: Uri = endpoint_url
+            .parse()
+            .map_err(|e| format!("Invalid CloudWatch endpoint: {}", e))?;
+
+        let region = aws_config.region.clone();
+        let signer = AwsRequestSigner::new("logs", &region, aws_config, SystemClock);
+
+        let mut base_headers = HeaderMap::new();
+        base_headers.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        base_headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/x-amz-json-1.1"),
+        );
+
+        // Use the existing HTTP client builder
+        let client = build_hyper_client(Config::default(), false)?;
+
+        Ok(Self {
+            signer,
+            endpoint,
+            base_headers,
+            log_group,
+            log_stream,
+            log_retention,
+            client,
+        })
+    }
+
+    /// Called when a resource (log group/stream) is not found
+    /// Log stream/group are set statically for entire runtime, but we may want to support
+    /// dynamic names in the future.
+    pub(crate) async fn create_stream(&self) -> Result<(), BoxError> {
+        debug!(
+            "Attempting to create log stream: {} in group: {}",
+            self.log_stream, self.log_group
+        );
+
+        match self
+            .create_log_stream(&self.log_group, &self.log_stream)
+            .await
+        {
+            Ok(_) => {
+                debug!("Successfully created log stream: {}", self.log_stream);
+                Ok(())
+            }
+            Err(e) => {
+                if self.is_resource_not_found_error(&e) {
+                    warn!(
+                        "Log group not found, attempting to create: {}",
+                        self.log_group
+                    );
+
+                    // Try to create the log group first
+                    self.create_log_group(&self.log_group).await?;
+
+                    // Set the retention policy for the newly created log group if not zero.
+                    // Log groups default to never expire.
+                    if self.log_retention != 0 {
+                        self.set_log_retention(&self.log_group, self.log_retention)
+                            .await?;
+                    }
+
+                    // Now try to create the log stream again
+                    self.create_log_stream(&self.log_group, &self.log_stream)
+                        .await?;
+
+                    debug!("Successfully created log group and stream");
+                    Ok(())
+                } else {
+                    error!("Failed to create log stream: {}", e);
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    async fn set_log_retention(
+        &self,
+        log_group_name: &str,
+        retention_in_days: u16,
+    ) -> Result<(), BoxError> {
+        let payload = json!({
+            "logGroupName": log_group_name,
+            "retentionInDays": retention_in_days
+        });
+
+        let mut headers = self.base_headers.clone();
+        headers.insert(
+            "X-Amz-Target",
+            HeaderValue::from_static("Logs_20140328.PutRetentionPolicy"),
+        );
+
+        self.make_request(payload, headers).await
+    }
+
+    async fn create_log_stream(
+        &self,
+        log_group_name: &str,
+        log_stream_name: &str,
+    ) -> Result<(), BoxError> {
+        let payload = json!({
+            "logGroupName": log_group_name,
+            "logStreamName": log_stream_name
+        });
+
+        let mut headers = self.base_headers.clone();
+        headers.insert(
+            "X-Amz-Target",
+            HeaderValue::from_static("Logs_20140328.CreateLogStream"),
+        );
+
+        self.make_request(payload, headers).await
+    }
+
+    async fn create_log_group(&self, log_group_name: &str) -> Result<(), BoxError> {
+        let payload = json!({
+            "logGroupName": log_group_name
+        });
+
+        let mut headers = self.base_headers.clone();
+        headers.insert(
+            "X-Amz-Target",
+            HeaderValue::from_static("Logs_20140328.CreateLogGroup"),
+        );
+
+        self.make_request(payload, headers).await
+    }
+
+    async fn make_request(
+        &self,
+        payload: serde_json::Value,
+        headers: HeaderMap,
+    ) -> Result<(), BoxError> {
+        let payload_str = payload.to_string();
+        let payload_bytes = Bytes::from(payload_str.into_bytes());
+
+        // Compress the payload
+        let mut gz_vec = Vec::new();
+        let mut gz = GzEncoder::new(&payload_bytes[..], Compression::default());
+        gz.read_to_end(&mut gz_vec)
+            .map_err(|e| format!("Failed to compress request body: {}", e))?;
+        let compressed_body = Bytes::from(gz_vec);
+
+        // Sign the request
+        let signed_request = self.signer.sign(
+            self.endpoint.clone(),
+            Method::POST,
+            headers,
+            compressed_body,
+        )?;
+
+        // Make the HTTP request
+        self.send_request(signed_request, AwsEmfDecoder::default())
+            .await
+    }
+
+    async fn send_request<Dec>(
+        &self,
+        request: Request<Full<Bytes>>,
+        decoder: Dec,
+    ) -> Result<(), BoxError>
+    where
+        Dec: ResponseDecode<AwsEmfResponse>, // Reuse for decoding here, may want to abstract later
+    {
+        // Send the request using the hyper client
+        let response = self
+            .client
+            .request(request)
+            .await
+            .map_err(|e| format!("Failed to send request: {}", e))?;
+
+        // Check the response status
+        let status = response.status();
+        if status.is_success() {
+            debug!("CloudWatch API request successful: {}", status);
+            Ok(())
+        } else {
+            let (head, body) = response.into_parts();
+
+            let encoding = match head.headers.get(CONTENT_ENCODING) {
+                None => ContentEncoding::None,
+                Some(v) => match TryFrom::try_from(v) {
+                    Ok(ce) => ce,
+                    Err(e) => return Err(e),
+                },
+            };
+
+            // Collect response body for error details
+            let body_bytes = body
+                .collect()
+                .await
+                .map_err(|e| format!("Failed to read response body: {}", e))?
+                .to_bytes();
+
+            // We are looking for the ResourceNotFoundException to identify if we need to create
+            // the higher level resources, like log group. It's possible a resource already exists
+            // if it was created by another thread, so don't fail those requests.
+            //
+            // We also translate resource not found into an error for easier handling.
+            match decoder.decode(body_bytes, encoding) {
+                Ok(AwsEmfResponse::ResourceNotFoundException(_)) => {
+                    Err("ResourceNotFoundException".into())
+                }
+                Ok(AwsEmfResponse::ResourceAlreadyExistsException(_)) => Ok(()),
+                Ok(r) => Err(format!("Unexpected error: {}", r).into()),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    fn is_resource_not_found_error(&self, error: &BoxError) -> bool {
+        // Check if the error message matches ResourceNotFoundException
+        let error_str = format!("{}", error);
+        error_str.contains("ResourceNotFoundException")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aws_api::config::AwsConfig;
+    use crate::crypto::init_crypto_provider;
+
+    fn sample_aws_config() -> AwsConfig {
+        AwsConfig {
+            region: "us-east-1".to_string(),
+            aws_access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            aws_secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+            aws_session_token: None,
+        }
+    }
+
+    #[test]
+    fn test_is_resource_not_found_error() {
+        init_crypto_provider().expect("Failed to init crypto");
+        let config = sample_aws_config();
+        let cw = Cloudwatch::new(config, None, String::new(), String::new(), 0).unwrap();
+
+        let error: BoxError = "ResourceNotFoundException: Log group does not exist".into();
+        assert!(cw.is_resource_not_found_error(&error));
+
+        let error: BoxError = "Some other error".into();
+        assert!(!cw.is_resource_not_found_error(&error));
+    }
+}

--- a/src/exporters/awsemf/dim_filter.rs
+++ b/src/exporters/awsemf/dim_filter.rs
@@ -1,0 +1,203 @@
+use tower::BoxError;
+use wildcard::{Wildcard, WildcardBuilder};
+
+pub(crate) struct DimensionFilter {
+    includes: Vec<Wildcard<'static, u8>>,
+    excludes: Vec<Wildcard<'static, u8>>,
+}
+
+impl DimensionFilter {
+    pub(crate) fn new(
+        include_dimensions: Vec<String>,
+        exclude_dimensions: Vec<String>,
+    ) -> Result<Self, BoxError> {
+        let includes = include_dimensions
+            .into_iter()
+            .map(|f| new_wildcard(f))
+            .collect::<Result<Vec<_>, _>>()?;
+        let excludes = exclude_dimensions
+            .into_iter()
+            .map(|f| new_wildcard(f))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { includes, excludes })
+    }
+
+    // Identify if the dimension should be included by checking the include
+    // and exclude patterns. For complex filtering, we could possibly optimize
+    // this by caching the result for common dimensions.
+    pub(crate) fn should_include(&self, dimension_name: &str) -> bool {
+        let name_bytes = dimension_name.as_bytes();
+
+        // If there are include patterns, the dimension must match at least one
+        if !self.includes.is_empty() {
+            let matches_include = self
+                .includes
+                .iter()
+                .any(|pattern| pattern.is_match(name_bytes));
+            if !matches_include {
+                return false;
+            }
+        }
+
+        // If there are exclude patterns, the dimension must not match any
+        if !self.excludes.is_empty() {
+            let matches_exclude = self
+                .excludes
+                .iter()
+                .any(|pattern| pattern.is_match(name_bytes));
+            if matches_exclude {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+fn new_wildcard(s: String) -> Result<Wildcard<'static, u8>, BoxError> {
+    // Leak the string to get 'static lifetime - this is intentional for filter patterns
+    // that are expected to live for the duration of the program
+    let leaked_bytes: &'static [u8] = Box::leak(s.into_bytes().into_boxed_slice());
+    WildcardBuilder::new(leaked_bytes)
+        .with_any_metasymbol('*' as u8) // Use * as the any symbol
+        .without_one_metasymbol() // Disable ?
+        .without_escape() // No escaping
+        .build()
+        .map_err(|e| e.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_filters_allows_all() {
+        let filter = DimensionFilter::new(vec![], vec![]).unwrap();
+
+        assert!(filter.should_include("service.name"));
+        assert!(filter.should_include("http.method"));
+    }
+
+    #[test]
+    fn test_include_exact_match() {
+        let filter = DimensionFilter::new(
+            vec!["service.name".to_string(), "http.method".to_string()],
+            vec![],
+        )
+        .unwrap();
+
+        assert!(filter.should_include("service.name"));
+        assert!(filter.should_include("http.method"));
+        assert!(!filter.should_include("other.dimension"));
+        assert!(!filter.should_include("service.version"));
+    }
+
+    #[test]
+    fn test_include_wildcard_patterns() {
+        let filter =
+            DimensionFilter::new(vec!["service.*".to_string(), "http.*".to_string()], vec![])
+                .unwrap();
+
+        assert!(filter.should_include("service.name"));
+        assert!(filter.should_include("service.version"));
+        assert!(filter.should_include("http.method"));
+        assert!(filter.should_include("http.status_code"));
+        assert!(!filter.should_include("other.dimension"));
+        assert!(!filter.should_include("db.connection"));
+    }
+
+    #[test]
+    fn test_exclude_exact_match() {
+        let filter = DimensionFilter::new(
+            vec![],
+            vec!["service.name".to_string(), "http.method".to_string()],
+        )
+        .unwrap();
+
+        assert!(!filter.should_include("service.name"));
+        assert!(!filter.should_include("http.method"));
+        assert!(filter.should_include("other.dimension"));
+        assert!(filter.should_include("service.version"));
+    }
+
+    #[test]
+    fn test_exclude_wildcard_patterns() {
+        let filter =
+            DimensionFilter::new(vec![], vec!["service.*".to_string(), "http.*".to_string()])
+                .unwrap();
+
+        assert!(!filter.should_include("service.name"));
+        assert!(!filter.should_include("service.version"));
+        assert!(!filter.should_include("http.method"));
+        assert!(!filter.should_include("http.status_code"));
+        assert!(filter.should_include("other.dimension"));
+        assert!(filter.should_include("db.connection"));
+    }
+
+    #[test]
+    fn test_include_and_exclude_combined() {
+        let filter = DimensionFilter::new(
+            vec!["service.*".to_string()],
+            vec!["service.internal".to_string()],
+        )
+        .unwrap();
+
+        assert!(filter.should_include("service.name"));
+        assert!(filter.should_include("service.version"));
+        assert!(!filter.should_include("service.internal")); // excluded
+        assert!(!filter.should_include("http.method")); // not included
+        assert!(!filter.should_include("other.dimension")); // not included
+    }
+
+    #[test]
+    fn test_include_and_exclude_wildcard_combined() {
+        let filter = DimensionFilter::new(
+            vec!["*".to_string()],                                 // include all
+            vec!["internal.*".to_string(), "debug.*".to_string()], // exclude internal and debug
+        )
+        .unwrap();
+
+        assert!(filter.should_include("service.name"));
+        assert!(filter.should_include("http.method"));
+        assert!(!filter.should_include("internal.metric"));
+        assert!(!filter.should_include("debug.info"));
+        assert!(!filter.should_include("internal.counter"));
+    }
+
+    #[test]
+    fn test_partial_wildcard_patterns() {
+        let filter =
+            DimensionFilter::new(vec!["*_total".to_string(), "cpu_*".to_string()], vec![]).unwrap();
+
+        assert!(filter.should_include("requests_total"));
+        assert!(filter.should_include("errors_total"));
+        assert!(filter.should_include("cpu_usage"));
+        assert!(filter.should_include("cpu_percent"));
+        assert!(!filter.should_include("requests_count"));
+        assert!(!filter.should_include("memory_usage"));
+    }
+
+    #[test]
+    fn test_case_sensitive_matching() {
+        let filter = DimensionFilter::new(vec!["Service.*".to_string()], vec![]).unwrap();
+
+        assert!(filter.should_include("Service.Name"));
+        assert!(!filter.should_include("service.name")); // lowercase doesn't match
+        assert!(!filter.should_include("SERVICE.NAME")); // uppercase doesn't match
+    }
+
+    #[test]
+    fn test_complex_exclude_priority() {
+        // Include service.* but exclude service.internal.*
+        let filter = DimensionFilter::new(
+            vec!["service.*".to_string()],
+            vec!["service.internal.*".to_string()],
+        )
+        .unwrap();
+
+        assert!(filter.should_include("service.name"));
+        assert!(filter.should_include("service.version"));
+        assert!(!filter.should_include("service.internal.debug"));
+        assert!(!filter.should_include("service.internal.metric"));
+    }
+}

--- a/src/exporters/awsemf/response_interceptor.rs
+++ b/src/exporters/awsemf/response_interceptor.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tower::util::ServiceExt;
+use tower::{BoxError, Service};
+use tracing::warn;
+
+use super::cloudwatch::Cloudwatch;
+use super::errors::AwsEmfResponse;
+use crate::exporters::http::response::Response;
+
+/// Middleware that intercepts responses from the client layer and potentially
+/// invokes methods on CloudwatchAPI before passing the response to the retry layer
+#[derive(Clone)]
+pub(crate) struct ResponseInterceptor<S> {
+    inner: S,
+    cloudwatch_api: Arc<Cloudwatch>,
+}
+
+impl<S> ResponseInterceptor<S> {
+    pub(crate) fn new(inner: S, cloudwatch_api: Arc<Cloudwatch>) -> Self {
+        Self {
+            inner,
+            cloudwatch_api,
+        }
+    }
+}
+
+impl<S, ReqBody> Service<http::Request<ReqBody>> for ResponseInterceptor<S>
+where
+    S: Service<http::Request<ReqBody>, Response = Response<AwsEmfResponse>, Error = BoxError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = Response<AwsEmfResponse>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let cloudwatch_api = self.cloudwatch_api.clone();
+
+        Box::pin(async move {
+            // Call the inner service (timeout -> client)
+            let response = inner.ready().await?.call(req).await;
+
+            if let Ok(resp) = &response {
+                // Call CloudwatchAPI method based on the response
+                if let Err(e) = process_response(cloudwatch_api, resp).await {
+                    warn!("Failed to process response with CloudWatch API: {}", e);
+                    // Continue with original response even if CloudWatch processing fails
+                }
+            }
+
+            response
+        })
+    }
+}
+
+async fn process_response(
+    cloudwatch_api: Arc<Cloudwatch>,
+    response: &Response<AwsEmfResponse>,
+) -> Result<(), BoxError> {
+    let body = match response {
+        crate::exporters::http::response::Response::Http(_, Some(body)) => body,
+        crate::exporters::http::response::Response::Grpc(_, Some(body)) => body,
+        _ => return Ok(()), // No body to process
+    };
+
+    match body {
+        AwsEmfResponse::ResourceNotFoundException(_) => {
+            // Resource not found - maybe create log group/stream
+            cloudwatch_api.create_stream().await?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}

--- a/src/init/awsemf_exporter.rs
+++ b/src/init/awsemf_exporter.rs
@@ -40,6 +40,13 @@ pub struct AwsEmfExporterArgs {
     )]
     pub log_stream_name: String,
 
+    /// CloudWatch log group retention
+    #[arg(
+        long("awsemf-exporter-log-retention"),
+        env = "ROTEL_AWSEMF_EXPORTER_LOG_RETENTION"
+    )]
+    pub log_retention: Option<u16>,
+
     /// CloudWatch metrics namespace
     #[arg(
         long("awsemf-exporter-namespace"),
@@ -79,6 +86,7 @@ impl Default for AwsEmfExporterArgs {
             custom_endpoint: None,
             log_group_name: "/metrics/default".to_string(),
             log_stream_name: "otel-stream".to_string(),
+            log_retention: None,
             namespace: None,
             retain_initial_value_of_delta_metric: false,
             include_dimensions: Vec::new(),

--- a/src/init/awsemf_exporter.rs
+++ b/src/init/awsemf_exporter.rs
@@ -54,6 +54,22 @@ pub struct AwsEmfExporterArgs {
         default_value = "false"
     )]
     pub retain_initial_value_of_delta_metric: bool,
+
+    /// Dimensions include list
+    #[arg(
+        long("awsemf-exporter-include-dimensions"),
+        env = "ROTEL_AWSEMF_EXPORTER_INCLUDE_DIMENSIONS",
+        value_delimiter = ','
+    )]
+    pub include_dimensions: Vec<String>,
+
+    /// Dimensions exclude list
+    #[arg(
+        long("awsemf-exporter-exclude-dimensions"),
+        env = "ROTEL_AWSEMF_EXPORTER_EXCLUDE_DIMENSIONS",
+        value_delimiter = ','
+    )]
+    pub exclude_dimensions: Vec<String>,
 }
 
 impl Default for AwsEmfExporterArgs {
@@ -65,6 +81,8 @@ impl Default for AwsEmfExporterArgs {
             log_stream_name: "otel-stream".to_string(),
             namespace: None,
             retain_initial_value_of_delta_metric: false,
+            include_dimensions: Vec::new(),
+            exclude_dimensions: Vec::new(),
         }
     }
 }

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -281,6 +281,8 @@ impl TryIntoConfig for ExporterArgs {
                     .with_region(awsemf.region)
                     .with_log_group_name(awsemf.log_group_name.clone())
                     .with_log_stream_name(awsemf.log_stream_name.clone())
+                    .with_include_dimensions(awsemf.include_dimensions.clone())
+                    .with_exclude_dimensions(awsemf.exclude_dimensions.clone())
                     .with_retain_initial_value_of_delta_metric(
                         awsemf.retain_initial_value_of_delta_metric,
                     );
@@ -498,6 +500,7 @@ fn args_from_env_prefix(exporter_type: &str, prefix: &str) -> Result<ExporterArg
                 Ok(args) => args,
                 Err(e) => return Err(format!("failed to parse AWS EMF config: {}", e).into()),
             };
+
             Ok(ExporterArgs::Awsemf(args))
         }
         #[cfg(feature = "rdkafka")]

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -287,6 +287,10 @@ impl TryIntoConfig for ExporterArgs {
                         awsemf.retain_initial_value_of_delta_metric,
                     );
 
+                if let Some(log_retention) = &awsemf.log_retention {
+                    builder = builder.with_log_retention(*log_retention);
+                }
+
                 if let Some(namespace) = &awsemf.namespace {
                     builder = builder.with_namespace(namespace.clone());
                 }


### PR DESCRIPTION
This adds a simple filtering mechanism for reducing the dimensions that will be populated in Cloudwatch Metrics, while leaving the remaining dimensions in the logs. This can help reduce costs of high cardinality dimensions while allowing the dimensions to be queried later.

For example:

- `--awsemf-exporter-include-dimensions service.*,http.*`
- `--awsemf-exporter-exclude-dimensions *.internal`

With these options, here's how the following attributes would be handled:

- `service.name`: included
- `http.method`: included
- `http.internal`: excluded
- `telemetry.sdk.language`: excluded

Resolves: #170 