### PR TITLE
clone resource on split in BatchSplittable

### DIFF
--- a/src/topology/batch.rs
+++ b/src/topology/batch.rs
@@ -148,6 +148,9 @@ mod tests {
         assert!(resp.is_ok());
         let spans = resp.unwrap().unwrap();
         assert_eq!(10, spans.size_of());
+        for rs in spans {
+            assert!(rs.resource.is_some())
+        }
         // Grab what's left in the batch
         let leftover = batch.take_batch();
         assert_eq!(2, leftover.size_of());
@@ -171,8 +174,11 @@ mod tests {
         let second_request = FakeOTLP::metrics_service_request_with_metrics(1, 7);
         let resp = batch.offer(second_request.resource_metrics);
         assert!(resp.is_ok());
-        let spans = resp.unwrap().unwrap();
-        assert_eq!(10, spans.size_of());
+        let metrics = resp.unwrap().unwrap();
+        assert_eq!(10, metrics.size_of());
+        for rm in metrics {
+            assert!(rm.resource.is_some())
+        }
         // Grab what's left in the batch
         let leftover = batch.take_batch();
         assert_eq!(2, leftover.size_of());
@@ -196,8 +202,11 @@ mod tests {
         let second_request = FakeOTLP::logs_service_request_with_logs(1, 7);
         let resp = batch.offer(second_request.resource_logs);
         assert!(resp.is_ok());
-        let spans = resp.unwrap().unwrap();
-        assert_eq!(10, spans.size_of());
+        let logs = resp.unwrap().unwrap();
+        assert_eq!(10, logs.size_of());
+        for rl in logs {
+            assert!(rl.resource.is_some())
+        }
         // Grab what's left in the batch
         let leftover = batch.take_batch();
         assert_eq!(2, leftover.size_of());

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -2,9 +2,9 @@
 
 use crate::bounded_channel::{BoundedReceiver, BoundedSender};
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
-use crate::topology::flush_control::{conditional_flush, FlushReceiver};
-use flume::r#async::SendFut;
+use crate::topology::flush_control::{FlushReceiver, conditional_flush};
 use flume::SendError;
+use flume::r#async::SendFut;
 use opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
@@ -13,7 +13,7 @@ use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
 #[cfg(feature = "pyo3")]
-use rotel_sdk::model::{register_processor, PythonProcessable};
+use rotel_sdk::model::{PythonProcessable, register_processor};
 #[cfg(feature = "pyo3")]
 use std::env;
 use std::error::Error;

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -2,9 +2,9 @@
 
 use crate::bounded_channel::{BoundedReceiver, BoundedSender};
 use crate::topology::batch::{BatchConfig, BatchSizer, BatchSplittable, NestedBatch};
-use crate::topology::flush_control::{FlushReceiver, conditional_flush};
-use flume::SendError;
+use crate::topology::flush_control::{conditional_flush, FlushReceiver};
 use flume::r#async::SendFut;
+use flume::SendError;
 use opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
@@ -13,7 +13,7 @@ use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
 #[cfg(feature = "pyo3")]
-use rotel_sdk::model::{PythonProcessable, register_processor};
+use rotel_sdk::model::{register_processor, PythonProcessable};
 #[cfg(feature = "pyo3")]
 use std::env;
 use std::error::Error;
@@ -423,11 +423,11 @@ impl BatchSplittable for ResourceSpans {
                 split_scope_spans.push(ss)
             }
         }
-        let mut rs = ResourceSpans::default();
-        rs.scope_spans = split_scope_spans;
-        rs.schema_url = self.schema_url.clone();
-        rs.resource = rs.resource.clone();
-        rs
+        ResourceSpans {
+            scope_spans: split_scope_spans,
+            schema_url: self.schema_url.clone(),
+            resource: self.resource.clone(),
+        }
     }
 }
 
@@ -488,11 +488,11 @@ impl BatchSplittable for ResourceMetrics {
                 split_scope_metrics.push(sm)
             }
         }
-        let mut rs = ResourceMetrics::default();
-        rs.scope_metrics = split_scope_metrics;
-        rs.schema_url = self.schema_url.clone();
-        rs.resource = rs.resource.clone();
-        rs
+        ResourceMetrics {
+            scope_metrics: split_scope_metrics,
+            schema_url: self.schema_url.clone(),
+            resource: self.resource.clone(),
+        }
     }
 }
 
@@ -540,11 +540,11 @@ impl BatchSplittable for ResourceLogs {
                 split_scope_logs.push(sl)
             }
         }
-        let mut rs = ResourceLogs::default();
-        rs.scope_logs = split_scope_logs;
-        rs.schema_url = self.schema_url.clone();
-        rs.resource = rs.resource.clone();
-        rs
+        ResourceLogs {
+            scope_logs: split_scope_logs,
+            schema_url: self.schema_url.clone(),
+            resource: self.resource.clone(),
+        }
     }
 }
 

--- a/utilities/Cargo.lock
+++ b/utilities/Cargo.lock
@@ -225,17 +225,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
@@ -253,12 +242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,18 +253,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -412,22 +389,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -519,9 +486,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768ee97dc5cd695a4dd4a69a0678fb42789666b5a89e8c0af48bb06c6e427120"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -533,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "base64",
  "hex",
@@ -544,22 +511,20 @@ dependencies = [
  "prost",
  "serde",
  "tonic",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.0",
+ "rand",
  "serde_json",
  "thiserror",
 ]
@@ -660,34 +625,13 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
  "zerocopy 0.8.24",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -697,16 +641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
+ "rand_core",
 ]
 
 [[package]]
@@ -715,7 +650,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom",
 ]
 
 [[package]]
@@ -811,6 +746,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "base64",
@@ -897,17 +838,16 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
- "pin-project",
+ "indexmap",
  "pin-project-lite",
- "rand 0.8.5",
  "slab",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",


### PR DESCRIPTION
Completes: STR-3555

BatchSplittable implementations needs to clone the resource of the ResourceSpans/Metrics/Logs that it's currently splitting when it returns a subset of the data to help fill the batch. We're likely not hitting this condition as we haven't seen it in practice or heard reports of it, but we should promptly cut a release after landing as this change ensures we don't accidentally publish an empty Resource on very large payloads from the receiver.

Side Note: I'm not entirely sure why the Cargo.lock change in util is sneaking in. I know you were looking at updating crates attempting to reduce duplicates. Wondering if we potentially have some conflict between osx and linux dev environments.