### PR TITLE
Make CH request timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ and traces.
 | --clickhouse-exporter-table-prefix    | otel    |             |
 | --clickhouse-exporter-compression     | lz4     | none, lz4   |
 | --clickhouse-exporter-async-insert    | true    | true, false |
+| --clickhouse-exporter-request-timeout | 5s      |             |
 | --clickhouse-exporter-enable-json     |         |             |
 | --clickhouse-exporter-json-underscore |         |             |
 | --clickhouse-exporter-user            |         |             |

--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -76,6 +76,16 @@ pub struct ClickhouseExporterArgs {
         default_value = "false"
     )]
     pub json_underscore: bool,
+
+    /// Clickhouse Exporter request timeout
+    #[arg(
+        id("CLICKHOUSE_EXPORTER_REQUEST_TIMEOUT"),
+        long("clickhouse-exporter-request-timeout"),
+        env = "ROTEL_CLICKHOUSE_EXPORTER_REQUEST_TIMEOUT",
+        default_value = "5s",
+        value_parser = humantime::parse_duration
+    )]
+    pub request_timeout: std::time::Duration,
 }
 
 impl Default for ClickhouseExporterArgs {
@@ -90,6 +100,7 @@ impl Default for ClickhouseExporterArgs {
             async_insert: "true".to_string(),
             enable_json: false,
             json_underscore: false,
+            request_timeout: std::time::Duration::from_secs(5),
         }
     }
 }

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -242,7 +242,8 @@ impl TryIntoConfig for ExporterArgs {
                 .with_compression(ch.compression)
                 .with_async_insert(async_insert)
                 .with_json(ch.enable_json)
-                .with_json_underscore(ch.json_underscore);
+                .with_json_underscore(ch.json_underscore)
+                .with_request_timeout(ch.request_timeout);
 
                 if let Some(user) = &ch.user {
                     cfg_builder = cfg_builder.with_user(user.clone());


### PR DESCRIPTION
Allow the Clickhouse request timeout to be configured with `--clickhouse-exporter-request-timeout`. Defaults to the previous 5 seconds.

Resolves: #134 