### PR TITLE
Clickhouse exporter perf improvements for metrics/logs

### DIFF
--- a/src/exporters/clickhouse/schema.rs
+++ b/src/exporters/clickhouse/schema.rs
@@ -130,21 +130,18 @@ pub fn get_log_row_col_keys() -> String {
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "PascalCase")]
-pub struct MetricsMeta {
-    pub(crate) resource_attributes: MapOrJson<'static>,
-    pub(crate) resource_schema_url: String,
-    pub(crate) scope_name: String,
-    pub(crate) scope_version: String,
-    pub(crate) scope_attributes: MapOrJson<'static>,
+pub struct MetricsMeta<'a> {
+    pub(crate) resource_attributes: &'a MapOrJson<'a>,
+    pub(crate) resource_schema_url: &'a str,
+    pub(crate) scope_name: &'a str,
+    pub(crate) scope_version: &'a str,
+    pub(crate) scope_attributes: &'a MapOrJson<'a>,
     pub(crate) scope_dropped_attr_count: u32,
-    pub(crate) scope_schema_url: String,
-    pub(crate) service_name: String,
-    pub(crate) metric_name: String,
-    pub(crate) metric_description: String,
-    pub(crate) metric_unit: String,
-    pub(crate) attributes: MapOrJson<'static>,
-    pub(crate) start_time_unix: u64,
-    pub(crate) time_unix: u64,
+    pub(crate) scope_schema_url: &'a str,
+    pub(crate) service_name: &'a str,
+    pub(crate) metric_name: &'a str,
+    pub(crate) metric_description: &'a str,
+    pub(crate) metric_unit: &'a str,
 }
 
 pub fn get_metrics_meta_col_keys<'a>() -> Vec<&'a str> {
@@ -160,9 +157,6 @@ pub fn get_metrics_meta_col_keys<'a>() -> Vec<&'a str> {
         "MetricName",
         "MetricDescription",
         "MetricUnit",
-        "Attributes",
-        "StartTimeUnix",
-        "TimeUnix",
     ]
 }
 
@@ -195,7 +189,11 @@ pub fn get_metrics_exemplars_col_keys<'a>() -> Vec<&'a str> {
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsSumRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: &'a MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta<'a>,
+
+    pub(crate) attributes: &'a MapOrJson<'a>,
+    pub(crate) start_time_unix: u64,
+    pub(crate) time_unix: u64,
 
     pub(crate) value: f64,
     pub(crate) flags: u32,
@@ -210,6 +208,7 @@ pub struct MetricsSumRow<'a> {
 pub fn get_metrics_sum_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
+        vec!["Attributes", "StartTimeUnix", "TimeUnix"],
         vec!["Value", "Flags", "AggregationTemporality", "IsMonotonic"],
         get_metrics_exemplars_col_keys(),
     ]
@@ -222,7 +221,11 @@ pub fn get_metrics_sum_row_col_keys() -> String {
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsGaugeRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: &'a MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta<'a>,
+
+    pub(crate) attributes: &'a MapOrJson<'a>,
+    pub(crate) start_time_unix: u64,
+    pub(crate) time_unix: u64,
 
     pub(crate) value: f64,
     pub(crate) flags: u32,
@@ -234,6 +237,7 @@ pub struct MetricsGaugeRow<'a> {
 pub fn get_metrics_gauge_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
+        vec!["Attributes", "StartTimeUnix", "TimeUnix"],
         vec!["Value", "Flags"],
         get_metrics_exemplars_col_keys(),
     ]
@@ -246,7 +250,11 @@ pub fn get_metrics_gauge_row_col_keys() -> String {
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsHistogramRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: &'a MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta<'a>,
+
+    pub(crate) attributes: &'a MapOrJson<'a>,
+    pub(crate) start_time_unix: u64,
+    pub(crate) time_unix: u64,
 
     pub(crate) count: u64,
     pub(crate) sum: f64,
@@ -265,6 +273,7 @@ pub struct MetricsHistogramRow<'a> {
 pub fn get_metrics_histogram_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
+        vec!["Attributes", "StartTimeUnix", "TimeUnix"],
         vec![
             "Count",
             "Sum",
@@ -286,7 +295,11 @@ pub fn get_metrics_histogram_row_col_keys() -> String {
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsExpHistogramRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: &'a MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta<'a>,
+
+    pub(crate) attributes: &'a MapOrJson<'a>,
+    pub(crate) start_time_unix: u64,
+    pub(crate) time_unix: u64,
 
     pub(crate) count: u64,
     pub(crate) sum: f64,
@@ -310,6 +323,7 @@ pub struct MetricsExpHistogramRow<'a> {
 pub fn get_metrics_exp_histogram_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
+        vec!["Attributes", "StartTimeUnix", "TimeUnix"],
         vec![
             "Count",
             "Sum",
@@ -335,7 +349,11 @@ pub fn get_metrics_exp_histogram_row_col_keys() -> String {
 #[serde(rename_all = "PascalCase")]
 pub struct MetricsSummaryRow<'a> {
     #[serde(flatten)]
-    pub(crate) meta: &'a MetricsMeta,
+    pub(crate) meta: &'a MetricsMeta<'a>,
+
+    pub(crate) attributes: &'a MapOrJson<'a>,
+    pub(crate) start_time_unix: u64,
+    pub(crate) time_unix: u64,
 
     pub(crate) count: u64,
     pub(crate) sum: f64,
@@ -351,6 +369,7 @@ pub struct MetricsSummaryRow<'a> {
 pub fn get_metrics_summary_row_col_keys() -> String {
     let fields = [
         get_metrics_meta_col_keys(),
+        vec!["Attributes", "StartTimeUnix", "TimeUnix"],
         vec![
             "Count",
             "Sum",

--- a/src/exporters/clickhouse/schema.rs
+++ b/src/exporters/clickhouse/schema.rs
@@ -90,19 +90,19 @@ pub fn get_span_row_col_keys() -> String {
 #[serde(rename_all = "PascalCase")]
 pub struct LogRecordRow<'a> {
     pub(crate) timestamp: u64,
-    pub(crate) trace_id: String,
-    pub(crate) span_id: String,
+    pub(crate) trace_id: &'a str,
+    pub(crate) span_id: &'a str,
     pub(crate) trace_flags: u8,
     pub(crate) severity_text: String,
     pub(crate) severity_number: u8,
-    pub(crate) service_name: String,
+    pub(crate) service_name: &'a str,
     pub(crate) body: String,
-    pub(crate) resource_schema_url: String,
-    pub(crate) resource_attributes: MapOrJson<'a>,
-    pub(crate) scope_schema_url: String,
-    pub(crate) scope_name: String,
-    pub(crate) scope_version: String,
-    pub(crate) scope_attributes: MapOrJson<'a>,
+    pub(crate) resource_schema_url: &'a str,
+    pub(crate) resource_attributes: &'a MapOrJson<'a>,
+    pub(crate) scope_schema_url: &'a str,
+    pub(crate) scope_name: &'a str,
+    pub(crate) scope_version: &'a str,
+    pub(crate) scope_attributes: &'a MapOrJson<'a>,
     pub(crate) log_attributes: MapOrJson<'a>,
 }
 

--- a/src/exporters/clickhouse/transform_logs.rs
+++ b/src/exporters/clickhouse/transform_logs.rs
@@ -2,7 +2,7 @@ use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayload
 use crate::exporters::clickhouse::request_builder::TransformPayload;
 use crate::exporters::clickhouse::request_mapper::RequestType;
 use crate::exporters::clickhouse::schema::LogRecordRow;
-use crate::exporters::clickhouse::transformer::{Transformer, find_attribute};
+use crate::exporters::clickhouse::transformer::{Transformer, encode_id, find_attribute};
 use crate::otlp::cvattr;
 use crate::otlp::cvattr::ConvertedAttrValue;
 use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
@@ -17,8 +17,10 @@ impl TransformPayload<ResourceLogs> for Transformer {
         let mut payload_builder = ClickhousePayloadBuilder::new(self.compression.clone());
         for rl in input {
             let res_attrs = rl.resource.unwrap_or_default().attributes;
-            let res_attrs = cvattr::convert(&res_attrs);
+            let res_attrs = cvattr::convert_into(res_attrs);
             let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+            let res_attrs_field = self.transform_attrs(&res_attrs);
+
             let res_schema_url = rl.schema_url;
 
             for sl in rl.scope_logs {
@@ -26,34 +28,41 @@ impl TransformPayload<ResourceLogs> for Transformer {
                     Some(scope) => (
                         scope.name,
                         scope.version,
-                        cvattr::convert(&scope.attributes),
+                        cvattr::convert_into(scope.attributes),
                     ),
                     None => (String::new(), String::new(), Vec::new()),
                 };
 
+                let scope_attrs = self.transform_attrs(&scope_attrs);
+
                 for log in sl.log_records {
-                    let log_attrs = cvattr::convert(&log.attributes);
+                    let log_attrs = cvattr::convert_into(log.attributes);
 
                     let body_conv: Option<ConvertedAttrValue> = match log.body {
                         None => None,
                         Some(av) => av.value.map(|v| v.into()),
                     };
 
+                    let mut trace_id_ar = [0u8; 32];
+                    let mut span_id_ar = [0u8; 16];
+                    let trace_id = encode_id(&log.trace_id, &mut trace_id_ar);
+                    let span_id = encode_id(&log.span_id, &mut span_id_ar);
+
                     let row = LogRecordRow {
                         timestamp: log.time_unix_nano,
-                        trace_id: hex::encode(log.trace_id),
-                        span_id: hex::encode(log.span_id),
+                        trace_id,
+                        span_id,
                         trace_flags: (log.flags & 0x000000FF) as u8,
                         severity_text: log.severity_text,
                         severity_number: (log.severity_number & 0x000000FF) as u8,
-                        service_name: service_name.clone(),
+                        service_name: &service_name,
                         body: body_conv.map(|av| av.to_string()).unwrap_or_default(),
-                        resource_schema_url: res_schema_url.clone(),
-                        resource_attributes: self.transform_attrs(&res_attrs),
-                        scope_schema_url: sl.schema_url.clone(),
-                        scope_name: scope_name.clone(),
-                        scope_version: scope_version.clone(),
-                        scope_attributes: self.transform_attrs(&scope_attrs),
+                        resource_schema_url: &res_schema_url,
+                        resource_attributes: &res_attrs_field,
+                        scope_schema_url: &sl.schema_url,
+                        scope_name: &scope_name,
+                        scope_version: &scope_version,
+                        scope_attributes: &scope_attrs,
                         log_attributes: self.transform_attrs(&log_attrs),
                     };
 

--- a/src/exporters/clickhouse/transform_metrics.rs
+++ b/src/exporters/clickhouse/transform_metrics.rs
@@ -76,8 +76,8 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                                         exemplars: self.parse_exemplars(&dp.exemplars),
                                     };
 
-                                    let e = payloads.entry(RequestType::MetricsSum).or_insert(
-                                        ClickhousePayloadBuilder::new(self.compression.clone()),
+                                    let e = payloads.entry(RequestType::MetricsSum).or_insert_with(
+                                        || ClickhousePayloadBuilder::new(self.compression.clone()),
                                     );
 
                                     e.add_row(&row)?;
@@ -99,9 +99,11 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                                         exemplars: self.parse_exemplars(&dp.exemplars),
                                     };
 
-                                    let e = payloads.entry(RequestType::MetricsGauge).or_insert(
-                                        ClickhousePayloadBuilder::new(self.compression.clone()),
-                                    );
+                                    let e = payloads
+                                        .entry(RequestType::MetricsGauge)
+                                        .or_insert_with(|| {
+                                            ClickhousePayloadBuilder::new(self.compression.clone())
+                                        });
 
                                     e.add_row(&row)?;
                                 }
@@ -128,10 +130,11 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                                         exemplars: self.parse_exemplars(&dp.exemplars),
                                     };
 
-                                    let e =
-                                        payloads.entry(RequestType::MetricsHistogram).or_insert(
-                                            ClickhousePayloadBuilder::new(self.compression.clone()),
-                                        );
+                                    let e = payloads
+                                        .entry(RequestType::MetricsHistogram)
+                                        .or_insert_with(|| {
+                                            ClickhousePayloadBuilder::new(self.compression.clone())
+                                        });
 
                                     e.add_row(&row)?;
                                 }
@@ -174,9 +177,9 @@ impl TransformPayload<ResourceMetrics> for Transformer {
 
                                     let e = payloads
                                         .entry(RequestType::MetricsExponentialHistogram)
-                                        .or_insert(ClickhousePayloadBuilder::new(
-                                            self.compression.clone(),
-                                        ));
+                                        .or_insert_with(|| {
+                                            ClickhousePayloadBuilder::new(self.compression.clone())
+                                        });
 
                                     e.add_row(&row)?;
                                 }
@@ -207,9 +210,11 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                                         flags: dp.flags,
                                     };
 
-                                    let e = payloads.entry(RequestType::MetricsSummary).or_insert(
-                                        ClickhousePayloadBuilder::new(self.compression.clone()),
-                                    );
+                                    let e = payloads
+                                        .entry(RequestType::MetricsSummary)
+                                        .or_insert_with(|| {
+                                            ClickhousePayloadBuilder::new(self.compression.clone())
+                                        });
 
                                     e.add_row(&row)?;
                                 }

--- a/src/exporters/clickhouse/transform_metrics.rs
+++ b/src/exporters/clickhouse/transform_metrics.rs
@@ -2,8 +2,8 @@ use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayload
 use crate::exporters::clickhouse::request_builder::TransformPayload;
 use crate::exporters::clickhouse::request_mapper::RequestType;
 use crate::exporters::clickhouse::schema::{
-    MapOrJson, MetricsExemplars, MetricsExpHistogramRow, MetricsGaugeRow, MetricsHistogramRow,
-    MetricsMeta, MetricsSumRow, MetricsSummaryRow,
+    MetricsExemplars, MetricsExpHistogramRow, MetricsGaugeRow, MetricsHistogramRow, MetricsMeta,
+    MetricsSumRow, MetricsSummaryRow,
 };
 use crate::exporters::clickhouse::transformer::{Transformer, find_attribute};
 use crate::otlp::cvattr;
@@ -24,52 +24,51 @@ impl TransformPayload<ResourceMetrics> for Transformer {
 
         for rm in input {
             let res_attrs = rm.resource.unwrap_or_default().attributes;
-            let res_attrs = cvattr::convert(&res_attrs);
+            let res_attrs = cvattr::convert_into(res_attrs);
             let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+            let res_attrs_field = self.transform_attrs(&res_attrs);
 
             for sm in rm.scope_metrics {
                 let (scope_name, scope_version, scope_attrs, dropped_attr_count) = match sm.scope {
                     Some(scope) => (
                         scope.name,
                         scope.version,
-                        cvattr::convert(&scope.attributes),
+                        cvattr::convert_into(scope.attributes),
                         scope.dropped_attributes_count,
                     ),
                     None => (String::new(), String::new(), Vec::new(), 0),
                 };
 
+                let scope_attrs = self.transform_attrs(&scope_attrs);
+
                 for metric in sm.metrics {
                     if let Some(data) = metric.data {
-                        let mut meta = MetricsMeta {
-                            resource_attributes: self.transform_attrs_owned(&res_attrs),
-                            resource_schema_url: rm.schema_url.clone(),
-                            scope_name: scope_name.clone(),
-                            scope_version: scope_version.clone(),
-                            scope_attributes: self.transform_attrs_owned(&scope_attrs),
+                        let meta = MetricsMeta {
+                            resource_attributes: &res_attrs_field,
+                            resource_schema_url: &rm.schema_url,
+                            scope_name: &scope_name,
+                            scope_version: &scope_version,
+                            scope_attributes: &scope_attrs,
                             scope_dropped_attr_count: dropped_attr_count,
-                            scope_schema_url: sm.schema_url.clone(),
-                            service_name: service_name.clone(),
-                            metric_name: metric.name,
-                            metric_description: metric.description,
-                            metric_unit: metric.unit,
-                            // Placeholder values that will be replaced per data point
-                            attributes: MapOrJson::JsonOwned(HashMap::new()),
-                            start_time_unix: 0,
-                            time_unix: 0,
+                            scope_schema_url: &sm.schema_url,
+                            service_name: &service_name,
+                            metric_name: &metric.name,
+                            metric_description: &metric.description,
+                            metric_unit: &metric.unit,
                         };
 
                         match data {
                             Data::Sum(s) => {
                                 for dp in s.data_points {
-                                    let attrs = cvattr::convert(&dp.attributes);
-
-                                    meta.attributes = self.transform_attrs_owned(&attrs);
-                                    meta.start_time_unix = dp.start_time_unix_nano;
-                                    meta.time_unix = dp.time_unix_nano;
+                                    let attrs = cvattr::convert_into(dp.attributes);
+                                    let attrs = self.transform_attrs(&attrs);
 
                                     let row = MetricsSumRow {
                                         meta: &meta,
 
+                                        attributes: &attrs,
+                                        start_time_unix: dp.start_time_unix_nano,
+                                        time_unix: dp.time_unix_nano,
                                         value: get_metric_value(dp.value),
                                         flags: dp.flags,
                                         aggregation_temporality: s.aggregation_temporality,
@@ -86,15 +85,15 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                             }
                             Data::Gauge(g) => {
                                 for dp in g.data_points {
-                                    let attrs = cvattr::convert(&dp.attributes);
-
-                                    meta.attributes = self.transform_attrs_owned(&attrs);
-                                    meta.start_time_unix = dp.start_time_unix_nano;
-                                    meta.time_unix = dp.time_unix_nano;
+                                    let attrs = cvattr::convert_into(dp.attributes);
+                                    let attrs = self.transform_attrs(&attrs);
 
                                     let row = MetricsGaugeRow {
                                         meta: &meta,
 
+                                        attributes: &attrs,
+                                        start_time_unix: dp.start_time_unix_nano,
+                                        time_unix: dp.time_unix_nano,
                                         value: get_metric_value(dp.value),
                                         flags: dp.flags,
                                         exemplars: self.parse_exemplars(&dp.exemplars),
@@ -109,15 +108,15 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                             }
                             Data::Histogram(h) => {
                                 for dp in h.data_points {
-                                    let attrs = cvattr::convert(&dp.attributes);
-
-                                    meta.attributes = self.transform_attrs_owned(&attrs);
-                                    meta.start_time_unix = dp.start_time_unix_nano;
-                                    meta.time_unix = dp.time_unix_nano;
+                                    let attrs = cvattr::convert_into(dp.attributes);
+                                    let attrs = self.transform_attrs(&attrs);
 
                                     let row = MetricsHistogramRow {
                                         meta: &meta,
 
+                                        attributes: &attrs,
+                                        start_time_unix: dp.start_time_unix_nano,
+                                        time_unix: dp.time_unix_nano,
                                         count: dp.count,
                                         sum: dp.sum.unwrap_or(0.0),
                                         bucket_counts: dp.bucket_counts,
@@ -139,15 +138,15 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                             }
                             Data::ExponentialHistogram(e) => {
                                 for dp in e.data_points {
-                                    let attrs = cvattr::convert(&dp.attributes);
-
-                                    meta.attributes = self.transform_attrs_owned(&attrs);
-                                    meta.start_time_unix = dp.start_time_unix_nano;
-                                    meta.time_unix = dp.time_unix_nano;
+                                    let attrs = cvattr::convert_into(dp.attributes);
+                                    let attrs = self.transform_attrs(&attrs);
 
                                     let mut row = MetricsExpHistogramRow {
                                         meta: &meta,
 
+                                        attributes: &attrs,
+                                        start_time_unix: dp.start_time_unix_nano,
+                                        time_unix: dp.time_unix_nano,
                                         count: dp.count,
                                         sum: dp.sum.unwrap_or(0.0),
                                         scale: dp.scale,
@@ -184,15 +183,15 @@ impl TransformPayload<ResourceMetrics> for Transformer {
                             }
                             Data::Summary(s) => {
                                 for dp in s.data_points {
-                                    let attrs = cvattr::convert(&dp.attributes);
-
-                                    meta.attributes = self.transform_attrs_owned(&attrs);
-                                    meta.start_time_unix = dp.start_time_unix_nano;
-                                    meta.time_unix = dp.time_unix_nano;
+                                    let attrs = cvattr::convert_into(dp.attributes);
+                                    let attrs = self.transform_attrs(&attrs);
 
                                     let row = MetricsSummaryRow {
                                         meta: &meta,
 
+                                        attributes: &attrs,
+                                        start_time_unix: dp.start_time_unix_nano,
+                                        time_unix: dp.time_unix_nano,
                                         count: dp.count,
                                         sum: dp.sum,
                                         value_at_quantiles_quantile: dp

--- a/src/exporters/clickhouse/transform_traces.rs
+++ b/src/exporters/clickhouse/transform_traces.rs
@@ -2,7 +2,7 @@ use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayload
 use crate::exporters::clickhouse::request_builder::TransformPayload;
 use crate::exporters::clickhouse::request_mapper::RequestType;
 use crate::exporters::clickhouse::schema::SpanRow;
-use crate::exporters::clickhouse::transformer::{Transformer, find_attribute};
+use crate::exporters::clickhouse::transformer::{encode_id, find_attribute, Transformer};
 use crate::otlp::cvattr;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, Span};
@@ -123,20 +123,6 @@ impl TransformPayload<ResourceSpans> for Transformer {
         payload_builder
             .finish()
             .map(|payload| vec![(RequestType::Traces, payload)])
-    }
-}
-
-fn encode_id<'a>(id: &[u8], out: &'a mut [u8]) -> &'a str {
-    match hex::encode_to_slice(id, out) {
-        Ok(_) => {
-            // We can be pretty sure the encoded string is utf8 safe
-            std::str::from_utf8(out).unwrap_or_default()
-        }
-        Err(_) => {
-            // Trace and Span IDs are required to have a certain length (8 or 16 bytes), the only
-            // case this should fail is on an empty ID, like parent_span_id on a root span.
-            ""
-        }
     }
 }
 

--- a/src/exporters/clickhouse/transform_traces.rs
+++ b/src/exporters/clickhouse/transform_traces.rs
@@ -2,7 +2,7 @@ use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayload
 use crate::exporters::clickhouse::request_builder::TransformPayload;
 use crate::exporters::clickhouse::request_mapper::RequestType;
 use crate::exporters::clickhouse::schema::SpanRow;
-use crate::exporters::clickhouse::transformer::{encode_id, find_attribute, Transformer};
+use crate::exporters::clickhouse::transformer::{Transformer, encode_id, find_attribute};
 use crate::otlp::cvattr;
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
 use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, Span};

--- a/src/exporters/clickhouse/transformer.rs
+++ b/src/exporters/clickhouse/transformer.rs
@@ -109,6 +109,20 @@ pub(crate) fn find_attribute(attr: &str, attributes: &[ConvertedAttrKeyValue]) -
         .unwrap_or(String::new())
 }
 
+pub(crate) fn encode_id<'a>(id: &[u8], out: &'a mut [u8]) -> &'a str {
+    match hex::encode_to_slice(id, out) {
+        Ok(_) => {
+            // We can be pretty sure the encoded string is utf8 safe
+            std::str::from_utf8(out).unwrap_or_default()
+        }
+        Err(_) => {
+            // Trace and Span IDs are required to have a certain length (8 or 16 bytes), the only
+            // case this should fail is on an empty ID, like parent_span_id on a root span.
+            ""
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Mirror the performance improvements made for traces to logs and metrics. Quick performance tests showed a 15% improvement for logs.

The metric exemplars were left as a future exercise. There didn't seem to be a good way to make them completely copy free without some major surgery or in-lining a lot of code.
