### PR TITLE
AWSEMF: Auto create log stream and log groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ are automatically sourced from Rotel's environment on startup.
 | --awsemf-exporter-custom-endpoint                      |                  |                  |
 | --awsemf-exporter-log-group-name                       | /metrics/default |                  |
 | --awsemf-exporter-log-stream-name                      | otel-stream      |                  |
+| --awsemf-exporter-log-retention                        | 0                |                  |
 | --awsemf-exporter-namespace                            |                  |                  |
 | --awsemf-exporter-retain-initial-value-of-delta-metric | false            |                  |
 | --awsemf-exporter-include-dimensions                   |                  |                  |
@@ -293,13 +294,14 @@ With these options, here's how the following attributes would be handled:
 - `http.internal`: excluded
 - `telemetry.sdk.language`: excluded
 
-
 **NOTE**:
 
 - At the moment the log group and log stream must exist or the exporter will fail to send logs.
 - If `--awsemf-exporter-retain-initial-value-of-delta-metric` is true, then the initial value of a delta metric is retained when calculating deltas.
 - If the namespace is not specified, Rotel will look for `service.namespace` and `service.name` in the resource attributes and use those. If those
   don't exist, it will fall back to a namespace of _default_.
+- Log retention is specified in days, with zero meaning never expire. Valid values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545,
+  731, 1827, 2192, 2557, 2922, 3288, or 3653.
 
 ### Kafka exporter configuration (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ With these options, here's how the following attributes would be handled:
 
 **NOTE**:
 
-- At the moment the log group and log stream must exist or the exporter will fail to send logs.
+- If the log stream or log group do not exist, the exporter will attempt to create them automatically. Make sure that the credentials have the
+  right IAM permissions.
 - If `--awsemf-exporter-retain-initial-value-of-delta-metric` is true, then the initial value of a delta metric is retained when calculating deltas.
 - If the namespace is not specified, Rotel will look for `service.namespace` and `service.name` in the resource attributes and use those. If those
   don't exist, it will fall back to a namespace of _default_.

--- a/src/exporters/awsemf/cloudwatch.rs
+++ b/src/exporters/awsemf/cloudwatch.rs
@@ -1,0 +1,246 @@
+use crate::aws_api::auth::{AwsRequestSigner, SystemClock};
+use crate::aws_api::config::AwsConfig;
+use crate::exporters::http::client::{ResponseDecode, build_hyper_client};
+use crate::exporters::http::tls::Config;
+use crate::exporters::http::types::ContentEncoding;
+use bytes::Bytes;
+use flate2::Compression;
+use flate2::bufread::GzEncoder;
+use http::header::{CONTENT_ENCODING, CONTENT_TYPE};
+use http::{HeaderMap, HeaderValue, Method, Request, Uri};
+use http_body_util::{BodyExt, Full};
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::Client as HyperClient;
+use hyper_util::client::legacy::connect::HttpConnector;
+use serde_json::json;
+use std::io::Read;
+use tower::BoxError;
+use tracing::{debug, error, warn};
+
+use super::{AwsEmfDecoder, AwsEmfResponse};
+
+pub(crate) struct Cloudwatch {
+    signer: AwsRequestSigner<SystemClock>,
+    endpoint: Uri,
+    base_headers: HeaderMap,
+    log_group: String,
+    log_stream: String,
+    client: HyperClient<HttpsConnector<HttpConnector>, Full<Bytes>>,
+}
+
+impl Cloudwatch {
+    pub(crate) fn new(
+        aws_config: AwsConfig,
+        endpoint: Option<String>,
+        log_group: String,
+        log_stream: String,
+    ) -> Result<Self, BoxError> {
+        let endpoint_url =
+            endpoint.unwrap_or_else(|| format!("https://logs.{}.amazonaws.com", aws_config.region));
+
+        let endpoint: Uri = endpoint_url
+            .parse()
+            .map_err(|e| format!("Invalid CloudWatch endpoint: {}", e))?;
+
+        let region = aws_config.region.clone();
+        let signer = AwsRequestSigner::new("logs", &region, aws_config, SystemClock);
+
+        let mut base_headers = HeaderMap::new();
+        base_headers.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+        base_headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/x-amz-json-1.1"),
+        );
+
+        // Use the existing HTTP client builder
+        let client = build_hyper_client(Config::default(), false)?;
+
+        Ok(Self {
+            signer,
+            endpoint,
+            base_headers,
+            log_group,
+            log_stream,
+            client,
+        })
+    }
+
+    /// Called when a resource (log group/stream) is not found
+    /// Log stream/group are set statically for entire runtime, but we may want to support
+    /// dynamic names in the future.
+    pub(crate) async fn create_stream(&self) -> Result<(), BoxError> {
+        debug!(
+            "Attempting to create log stream: {} in group: {}",
+            self.log_stream, self.log_group
+        );
+
+        match self
+            .create_log_stream(&self.log_group, &self.log_stream)
+            .await
+        {
+            Ok(_) => {
+                debug!("Successfully created log stream: {}", self.log_stream);
+                Ok(())
+            }
+            Err(e) => {
+                if self.is_resource_not_found_error(&e) {
+                    warn!(
+                        "Log group not found, attempting to create: {}",
+                        self.log_group
+                    );
+
+                    // Try to create the log group first
+                    self.create_log_group(&self.log_group).await?;
+
+                    // Now try to create the log stream again
+                    self.create_log_stream(&self.log_group, &self.log_stream)
+                        .await?;
+
+                    debug!("Successfully created log group and stream");
+                    Ok(())
+                } else {
+                    error!("Failed to create log stream: {}", e);
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    async fn create_log_stream(
+        &self,
+        log_group_name: &str,
+        log_stream_name: &str,
+    ) -> Result<(), BoxError> {
+        let payload = json!({
+            "logGroupName": log_group_name,
+            "logStreamName": log_stream_name
+        });
+
+        let mut headers = self.base_headers.clone();
+        headers.insert(
+            "X-Amz-Target",
+            HeaderValue::from_static("Logs_20140328.CreateLogStream"),
+        );
+
+        self.make_request(payload, headers).await
+    }
+
+    async fn create_log_group(&self, log_group_name: &str) -> Result<(), BoxError> {
+        let payload = json!({
+            "logGroupName": log_group_name
+        });
+
+        let mut headers = self.base_headers.clone();
+        headers.insert(
+            "X-Amz-Target",
+            HeaderValue::from_static("Logs_20140328.CreateLogGroup"),
+        );
+
+        self.make_request(payload, headers).await
+    }
+
+    async fn make_request(
+        &self,
+        payload: serde_json::Value,
+        headers: HeaderMap,
+    ) -> Result<(), BoxError> {
+        let payload_str = payload.to_string();
+        let payload_bytes = Bytes::from(payload_str.into_bytes());
+
+        // Compress the payload
+        let mut gz_vec = Vec::new();
+        let mut gz = GzEncoder::new(&payload_bytes[..], Compression::default());
+        gz.read_to_end(&mut gz_vec)
+            .map_err(|e| format!("Failed to compress request body: {}", e))?;
+        let compressed_body = Bytes::from(gz_vec);
+
+        // Sign the request
+        let signed_request = self.signer.sign(
+            self.endpoint.clone(),
+            Method::POST,
+            headers,
+            compressed_body,
+        )?;
+
+        // Make the HTTP request
+        self.send_request(signed_request, AwsEmfDecoder::default())
+            .await
+    }
+
+    async fn send_request<Dec>(
+        &self,
+        request: Request<Full<Bytes>>,
+        decoder: Dec,
+    ) -> Result<(), BoxError>
+    where
+        Dec: ResponseDecode<AwsEmfResponse>, // Reuse for decoding here, may want to abstract later
+    {
+        // Send the request using the hyper client
+        let response = self
+            .client
+            .request(request)
+            .await
+            .map_err(|e| format!("Failed to send request: {}", e))?;
+
+        // Check the response status
+        let status = response.status();
+        if status.is_success() {
+            debug!("CloudWatch API request successful: {}", status);
+            Ok(())
+        } else {
+            // Collect response body for error details
+            let body_bytes = response
+                .into_body()
+                .collect()
+                .await
+                .map_err(|e| format!("Failed to read response body: {}", e))?
+                .to_bytes();
+
+            // We are looking for the ResourceNotFoundException to identify if we need to create
+            // the higher level resources, like log group. We also translate this into an error
+            // for easier handling.
+            match decoder.decode(body_bytes, ContentEncoding::Gzip) {
+                Ok(AwsEmfResponse::ResourceNotFoundException(_)) => {
+                    Err("ResourceNotFoundException".into())
+                }
+                Ok(r) => Err(format!("Unexpected error: {}", r).into()),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    fn is_resource_not_found_error(&self, error: &BoxError) -> bool {
+        // Check if the error message matches ResourceNotFoundException
+        let error_str = format!("{}", error);
+        error_str.contains("ResourceNotFoundException")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aws_api::config::AwsConfig;
+    use crate::crypto::init_crypto_provider;
+
+    fn sample_aws_config() -> AwsConfig {
+        AwsConfig {
+            region: "us-east-1".to_string(),
+            aws_access_key_id: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            aws_secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+            aws_session_token: None,
+        }
+    }
+
+    #[test]
+    fn test_is_resource_not_found_error() {
+        init_crypto_provider().expect("Failed to init crypto");
+        let config = sample_aws_config();
+        let cw = Cloudwatch::new(config, None, String::new(), String::new()).unwrap();
+
+        let error: BoxError = "ResourceNotFoundException: Log group does not exist".into();
+        assert!(cw.is_resource_not_found_error(&error));
+
+        let error: BoxError = "Some other error".into();
+        assert!(!cw.is_resource_not_found_error(&error));
+    }
+}

--- a/src/exporters/awsemf/mod.rs
+++ b/src/exporters/awsemf/mod.rs
@@ -67,6 +67,7 @@ pub struct AwsEmfExporterConfig {
     pub region: Region,
     pub log_group_name: String,
     pub log_stream_name: String,
+    pub log_retention: u16,
     pub namespace: Option<String>,
     pub custom_endpoint: Option<String>,
     pub retain_initial_value_of_delta_metric: bool,
@@ -81,6 +82,7 @@ impl Default for AwsEmfExporterConfig {
             region: Region::UsEast1,
             log_group_name: "/metrics/default".to_string(),
             log_stream_name: "otel-stream".to_string(),
+            log_retention: 0,
             namespace: None,
             custom_endpoint: None,
             retain_initial_value_of_delta_metric: false,
@@ -120,6 +122,11 @@ impl AwsEmfExporterConfigBuilder {
 
     pub fn with_log_stream_name<S: Into<String>>(mut self, log_stream_name: S) -> Self {
         self.config.log_stream_name = log_stream_name.into();
+        self
+    }
+
+    pub fn with_log_retention(mut self, log_retention: u16) -> Self {
+        self.config.log_retention = log_retention;
         self
     }
 
@@ -190,6 +197,7 @@ impl AwsEmfExporterBuilder {
             self.config.custom_endpoint.clone(),
             self.config.log_group_name.clone(),
             self.config.log_stream_name.clone(),
+            self.config.log_retention,
         )?);
 
         // Build service stack: retry -> response_interceptor -> timeout -> client

--- a/src/exporters/awsemf/mod.rs
+++ b/src/exporters/awsemf/mod.rs
@@ -16,7 +16,7 @@ use crate::topology::flush_control::FlushReceiver;
 use bytes::Bytes;
 
 use dim_filter::DimensionFilter;
-use errors::{AwsEmfDecoder, AwsEmfResponse};
+use errors::{AwsEmfDecoder, AwsEmfResponse, is_retryable_error};
 use flume::r#async::RecvStream;
 use http::Request;
 use http_body_util::Full;
@@ -188,7 +188,7 @@ impl AwsEmfExporterBuilder {
         let req_builder =
             RequestBuilder::new(transformer, aws_config.clone(), self.config.clone())?;
 
-        let retry_layer = RetryPolicy::new(self.config.retry_config, None);
+        let retry_layer = RetryPolicy::new(self.config.retry_config, Some(is_retryable_error));
         let retry_broadcast = retry_layer.retry_broadcast();
 
         // Create CloudWatch API instance

--- a/src/exporters/awsemf/mod.rs
+++ b/src/exporters/awsemf/mod.rs
@@ -229,3 +229,300 @@ impl AwsEmfExporterBuilder {
         Ok(exp)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate utilities;
+
+    use crate::aws_api::config::AwsConfig;
+    use crate::bounded_channel::{BoundedReceiver, bounded};
+    use crate::exporters::awsemf::{AwsEmfExporterConfigBuilder, ExporterType};
+    use crate::exporters::crypto_init_tests::init_crypto;
+    use crate::exporters::http::retry::RetryConfig;
+    use crate::exporters::shared::aws::Region;
+    use httpmock::prelude::*;
+    use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
+    use std::time::Duration;
+    use tokio::join;
+    use tokio_test::{assert_err, assert_ok};
+    use tokio_util::sync::CancellationToken;
+    use utilities::otlp::FakeOTLP;
+
+    #[tokio::test]
+    async fn success_and_retry() {
+        init_crypto();
+        let server = MockServer::start();
+        let addr = format!("http://127.0.0.1:{}", server.port());
+
+        let hello_mock = server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body("{}");
+        });
+
+        let (btx, brx) = bounded::<Vec<ResourceMetrics>>(100);
+        let config = AwsConfig::from_env();
+        let exporter = new_exporter(addr, brx, config, None);
+
+        let cancellation_token = CancellationToken::new();
+
+        let cancel_clone = cancellation_token.clone();
+        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await });
+
+        let metrics = FakeOTLP::metrics_service_request();
+        btx.send(metrics.resource_metrics).await.unwrap();
+        drop(btx);
+        let res = join!(jh);
+        assert_ok!(res.0.unwrap());
+
+        hello_mock.assert();
+
+        // Test retry scenario with 429 status
+        let server = MockServer::start();
+        let addr = format!("http://127.0.0.1:{}", server.port());
+
+        let hello_mock = server.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(429)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"__type":"ServiceUnavailableException","message":"Rate exceeded"}"#);
+        });
+
+        let (btx, brx) = bounded::<Vec<ResourceMetrics>>(100);
+        let config = AwsConfig::from_env();
+        let exporter = new_exporter(addr, brx, config, None);
+
+        let cancellation_token = CancellationToken::new();
+
+        let cancel_clone = cancellation_token.clone();
+        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await });
+
+        let metrics = FakeOTLP::metrics_service_request();
+        btx.send(metrics.resource_metrics).await.unwrap();
+        drop(btx);
+        let res = join!(jh);
+        assert_err!(res.0.unwrap()); // failed to drain
+
+        assert!(hello_mock.hits() >= 3); // somewhat timing dependent
+    }
+
+    #[tokio::test]
+    async fn resource_not_found_triggers_creation() {
+        init_crypto();
+        let server = MockServer::start();
+        let addr = format!("http://127.0.0.1:{}", server.port());
+
+        // First request returns ResourceNotFoundException
+        let resource_not_found_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.PutLogEvents");
+            then.status(400)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"__type":"ResourceNotFoundException","message":"The specified log group does not exist."}"#);
+        });
+
+        // Mock for creating log stream
+        let create_log_stream_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.CreateLogStream");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body("{}");
+        });
+
+        // Because create log stream succeeds, the following will not be called
+
+        // Mock for creating log group
+        let create_log_group_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.CreateLogGroup");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body("{}");
+        });
+
+        // Retention mock
+        let retention_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.PutRetentionPolicy");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"nextSequenceToken":"12345"}"#);
+        });
+
+        let (btx, brx) = bounded::<Vec<ResourceMetrics>>(100);
+        let config = AwsConfig::from_env();
+        let exporter = new_exporter(addr, brx, config, None);
+
+        let cancellation_token = CancellationToken::new();
+
+        let cancel_clone = cancellation_token.clone();
+        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await });
+
+        let metrics = FakeOTLP::metrics_service_request();
+        btx.send(metrics.resource_metrics).await.unwrap();
+        drop(btx);
+        let res = join!(jh);
+        assert_err!(res.0.unwrap());
+
+        // Verify the calls made
+        assert!(resource_not_found_mock.hits() > 0);
+        assert!(create_log_stream_mock.hits() > 0);
+        create_log_group_mock.assert_hits(0);
+        retention_mock.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn resource_already_exists_is_handled() {
+        init_crypto();
+        let server = MockServer::start();
+        let addr = format!("http://127.0.0.1:{}", server.port());
+
+        // First request returns ResourceNotFoundException
+        let put_log_events_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.PutLogEvents");
+            then.status(400)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"__type":"ResourceNotFoundException","message":"The specified log stream does not exist."}"#);
+        });
+
+        // Mock for creating log stream that returns resource already exists
+        let create_log_stream_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.CreateLogStream");
+            then.status(400)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"__type":"ResourceAlreadyExistsException","message":"The specified log stream already exists."}"#);
+        });
+
+        // should not be hit
+        let create_log_group_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.CreateLogGroup");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body("{}");
+        });
+
+        let (btx, brx) = bounded::<Vec<ResourceMetrics>>(100);
+        let config = AwsConfig::from_env();
+        let exporter = new_exporter(addr, brx, config, None);
+
+        let cancellation_token = CancellationToken::new();
+
+        let cancel_clone = cancellation_token.clone();
+        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await });
+
+        let metrics = FakeOTLP::metrics_service_request();
+        btx.send(metrics.resource_metrics).await.unwrap();
+        drop(btx);
+        let res = join!(jh);
+        assert_err!(res.0.unwrap());
+
+        // Verify the calls were made
+        assert!(put_log_events_mock.hits() > 0);
+        assert!(create_log_stream_mock.hits() > 0);
+        create_log_group_mock.assert_hits(0);
+    }
+
+    #[tokio::test]
+    async fn log_group_retention() {
+        init_crypto();
+        let server = MockServer::start();
+        let addr = format!("http://127.0.0.1:{}", server.port());
+
+        // First request returns ResourceNotFoundException
+        let put_logs_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.PutLogEvents");
+            then.status(400)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"__type":"ResourceNotFoundException","message":"The specified log stream does not exist."}"#);
+        });
+
+        // Mock for creating log stream
+        let create_log_stream_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.CreateLogStream");
+            then.status(400)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"__type":"ResourceNotFoundException","message":"The specified log group does not exist."}"#);
+        });
+
+        // Mock for creating log group
+        let create_log_group_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.CreateLogGroup");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body("{}");
+        });
+
+        // Retention mock
+        let retention_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .header("x-amz-target", "Logs_20140328.PutRetentionPolicy");
+            then.status(200)
+                .header("content-type", "application/x-amz-json-1.1")
+                .body(r#"{"nextSequenceToken":"12345"}"#);
+        });
+
+        let (btx, brx) = bounded::<Vec<ResourceMetrics>>(100);
+        let config = AwsConfig::from_env();
+        let exporter = new_exporter(addr, brx, config, Some(3));
+
+        let cancellation_token = CancellationToken::new();
+
+        let cancel_clone = cancellation_token.clone();
+        let jh = tokio::spawn(async move { exporter.start(cancel_clone).await });
+
+        let metrics = FakeOTLP::metrics_service_request();
+        btx.send(metrics.resource_metrics).await.unwrap();
+        drop(btx);
+        let res = join!(jh);
+        assert_err!(res.0.unwrap());
+
+        // Verify the calls were made
+        assert!(put_logs_mock.hits() > 0);
+        assert!(create_log_stream_mock.hits() > 0);
+        assert!(create_log_group_mock.hits() > 0);
+        assert!(retention_mock.hits() > 0);
+    }
+
+    fn new_exporter<'a>(
+        addr: String,
+        brx: BoundedReceiver<Vec<ResourceMetrics>>,
+        aws_config: AwsConfig,
+        log_retention: Option<u16>,
+    ) -> ExporterType<'a, ResourceMetrics> {
+        let mut builder = AwsEmfExporterConfigBuilder::new()
+            .with_region(Region::UsEast1)
+            .with_custom_endpoint(addr)
+            .with_log_group_name("test-log-group".to_string())
+            .with_log_stream_name("test-log-stream".to_string())
+            .with_retry_config(RetryConfig {
+                initial_backoff: Duration::from_millis(10),
+                max_backoff: Duration::from_millis(50),
+                max_elapsed_time: Duration::from_millis(50),
+            });
+
+        if let Some(log_retention) = &log_retention {
+            builder = builder.with_log_retention(*log_retention);
+        }
+
+        builder.build().build(brx, None, aws_config).unwrap()
+    }
+}

--- a/src/exporters/awsemf/response_interceptor.rs
+++ b/src/exporters/awsemf/response_interceptor.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tower::util::ServiceExt;
+use tower::{BoxError, Service};
+use tracing::warn;
+
+use super::cloudwatch::Cloudwatch;
+use super::errors::AwsEmfResponse;
+use crate::exporters::http::response::Response;
+
+/// Middleware that intercepts responses from the client layer and potentially
+/// invokes methods on CloudwatchAPI before passing the response to the retry layer
+#[derive(Clone)]
+pub(crate) struct ResponseInterceptor<S> {
+    inner: S,
+    cloudwatch_api: Arc<Cloudwatch>,
+}
+
+impl<S> ResponseInterceptor<S> {
+    pub(crate) fn new(inner: S, cloudwatch_api: Arc<Cloudwatch>) -> Self {
+        Self {
+            inner,
+            cloudwatch_api,
+        }
+    }
+}
+
+impl<S, ReqBody> Service<http::Request<ReqBody>> for ResponseInterceptor<S>
+where
+    S: Service<http::Request<ReqBody>, Response = Response<AwsEmfResponse>, Error = BoxError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = Response<AwsEmfResponse>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let cloudwatch_api = self.cloudwatch_api.clone();
+
+        Box::pin(async move {
+            // Call the inner service (timeout -> client)
+            let response = inner.ready().await?.call(req).await;
+
+            if let Ok(resp) = &response {
+                // Call CloudwatchAPI method based on the response
+                if let Err(e) = process_response(cloudwatch_api, resp).await {
+                    warn!("Failed to process response with CloudWatch API: {}", e);
+                    // Continue with original response even if CloudWatch processing fails
+                }
+            }
+
+            response
+        })
+    }
+}
+
+async fn process_response(
+    cloudwatch_api: Arc<Cloudwatch>,
+    response: &Response<AwsEmfResponse>,
+) -> Result<(), BoxError> {
+    let body = match response {
+        crate::exporters::http::response::Response::Http(_, Some(body)) => body,
+        crate::exporters::http::response::Response::Grpc(_, Some(body)) => body,
+        _ => return Ok(()), // No body to process
+    };
+
+    match body {
+        AwsEmfResponse::ResourceNotFoundException(_) => {
+            // Resource not found - maybe create log group/stream
+            cloudwatch_api.create_stream().await?;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}

--- a/src/init/awsemf_exporter.rs
+++ b/src/init/awsemf_exporter.rs
@@ -40,6 +40,13 @@ pub struct AwsEmfExporterArgs {
     )]
     pub log_stream_name: String,
 
+    /// CloudWatch log group retention
+    #[arg(
+        long("awsemf-exporter-log-retention"),
+        env = "ROTEL_AWSEMF_EXPORTER_LOG_RETENTION"
+    )]
+    pub log_retention: Option<u16>,
+
     /// CloudWatch metrics namespace
     #[arg(
         long("awsemf-exporter-namespace"),
@@ -79,6 +86,7 @@ impl Default for AwsEmfExporterArgs {
             custom_endpoint: None,
             log_group_name: "/metrics/default".to_string(),
             log_stream_name: "otel-stream".to_string(),
+            log_retention: None,
             namespace: None,
             retain_initial_value_of_delta_metric: false,
             include_dimensions: Vec::new(),

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -287,6 +287,10 @@ impl TryIntoConfig for ExporterArgs {
                         awsemf.retain_initial_value_of_delta_metric,
                     );
 
+                if let Some(log_retention) = &awsemf.log_retention {
+                    builder = builder.with_log_retention(*log_retention);
+                }
+
                 if let Some(namespace) = &awsemf.namespace {
                     builder = builder.with_namespace(namespace.clone());
                 }


### PR DESCRIPTION
This PR matches the behavior for the AWSEMF exporter by auto creating the EMF log stream and log groups if the PutLogEvents API fails with ResourceNotFound.

Added the log retention setting to set the log group retention when creating.

Depends on #171 

Resolves: #161 