### PR TITLE
Clarify AWS creds requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ The Rotel OTLP exporter can export to the
 [Cloudwatch OTLP endpoints](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html)
 for traces and logs. You'll need to select the HTTP protocol and enable the sigv4auth authenticator.
 
-The sigv4auth authenticator requires the AWS authentication environment variables to be set.
+The sigv4auth authenticator requires the AWS authentication environment variables to be set. At the moment this is restricted
+to credentials specified as: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN`.
 
 **Traces**
 


### PR DESCRIPTION
At the moment we require IAM user credentials, so make that clear in the documentation for sigv4auth. We plan to add support for more options in the future as part of #198 

Completes: STR-3569