### PR TITLE
Configurable concurrency

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -6,8 +6,9 @@ Rotel depends on the latest Rust toolchain, we recommend [rustup](https://rustup
 * gcc or another compiler with linker for libc
 * cmake
 * openssl
-* protoc
+* protobuf-compiler
 * libzstd-dev
+* libclang-dev
 
 ## Building and running
 

--- a/src/exporters/http/request_builder_mapper.rs
+++ b/src/exporters/http/request_builder_mapper.rs
@@ -33,6 +33,7 @@ where
 
     req_builder: ReqBuilder,
     encoding_futures: FuturesOrdered<JoinHandle<Result<ReqBuilder::Output, BoxError>>>,
+    max_concurrent_encoders: usize,
 }
 
 impl<InStr, Resource, Payload, ReqBuilder>
@@ -43,9 +44,16 @@ where
     <ReqBuilder as BuildRequest<Resource, Payload>>::Output: IntoIterator<Item = Request<Payload>>,
 {
     pub fn new(input: InStr, req_builder: ReqBuilder) -> Self {
+        let max_concurrent_encoders = std::env::var("ROTEL_MAX_CONCURRENT_ENCODERS")
+            .ok()
+            .and_then(|s| if s.trim().is_empty() { None } else { Some(s) })
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(MAX_CONCURRENT_ENCODERS);
+
         Self {
             input: input.fuse(),
             req_builder,
+            max_concurrent_encoders,
             encoding_futures: FuturesOrdered::new(),
         }
     }
@@ -69,7 +77,7 @@ where
         // start as many encoding futures as we can
         loop {
             // We are at the limit of encoding futures
-            if this.encoding_futures.len() >= MAX_CONCURRENT_ENCODERS {
+            if this.encoding_futures.len() >= *this.max_concurrent_encoders {
                 break;
             }
 


### PR DESCRIPTION
Pulling in these overrides for concurrency. They are really only needed at extreme loads, so for now skipping documentation of them as they were mostly used in performance testing.

These are a global override for all exporters, longer term we should make these per-exporter configurable.

Update developing list of pkg dependencies. 