### PR TITLE
Add fanout component to support multiple exporters

### DIFF
--- a/src/topology/batch_resources.rs
+++ b/src/topology/batch_resources.rs
@@ -1,0 +1,176 @@
+use opentelemetry_proto::tonic::{
+    logs::v1::{ResourceLogs, ScopeLogs},
+    metrics::v1::{ResourceMetrics, ScopeMetrics, metric::Data},
+    trace::v1::{ResourceSpans, ScopeSpans},
+};
+
+use crate::topology::batch::{BatchSizer, BatchSplittable};
+
+impl BatchSizer for ResourceSpans {
+    fn size_of(&self) -> usize {
+        self.scope_spans.iter().map(|sc| sc.spans.len()).sum()
+    }
+}
+
+impl BatchSizer for [ResourceSpans] {
+    fn size_of(&self) -> usize {
+        self.iter().map(|n| n.size_of()).sum()
+    }
+}
+
+impl BatchSplittable for ResourceSpans {
+    fn split(&mut self, split_n: usize) -> Self
+    where
+        Self: Sized,
+    {
+        let mut count_moved = 0;
+        let mut split_scope_spans = vec![];
+        while !self.scope_spans.is_empty() && count_moved < split_n {
+            // first just check and see if we can hoist all the spans in this scope span
+            let span_len = self.scope_spans[0].spans.len();
+            if span_len + count_moved <= split_n {
+                let v = self.scope_spans.remove(0);
+                split_scope_spans.push(v);
+                count_moved += span_len;
+            } else {
+                // We'll need to harvest a subset of the spans
+                let mut spans = vec![];
+                while !self.scope_spans[0].spans.is_empty() && count_moved < split_n {
+                    // Remove the span and add to the new ss
+                    let s = self.scope_spans[0].spans.remove(0);
+                    spans.push(s);
+                    count_moved += 1
+                }
+                // Now we need to clone data from this ScopeSpan for our new ScopeSpans
+                let ss = ScopeSpans {
+                    scope: self.scope_spans[0].scope.clone(),
+                    schema_url: self.scope_spans[0].schema_url.clone(),
+                    spans,
+                };
+                split_scope_spans.push(ss)
+            }
+        }
+        ResourceSpans {
+            scope_spans: split_scope_spans,
+            schema_url: self.schema_url.clone(),
+            resource: self.resource.clone(),
+        }
+    }
+}
+
+impl BatchSizer for ResourceMetrics {
+    fn size_of(&self) -> usize {
+        self.scope_metrics
+            .iter()
+            .flat_map(|sc| &sc.metrics)
+            .map(|m| match &m.data {
+                None => 0,
+                Some(d) => match d {
+                    Data::Gauge(g) => g.data_points.len(),
+                    Data::Sum(s) => s.data_points.len(),
+                    Data::Histogram(h) => h.data_points.len(),
+                    Data::ExponentialHistogram(e) => e.data_points.len(),
+                    Data::Summary(s) => s.data_points.len(),
+                },
+            })
+            .sum()
+    }
+}
+
+impl BatchSizer for [ResourceMetrics] {
+    fn size_of(&self) -> usize {
+        self.iter().map(|n| n.size_of()).sum()
+    }
+}
+
+impl BatchSplittable for ResourceMetrics {
+    fn split(&mut self, split_n: usize) -> Self
+    where
+        Self: Sized,
+    {
+        let mut count_moved = 0;
+        let mut split_scope_metrics = vec![];
+        while !self.scope_metrics.is_empty() && count_moved < split_n {
+            // first just check and see if we can hoist all the spans in this scope span
+            let metric_len = self.scope_metrics[0].metrics.len();
+            if metric_len + count_moved <= split_n {
+                let v = self.scope_metrics.remove(0);
+                split_scope_metrics.push(v);
+                count_moved += metric_len;
+            } else {
+                // We'll need to harvest a subset of the spans
+                let mut metrics = vec![];
+                while !self.scope_metrics[0].metrics.is_empty() && count_moved < split_n {
+                    // Remove the span and add to the new ss
+                    let s = self.scope_metrics[0].metrics.remove(0);
+                    metrics.push(s);
+                    count_moved += 1
+                }
+                // Now we need to clone data from this ScopeSpan for our new ScopeSpans
+                let sm = ScopeMetrics {
+                    scope: self.scope_metrics[0].scope.clone(),
+                    schema_url: self.scope_metrics[0].schema_url.clone(),
+                    metrics,
+                };
+                split_scope_metrics.push(sm)
+            }
+        }
+        ResourceMetrics {
+            scope_metrics: split_scope_metrics,
+            schema_url: self.schema_url.clone(),
+            resource: self.resource.clone(),
+        }
+    }
+}
+
+impl BatchSizer for ResourceLogs {
+    fn size_of(&self) -> usize {
+        self.scope_logs.iter().map(|sc| sc.log_records.len()).sum()
+    }
+}
+
+impl BatchSizer for [ResourceLogs] {
+    fn size_of(&self) -> usize {
+        self.iter().map(|n| n.size_of()).sum()
+    }
+}
+
+impl BatchSplittable for ResourceLogs {
+    fn split(&mut self, split_n: usize) -> Self
+    where
+        Self: Sized,
+    {
+        let mut count_moved = 0;
+        let mut split_scope_logs = vec![];
+        while !self.scope_logs.is_empty() && count_moved < split_n {
+            // first just check and see if we can hoist all the spans in this scope span
+            let span_len = self.scope_logs[0].log_records.len();
+            if span_len + count_moved <= split_n {
+                let v = self.scope_logs.remove(0);
+                split_scope_logs.push(v);
+                count_moved += span_len;
+            } else {
+                // We'll need to harvest a subset of the spans
+                let mut log_records = vec![];
+                while !self.scope_logs[0].log_records.is_empty() && count_moved < split_n {
+                    // Remove the span and add to the new ss
+                    let s = self.scope_logs[0].log_records.remove(0);
+                    log_records.push(s);
+                    count_moved += 1
+                }
+                // Now we need to clone data from this ScopeSpan for our new ScopeSpans
+                let sl = ScopeLogs {
+                    scope: self.scope_logs[0].scope.clone(),
+                    schema_url: self.scope_logs[0].schema_url.clone(),
+                    log_records,
+                };
+                split_scope_logs.push(sl)
+            }
+        }
+        ResourceLogs {
+            scope_logs: split_scope_logs,
+            schema_url: self.schema_url.clone(),
+            resource: self.resource.clone(),
+        }
+    }
+}

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::bounded_channel::BoundedSender;
+
+/// A fanout component that distributes messages to multiple consumers.
+///
+/// The fanout component takes a message and sends it to all configured consumers.
+/// The message is cloned for all consumers except the last one to avoid unnecessary cloning.
+///
+/// # Example
+///
+/// ```rust
+/// use rotel::bounded_channel::bounded;
+/// use rotel::topology::fanout::Fanout;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     // Create multiple consumers
+///     let (tx1, mut rx1) = bounded(10);
+///     let (tx2, mut rx2) = bounded(10);
+///     let (tx3, mut rx3) = bounded(10);
+///
+///     // Create fanout with the consumers
+///     let fanout = Fanout::new(vec![tx1, tx2, tx3]);
+///
+///     // Send a message to all consumers
+///     let message = vec![1, 2, 3, 4, 5];
+///     fanout.async_send(message.clone()).await?;
+///
+///     // All consumers receive the same message (sent sequentially)
+///     assert_eq!(Some(message.clone()), rx1.next().await);
+///     assert_eq!(Some(message.clone()), rx2.next().await);
+///     assert_eq!(Some(message), rx3.next().await);
+///
+///     Ok(())
+/// }
+/// ```
+pub struct Fanout<T> {
+    consumers: Vec<BoundedSender<Vec<T>>>,
+}
+
+/// Builder for constructing a Fanout component.
+///
+/// Provides a convenient way to add consumers one at a time and build the final Fanout instance.
+///
+/// # Example
+///
+/// ```rust
+/// use rotel::bounded_channel::bounded;
+/// use rotel::topology::fanout::FanoutBuilder;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let (tx1, _rx1) = bounded(10);
+///     let (tx2, _rx2) = bounded(10);
+///
+///     let fanout = FanoutBuilder::new()
+///         .add_tx(tx1)
+///         .add_tx(tx2)
+///         .build()?;
+///
+///     // Use fanout...
+///     Ok(())
+/// }
+/// ```
+#[derive(Default)]
+pub struct FanoutBuilder<T> {
+    consumers: Vec<BoundedSender<Vec<T>>>,
+}
+
+impl<T> Fanout<T>
+where
+    T: Clone,
+{
+    /// Creates a new fanout component with the given consumers.
+    ///
+    /// # Arguments
+    /// * `consumers` - A vector of BoundedSender consumers that will receive the messages
+    ///
+    /// # Panics
+    /// Panics if the consumers vector is empty.
+    pub fn new(consumers: Vec<BoundedSender<Vec<T>>>) -> Self {
+        if consumers.is_empty() {
+            panic!("Fanout requires at least one consumer");
+        }
+
+        Self { consumers }
+    }
+
+    /// Asynchronously sends a message to all consumers sequentially.
+    ///
+    /// The message will be cloned for all consumers except the last one.
+    /// Sends to each consumer one at a time, waiting for success before
+    /// proceeding to the next consumer. If any consumer fails, the operation
+    /// stops immediately and returns an error with the index of the failed consumer.
+    ///
+    /// # Arguments
+    /// * `message` - The message to send to all consumers
+    ///
+    /// # Returns
+    /// A future that resolves to `Result<(), FanoutError>` when all sends complete.
+    /// On failure, returns `FanoutError::Disconnected` containing the index of the
+    /// first consumer that failed to receive the message.
+    pub async fn async_send(&self, message: Vec<T>) -> Result<(), FanoutError> {
+        let consumer_count = self.consumers.len();
+
+        // Send to all consumers except the last one (with cloned messages)
+        for i in 0..consumer_count - 1 {
+            match self.consumers[i].send(message.clone()).await {
+                Ok(()) => continue,
+                Err(_) => return Err(FanoutError::Disconnected(vec![i])),
+            }
+        }
+
+        // Send to the last consumer with the original message (no clone needed)
+        let last_index = consumer_count - 1;
+        match self.consumers[last_index].send(message).await {
+            Ok(()) => Ok(()),
+            Err(_) => Err(FanoutError::Disconnected(vec![last_index])),
+        }
+    }
+}
+
+impl<T> FanoutBuilder<T> {
+    /// Creates a new FanoutBuilder.
+    pub fn new() -> Self {
+        Self {
+            consumers: Vec::new(),
+        }
+    }
+
+    /// Adds a consumer to the fanout.
+    ///
+    /// # Arguments
+    /// * `tx` - A BoundedSender that will receive messages from the fanout
+    ///
+    /// # Returns
+    /// Returns self for method chaining
+    pub fn add_tx(mut self, tx: BoundedSender<Vec<T>>) -> Self {
+        self.consumers.push(tx);
+        self
+    }
+
+    /// Builds the Fanout instance.
+    ///
+    /// # Returns
+    /// Returns `Ok(Fanout<T>)` if at least one consumer has been added,
+    /// otherwise returns `Err(FanoutBuilderError::NoConsumers)`
+    pub fn build(self) -> Result<Fanout<T>, FanoutBuilderError> {
+        if self.consumers.is_empty() {
+            Err(FanoutBuilderError::NoConsumers)
+        } else {
+            Ok(Fanout {
+                consumers: self.consumers,
+            })
+        }
+    }
+}
+
+/// Error type for fanout builder operations
+#[derive(Debug, PartialEq, Eq)]
+pub enum FanoutBuilderError {
+    /// No consumers were added to the builder
+    NoConsumers,
+}
+
+impl std::fmt::Display for FanoutBuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FanoutBuilderError::NoConsumers => {
+                write!(f, "At least one consumer must be added to the fanout")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FanoutBuilderError {}
+
+/// Error type for fanout operations
+#[derive(Debug, PartialEq, Eq)]
+pub enum FanoutError {
+    /// A consumer is disconnected. Contains the index of the first consumer that failed.
+    /// Due to sequential processing, only the first failure is reported.
+    Disconnected(Vec<usize>), // index of disconnected consumer (will contain single element)
+}
+
+impl std::fmt::Display for FanoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FanoutError::Disconnected(indices) => {
+                if indices.len() == 1 {
+                    write!(f, "Consumer at index {} is disconnected", indices[0])
+                } else {
+                    write!(f, "Consumers at indices {:?} are disconnected", indices)
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for FanoutError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bounded_channel::bounded;
+
+    #[tokio::test]
+    async fn test_fanout_single_consumer() {
+        let (tx, mut rx) = bounded(10);
+        let fanout = Fanout::new(vec![tx]);
+
+        let message = vec![1, 2, 3];
+        let send_result = fanout.async_send(message.clone()).await;
+
+        assert!(send_result.is_ok());
+
+        let received = rx.next().await;
+        assert_eq!(Some(message), received);
+    }
+
+    #[tokio::test]
+    async fn test_fanout_multiple_consumers() {
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, mut rx2) = bounded(10);
+        let (tx3, mut rx3) = bounded(10);
+
+        let fanout = Fanout::new(vec![tx1, tx2, tx3]);
+
+        let message = vec![1, 2, 3];
+        let send_result = fanout.async_send(message.clone()).await;
+
+        assert!(send_result.is_ok());
+
+        // All consumers should receive the same message
+        assert_eq!(Some(message.clone()), rx1.next().await);
+        assert_eq!(Some(message.clone()), rx2.next().await);
+        assert_eq!(Some(message), rx3.next().await);
+    }
+
+    #[tokio::test]
+    async fn test_fanout_disconnected_consumer() {
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, _rx2) = bounded(10); // rx2 will be dropped
+
+        let fanout = Fanout::new(vec![tx1, tx2]);
+
+        // Drop rx2 to simulate disconnection
+        drop(_rx2);
+
+        let message = vec![1, 2, 3];
+        let send_result = fanout.async_send(message.clone()).await;
+
+        // Should get an error indicating consumer 1 (index) is disconnected
+        match send_result {
+            Err(FanoutError::Disconnected(indices)) => {
+                assert_eq!(vec![1], indices);
+            }
+            _ => panic!("Expected disconnected error"),
+        }
+
+        // First consumer should still receive the message
+        assert_eq!(Some(message), rx1.next().await);
+    }
+
+    #[tokio::test]
+    async fn test_fanout_concurrent_sends() {
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, mut rx2) = bounded(10);
+
+        let fanout = Fanout::new(vec![tx1, tx2]);
+
+        // Send multiple messages concurrently
+        let msg1 = vec![1];
+        let msg2 = vec![2];
+        let msg3 = vec![3];
+
+        let (result1, result2, result3) = tokio::join!(
+            fanout.async_send(msg1.clone()),
+            fanout.async_send(msg2.clone()),
+            fanout.async_send(msg3.clone())
+        );
+
+        assert!(result1.is_ok());
+        assert!(result2.is_ok());
+        assert!(result3.is_ok());
+
+        // Collect all messages from both receivers
+        let mut rx1_msgs = Vec::new();
+        let mut rx2_msgs = Vec::new();
+
+        for _ in 0..3 {
+            rx1_msgs.push(rx1.next().await.unwrap());
+            rx2_msgs.push(rx2.next().await.unwrap());
+        }
+
+        // Both receivers should have received all messages (order may vary)
+        rx1_msgs.sort();
+        rx2_msgs.sort();
+
+        let expected = vec![vec![1], vec![2], vec![3]];
+        assert_eq!(expected, rx1_msgs);
+        assert_eq!(expected, rx2_msgs);
+    }
+
+    #[tokio::test]
+    async fn test_fanout_sequential_sending() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        // Track the order of sends using a shared counter
+        let send_order = Arc::new(Mutex::new(Vec::new()));
+
+        // Create custom receivers that track when they receive messages
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, mut rx2) = bounded(10);
+        let (tx3, mut rx3) = bounded(10);
+
+        let fanout = Fanout::new(vec![tx1, tx2, tx3]);
+
+        let message = vec![1, 2, 3];
+
+        // Create tasks to receive and record order
+        let order1 = send_order.clone();
+        let order2 = send_order.clone();
+        let order3 = send_order.clone();
+
+        let recv_task1 = tokio::spawn(async move {
+            if let Some(_msg) = rx1.next().await {
+                order1.lock().await.push(1);
+            }
+        });
+
+        let recv_task2 = tokio::spawn(async move {
+            if let Some(_msg) = rx2.next().await {
+                order2.lock().await.push(2);
+            }
+        });
+
+        let recv_task3 = tokio::spawn(async move {
+            if let Some(_msg) = rx3.next().await {
+                order3.lock().await.push(3);
+            }
+        });
+
+        // Send the message (should be sequential)
+        let send_result = fanout.async_send(message).await;
+        assert!(send_result.is_ok());
+
+        // Wait for all receivers to complete
+        let _ = tokio::join!(recv_task1, recv_task2, recv_task3);
+
+        // Verify all consumers received the message
+        let final_order = send_order.lock().await;
+        assert_eq!(final_order.len(), 3);
+        assert!(final_order.contains(&1));
+        assert!(final_order.contains(&2));
+        assert!(final_order.contains(&3));
+    }
+
+    #[tokio::test]
+    async fn test_fanout_early_failure_stops_processing() {
+        // Test that when a consumer fails, processing stops and later consumers don't receive messages
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, _rx2) = bounded(10); // rx2 will be dropped to simulate failure
+        let (tx3, mut rx3) = bounded(10);
+
+        // Drop rx2 to make the second consumer fail
+        drop(_rx2);
+
+        let fanout = Fanout::new(vec![tx1, tx2, tx3]);
+
+        let message = vec![1, 2, 3];
+        let send_result = fanout.async_send(message.clone()).await;
+
+        // Should fail at consumer index 1 (the second consumer)
+        match send_result {
+            Err(FanoutError::Disconnected(indices)) => {
+                assert_eq!(vec![1], indices);
+            }
+            _ => panic!("Expected disconnected error at index 1"),
+        }
+
+        // First consumer should have received the message
+        assert_eq!(Some(message), rx1.next().await);
+
+        // Third consumer should NOT have received anything since processing stopped at consumer 1
+        tokio::select! {
+            msg = rx3.next() => {
+                panic!("Third consumer should not have received a message, but got: {:?}", msg);
+            }
+            _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+                // This is expected - no message should be received
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Fanout requires at least one consumer")]
+    fn test_fanout_empty_consumers() {
+        let consumers: Vec<BoundedSender<Vec<i32>>> = vec![];
+        Fanout::new(consumers);
+    }
+
+    #[test]
+    fn test_fanout_builder_basic() {
+        let (tx1, _rx1) = bounded::<Vec<i32>>(10);
+        let (tx2, _rx2) = bounded::<Vec<i32>>(10);
+
+        let fanout = FanoutBuilder::new().add_tx(tx1).add_tx(tx2).build();
+
+        assert!(fanout.is_ok());
+        let fanout: Fanout<i32> = fanout.unwrap();
+        assert_eq!(fanout.consumers.len(), 2);
+    }
+
+    #[test]
+    fn test_fanout_builder_no_consumers() {
+        let builder: FanoutBuilder<i32> = FanoutBuilder::new();
+        let result = builder.build();
+
+        match result {
+            Err(FanoutBuilderError::NoConsumers) => {
+                // This is expected
+            }
+            _ => panic!("Expected NoConsumers error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fanout_builder_functionality() {
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, mut rx2) = bounded(10);
+
+        let fanout = FanoutBuilder::new()
+            .add_tx(tx1)
+            .add_tx(tx2)
+            .build()
+            .unwrap();
+
+        let message = vec![1, 2, 3];
+        let result = fanout.async_send(message.clone()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(Some(message.clone()), rx1.next().await);
+        assert_eq!(Some(message), rx2.next().await);
+    }
+
+    #[test]
+    fn test_fanout_builder_single_consumer() {
+        let (tx, _rx) = bounded::<Vec<i32>>(10);
+
+        let fanout = FanoutBuilder::new().add_tx(tx).build();
+
+        assert!(fanout.is_ok());
+        let fanout: Fanout<i32> = fanout.unwrap();
+        assert_eq!(fanout.consumers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fanout_builder_complex_chaining() {
+        // Test more complex builder usage with multiple add_tx calls
+        let (tx1, mut rx1) = bounded(10);
+        let (tx2, mut rx2) = bounded(10);
+        let (tx3, mut rx3) = bounded(10);
+        let (tx4, mut rx4) = bounded(10);
+
+        let mut builder = FanoutBuilder::new();
+        builder = builder.add_tx(tx1);
+        builder = builder.add_tx(tx2);
+
+        let fanout = builder.add_tx(tx3).add_tx(tx4).build().unwrap();
+
+        let message = vec![42, 43, 44];
+        let result = fanout.async_send(message.clone()).await;
+
+        assert!(result.is_ok());
+
+        // All four consumers should receive the message
+        assert_eq!(Some(message.clone()), rx1.next().await);
+        assert_eq!(Some(message.clone()), rx2.next().await);
+        assert_eq!(Some(message.clone()), rx3.next().await);
+        assert_eq!(Some(message), rx4.next().await);
+    }
+}

--- a/src/topology/fanout.rs
+++ b/src/topology/fanout.rs
@@ -10,68 +10,15 @@ use std::task::{Context, Poll};
 /// The fanout component takes a message and sends it to all configured consumers.
 /// The message is cloned for all consumers except the last one to avoid unnecessary cloning.
 ///
-/// # Example
-///
-/// ```rust
-/// use rotel::bounded_channel::bounded;
-/// use rotel::topology::fanout::Fanout;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Create multiple consumers
-///     let (tx1, mut rx1) = bounded(10);
-///     let (tx2, mut rx2) = bounded(10);
-///     let (tx3, mut rx3) = bounded(10);
-///
-///     // Create fanout with the consumers
-///     let fanout = Fanout::new(vec![tx1, tx2, tx3]);
-///
-///     // Send a message to all consumers
-///     let message = vec![1, 2, 3, 4, 5];
-///     fanout.async_send(message.clone()).await?;
-///
-///     // All consumers receive the same message (sent sequentially)
-///     assert_eq!(Some(message.clone()), rx1.next().await);
-///     assert_eq!(Some(message.clone()), rx2.next().await);
-///     assert_eq!(Some(message), rx3.next().await);
-///
-///     Ok(())
-/// }
-/// ```
 pub struct Fanout<T> {
     consumers: Vec<BoundedSender<Vec<T>>>,
 }
 
-/// Builder for constructing a Fanout component.
-///
-/// Provides a convenient way to add consumers one at a time and build the final Fanout instance.
-///
-/// # Example
-///
-/// ```rust
-/// use rotel::bounded_channel::bounded;
-/// use rotel::topology::fanout::FanoutBuilder;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let (tx1, _rx1) = bounded(10);
-///     let (tx2, _rx2) = bounded(10);
-///
-///     let fanout = FanoutBuilder::new()
-///         .add_tx(tx1)
-///         .add_tx(tx2)
-///         .build()?;
-///
-///     // Use fanout...
-///     Ok(())
-/// }
-/// ```
 #[derive(Default)]
 pub struct FanoutBuilder<T> {
     consumers: Vec<BoundedSender<Vec<T>>>,
 }
 
-/// Future returned by `async_send` that manages sequential sending to consumers
 pub struct FanoutFuture<'a, T> {
     consumers: &'a [BoundedSender<Vec<T>>],
     message: Option<Vec<T>>,
@@ -115,7 +62,7 @@ where
     /// A future that resolves to `Result<(), FanoutError>` when all sends complete.
     /// On failure, returns `FanoutError::Disconnected` containing the index of the
     /// first consumer that failed to receive the message.
-    pub fn async_send(&self, message: Vec<T>) -> FanoutFuture<'_, T> {
+    pub fn send_async(&self, message: Vec<T>) -> FanoutFuture<'_, T> {
         FanoutFuture::new(&self.consumers, message)
     }
 }
@@ -144,7 +91,6 @@ where
         let this = self.get_mut(); // Safe because FanoutFuture is Unpin
 
         loop {
-            // If we have a pending send, poll it
             if let Some(ref mut send_fut) = this.current_send {
                 let send_result = {
                     // SAFETY: We never move the SendFut after creating it
@@ -165,20 +111,15 @@ where
                         // Continue to next consumer
                     }
                     Poll::Ready(Err(_)) => {
-                        // Send failed
-                        return Poll::Ready(Err(FanoutError::Disconnected(vec![
-                            this.current_index,
-                        ])));
+                        return Poll::Ready(Err(FanoutError::Disconnected(this.current_index)));
                     }
                     Poll::Pending => {
-                        // Send is still in progress
                         return Poll::Pending;
                     }
                 }
             } else {
                 // No pending send, start sending to current consumer
                 if this.current_index >= this.consumers.len() {
-                    // All consumers processed
                     return Poll::Ready(Ok(()));
                 }
 
@@ -193,10 +134,8 @@ where
                         .clone()
                 };
 
-                // Start the send operation
                 let send_fut = this.consumers[this.current_index].send_async(message_to_send);
                 this.current_send = Some(send_fut);
-                // Loop back to poll the new send future
             }
         }
     }
@@ -262,18 +201,14 @@ impl std::error::Error for FanoutBuilderError {}
 pub enum FanoutError {
     /// A consumer is disconnected. Contains the index of the first consumer that failed.
     /// Due to sequential processing, only the first failure is reported.
-    Disconnected(Vec<usize>), // index of disconnected consumer (will contain single element)
+    Disconnected(usize),
 }
 
 impl std::fmt::Display for FanoutError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FanoutError::Disconnected(indices) => {
-                if indices.len() == 1 {
-                    write!(f, "Consumer at index {} is disconnected", indices[0])
-                } else {
-                    write!(f, "Consumers at indices {:?} are disconnected", indices)
-                }
+            FanoutError::Disconnected(index) => {
+                write!(f, "Consumer at index {} is disconnected", index)
             }
         }
     }
@@ -292,7 +227,7 @@ mod tests {
         let fanout = Fanout::new(vec![tx]);
 
         let message = vec![1, 2, 3];
-        let send_result = fanout.async_send(message.clone()).await;
+        let send_result = fanout.send_async(message.clone()).await;
 
         assert!(send_result.is_ok());
 
@@ -309,7 +244,7 @@ mod tests {
         let fanout = Fanout::new(vec![tx1, tx2, tx3]);
 
         let message = vec![1, 2, 3];
-        let send_result = fanout.async_send(message.clone()).await;
+        let send_result = fanout.send_async(message.clone()).await;
 
         assert!(send_result.is_ok());
 
@@ -330,237 +265,17 @@ mod tests {
         drop(_rx2);
 
         let message = vec![1, 2, 3];
-        let send_result = fanout.async_send(message.clone()).await;
+        let send_result = fanout.send_async(message.clone()).await;
 
         // Should get an error indicating consumer 1 (index) is disconnected
         match send_result {
-            Err(FanoutError::Disconnected(indices)) => {
-                assert_eq!(vec![1], indices);
+            Err(FanoutError::Disconnected(index)) => {
+                assert_eq!(1, index);
             }
             _ => panic!("Expected disconnected error"),
         }
 
         // First consumer should still receive the message
         assert_eq!(Some(message), rx1.next().await);
-    }
-
-    #[tokio::test]
-    async fn test_fanout_concurrent_sends() {
-        let (tx1, mut rx1) = bounded(10);
-        let (tx2, mut rx2) = bounded(10);
-
-        let fanout = Fanout::new(vec![tx1, tx2]);
-
-        // Send multiple messages concurrently
-        let msg1 = vec![1];
-        let msg2 = vec![2];
-        let msg3 = vec![3];
-
-        let (result1, result2, result3) = tokio::join!(
-            fanout.async_send(msg1.clone()),
-            fanout.async_send(msg2.clone()),
-            fanout.async_send(msg3.clone())
-        );
-
-        assert!(result1.is_ok());
-        assert!(result2.is_ok());
-        assert!(result3.is_ok());
-
-        // Collect all messages from both receivers
-        let mut rx1_msgs = Vec::new();
-        let mut rx2_msgs = Vec::new();
-
-        for _ in 0..3 {
-            rx1_msgs.push(rx1.next().await.unwrap());
-            rx2_msgs.push(rx2.next().await.unwrap());
-        }
-
-        // Both receivers should have received all messages (order may vary)
-        rx1_msgs.sort();
-        rx2_msgs.sort();
-
-        let expected = vec![vec![1], vec![2], vec![3]];
-        assert_eq!(expected, rx1_msgs);
-        assert_eq!(expected, rx2_msgs);
-    }
-
-    #[tokio::test]
-    async fn test_fanout_sequential_sending() {
-        use std::sync::Arc;
-        use tokio::sync::Mutex;
-
-        // Track the order of sends using a shared counter
-        let send_order = Arc::new(Mutex::new(Vec::new()));
-
-        // Create custom receivers that track when they receive messages
-        let (tx1, mut rx1) = bounded(10);
-        let (tx2, mut rx2) = bounded(10);
-        let (tx3, mut rx3) = bounded(10);
-
-        let fanout = Fanout::new(vec![tx1, tx2, tx3]);
-
-        let message = vec![1, 2, 3];
-
-        // Create tasks to receive and record order
-        let order1 = send_order.clone();
-        let order2 = send_order.clone();
-        let order3 = send_order.clone();
-
-        let recv_task1 = tokio::spawn(async move {
-            if let Some(_msg) = rx1.next().await {
-                order1.lock().await.push(1);
-            }
-        });
-
-        let recv_task2 = tokio::spawn(async move {
-            if let Some(_msg) = rx2.next().await {
-                order2.lock().await.push(2);
-            }
-        });
-
-        let recv_task3 = tokio::spawn(async move {
-            if let Some(_msg) = rx3.next().await {
-                order3.lock().await.push(3);
-            }
-        });
-
-        // Send the message (should be sequential)
-        let send_result = fanout.async_send(message).await;
-        assert!(send_result.is_ok());
-
-        // Wait for all receivers to complete
-        let _ = tokio::join!(recv_task1, recv_task2, recv_task3);
-
-        // Verify all consumers received the message
-        let final_order = send_order.lock().await;
-        assert_eq!(final_order.len(), 3);
-        assert!(final_order.contains(&1));
-        assert!(final_order.contains(&2));
-        assert!(final_order.contains(&3));
-    }
-
-    #[tokio::test]
-    async fn test_fanout_early_failure_stops_processing() {
-        // Test that when a consumer fails, processing stops and later consumers don't receive messages
-        let (tx1, mut rx1) = bounded(10);
-        let (tx2, _rx2) = bounded(10); // rx2 will be dropped to simulate failure
-        let (tx3, mut rx3) = bounded(10);
-
-        // Drop rx2 to make the second consumer fail
-        drop(_rx2);
-
-        let fanout = Fanout::new(vec![tx1, tx2, tx3]);
-
-        let message = vec![1, 2, 3];
-        let send_result = fanout.async_send(message.clone()).await;
-
-        // Should fail at consumer index 1 (the second consumer)
-        match send_result {
-            Err(FanoutError::Disconnected(indices)) => {
-                assert_eq!(vec![1], indices);
-            }
-            _ => panic!("Expected disconnected error at index 1"),
-        }
-
-        // First consumer should have received the message
-        assert_eq!(Some(message), rx1.next().await);
-
-        // Third consumer should NOT have received anything since processing stopped at consumer 1
-        tokio::select! {
-            msg = rx3.next() => {
-                panic!("Third consumer should not have received a message, but got: {:?}", msg);
-            }
-            _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
-                // This is expected - no message should be received
-            }
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "Fanout requires at least one consumer")]
-    fn test_fanout_empty_consumers() {
-        let consumers: Vec<BoundedSender<Vec<i32>>> = vec![];
-        Fanout::new(consumers);
-    }
-
-    #[test]
-    fn test_fanout_builder_basic() {
-        let (tx1, _rx1) = bounded::<Vec<i32>>(10);
-        let (tx2, _rx2) = bounded::<Vec<i32>>(10);
-
-        let fanout = FanoutBuilder::new().add_tx(tx1).add_tx(tx2).build();
-
-        assert!(fanout.is_ok());
-        let fanout: Fanout<i32> = fanout.unwrap();
-        assert_eq!(fanout.consumers.len(), 2);
-    }
-
-    #[test]
-    fn test_fanout_builder_no_consumers() {
-        let builder: FanoutBuilder<i32> = FanoutBuilder::new();
-        let result = builder.build();
-
-        match result {
-            Err(FanoutBuilderError::NoConsumers) => {
-                // This is expected
-            }
-            _ => panic!("Expected NoConsumers error"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_fanout_builder_functionality() {
-        let (tx1, mut rx1) = bounded(10);
-        let (tx2, mut rx2) = bounded(10);
-
-        let fanout = FanoutBuilder::new()
-            .add_tx(tx1)
-            .add_tx(tx2)
-            .build()
-            .unwrap();
-
-        let message = vec![1, 2, 3];
-        let result = fanout.async_send(message.clone()).await;
-
-        assert!(result.is_ok());
-        assert_eq!(Some(message.clone()), rx1.next().await);
-        assert_eq!(Some(message), rx2.next().await);
-    }
-
-    #[test]
-    fn test_fanout_builder_single_consumer() {
-        let (tx, _rx) = bounded::<Vec<i32>>(10);
-
-        let fanout = FanoutBuilder::new().add_tx(tx).build();
-
-        assert!(fanout.is_ok());
-        let fanout: Fanout<i32> = fanout.unwrap();
-        assert_eq!(fanout.consumers.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_fanout_builder_complex_chaining() {
-        // Test more complex builder usage with multiple add_tx calls
-        let (tx1, mut rx1) = bounded(10);
-        let (tx2, mut rx2) = bounded(10);
-        let (tx3, mut rx3) = bounded(10);
-        let (tx4, mut rx4) = bounded(10);
-
-        let mut builder = FanoutBuilder::new();
-        builder = builder.add_tx(tx1);
-        builder = builder.add_tx(tx2);
-
-        let fanout = builder.add_tx(tx3).add_tx(tx4).build().unwrap();
-
-        let message = vec![42, 43, 44];
-        let result = fanout.async_send(message.clone()).await;
-
-        assert!(result.is_ok());
-
-        // All four consumers should receive the message
-        assert_eq!(Some(message.clone()), rx1.next().await);
-        assert_eq!(Some(message.clone()), rx2.next().await);
-        assert_eq!(Some(message.clone()), rx3.next().await);
-        assert_eq!(Some(message), rx4.next().await);
     }
 }

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error};
 #[allow(dead_code)] // for the sake of the pyo3 feature
 pub struct Pipeline<T> {
     receiver: BoundedReceiver<Message<T>>,
-    fanout: Fanout<T>,
+    fanout: Fanout<Vec<T>>,
     batch_config: BatchConfig,
     processors: Vec<String>,
     flush_listener: Option<FlushReceiver>,
@@ -152,7 +152,7 @@ where
 {
     pub fn new(
         receiver: BoundedReceiver<Message<T>>,
-        fanout: Fanout<T>,
+        fanout: Fanout<Vec<T>>,
         flush_listener: Option<FlushReceiver>,
         batch_config: BatchConfig,
         processors: Vec<String>,
@@ -239,7 +239,7 @@ where
         let len_processor_modules = processor_modules.len();
         let mut flush_listener = self.flush_listener.take();
 
-        let mut send_fut: Option<FanoutFuture<T>> = None;
+        let mut send_fut: Option<FanoutFuture<Vec<T>>> = None;
 
         loop {
             select! {

--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -7,11 +7,10 @@ use crate::topology::flush_control::{FlushReceiver, conditional_flush};
 use crate::topology::payload::Message;
 use opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue};
-use opentelemetry_proto::tonic::logs::v1::{ResourceLogs, ScopeLogs};
-use opentelemetry_proto::tonic::metrics::v1::metric::Data;
-use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, ScopeMetrics};
+use opentelemetry_proto::tonic::logs::v1::ResourceLogs;
+use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics;
 use opentelemetry_proto::tonic::resource::v1::Resource;
-use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans};
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 #[cfg(feature = "pyo3")]
 use rotel_sdk::model::{PythonProcessable, register_processor};
 #[cfg(feature = "pyo3")]
@@ -265,7 +264,7 @@ where
                             .collect();
                         debug!(batch_size = to_send.len(), "Flushing a batch in timout handler");
 
-                        let fut = self.fanout.async_send(to_send);
+                        let fut = self.fanout.send_async(to_send);
                         send_fut = Some(fut);
                     }
                 },
@@ -286,7 +285,7 @@ where
                             .collect();
 
                         // We are exiting, so we just want to log the failure to send
-                        if let Err(e) = self.fanout.async_send(remain_batch).await {
+                        if let Err(e) = self.fanout.send_async(remain_batch).await {
                             error!(error = ?e, "Unable to send item while exiting, will drop data.");
                         }
 
@@ -337,7 +336,7 @@ where
                             let to_send: Vec<T> = popped.into_iter()
                                 .flat_map(|msg| msg.payload)
                                 .collect();
-                            let fut = self.fanout.async_send(to_send);
+                            let fut = self.fanout.send_async(to_send);
                             send_fut = Some(fut);
                         }
                         Ok(None) => {},
@@ -371,7 +370,7 @@ where
                                     .collect();
                                 debug!(batch_size = to_send.len(), "Flushing a batch on flush message");
 
-                                if let Err(e) = self.fanout.async_send(to_send).await {
+                                if let Err(e) = self.fanout.send_async(to_send).await {
                                     error!(error = ?e, "Unable to send item, exiting.");
                                     return Err(format!("Pipeline was unable to send downstream: {}", e).into())
                                 }
@@ -404,175 +403,6 @@ where
     match send_fut {
         None => None,
         Some(fut) => Some(fut.await),
-    }
-}
-
-impl BatchSizer for ResourceSpans {
-    fn size_of(&self) -> usize {
-        self.scope_spans.iter().map(|sc| sc.spans.len()).sum()
-    }
-}
-
-impl BatchSizer for [ResourceSpans] {
-    fn size_of(&self) -> usize {
-        self.iter().map(|n| n.size_of()).sum()
-    }
-}
-
-impl BatchSplittable for ResourceSpans {
-    fn split(&mut self, split_n: usize) -> Self
-    where
-        Self: Sized,
-    {
-        let mut count_moved = 0;
-        let mut split_scope_spans = vec![];
-        while !self.scope_spans.is_empty() && count_moved < split_n {
-            // first just check and see if we can hoist all the spans in this scope span
-            let span_len = self.scope_spans[0].spans.len();
-            if span_len + count_moved <= split_n {
-                let v = self.scope_spans.remove(0);
-                split_scope_spans.push(v);
-                count_moved += span_len;
-            } else {
-                // We'll need to harvest a subset of the spans
-                let mut spans = vec![];
-                while !self.scope_spans[0].spans.is_empty() && count_moved < split_n {
-                    // Remove the span and add to the new ss
-                    let s = self.scope_spans[0].spans.remove(0);
-                    spans.push(s);
-                    count_moved += 1
-                }
-                // Now we need to clone data from this ScopeSpan for our new ScopeSpans
-                let ss = ScopeSpans {
-                    scope: self.scope_spans[0].scope.clone(),
-                    schema_url: self.scope_spans[0].schema_url.clone(),
-                    spans,
-                };
-                split_scope_spans.push(ss)
-            }
-        }
-        ResourceSpans {
-            scope_spans: split_scope_spans,
-            schema_url: self.schema_url.clone(),
-            resource: self.resource.clone(),
-        }
-    }
-}
-
-impl BatchSizer for ResourceMetrics {
-    fn size_of(&self) -> usize {
-        self.scope_metrics
-            .iter()
-            .flat_map(|sc| &sc.metrics)
-            .map(|m| match &m.data {
-                None => 0,
-                Some(d) => match d {
-                    Data::Gauge(g) => g.data_points.len(),
-                    Data::Sum(s) => s.data_points.len(),
-                    Data::Histogram(h) => h.data_points.len(),
-                    Data::ExponentialHistogram(e) => e.data_points.len(),
-                    Data::Summary(s) => s.data_points.len(),
-                },
-            })
-            .sum()
-    }
-}
-
-impl BatchSizer for [ResourceMetrics] {
-    fn size_of(&self) -> usize {
-        self.iter().map(|n| n.size_of()).sum()
-    }
-}
-
-impl BatchSplittable for ResourceMetrics {
-    fn split(&mut self, split_n: usize) -> Self
-    where
-        Self: Sized,
-    {
-        let mut count_moved = 0;
-        let mut split_scope_metrics = vec![];
-        while !self.scope_metrics.is_empty() && count_moved < split_n {
-            // first just check and see if we can hoist all the spans in this scope span
-            let metric_len = self.scope_metrics[0].metrics.len();
-            if metric_len + count_moved <= split_n {
-                let v = self.scope_metrics.remove(0);
-                split_scope_metrics.push(v);
-                count_moved += metric_len;
-            } else {
-                // We'll need to harvest a subset of the spans
-                let mut metrics = vec![];
-                while !self.scope_metrics[0].metrics.is_empty() && count_moved < split_n {
-                    // Remove the span and add to the new ss
-                    let s = self.scope_metrics[0].metrics.remove(0);
-                    metrics.push(s);
-                    count_moved += 1
-                }
-                // Now we need to clone data from this ScopeSpan for our new ScopeSpans
-                let sm = ScopeMetrics {
-                    scope: self.scope_metrics[0].scope.clone(),
-                    schema_url: self.scope_metrics[0].schema_url.clone(),
-                    metrics,
-                };
-                split_scope_metrics.push(sm)
-            }
-        }
-        ResourceMetrics {
-            scope_metrics: split_scope_metrics,
-            schema_url: self.schema_url.clone(),
-            resource: self.resource.clone(),
-        }
-    }
-}
-
-impl BatchSizer for ResourceLogs {
-    fn size_of(&self) -> usize {
-        self.scope_logs.iter().map(|sc| sc.log_records.len()).sum()
-    }
-}
-
-impl BatchSizer for [ResourceLogs] {
-    fn size_of(&self) -> usize {
-        self.iter().map(|n| n.size_of()).sum()
-    }
-}
-
-impl BatchSplittable for ResourceLogs {
-    fn split(&mut self, split_n: usize) -> Self
-    where
-        Self: Sized,
-    {
-        let mut count_moved = 0;
-        let mut split_scope_logs = vec![];
-        while !self.scope_logs.is_empty() && count_moved < split_n {
-            // first just check and see if we can hoist all the spans in this scope span
-            let span_len = self.scope_logs[0].log_records.len();
-            if span_len + count_moved <= split_n {
-                let v = self.scope_logs.remove(0);
-                split_scope_logs.push(v);
-                count_moved += span_len;
-            } else {
-                // We'll need to harvest a subset of the spans
-                let mut log_records = vec![];
-                while !self.scope_logs[0].log_records.is_empty() && count_moved < split_n {
-                    // Remove the span and add to the new ss
-                    let s = self.scope_logs[0].log_records.remove(0);
-                    log_records.push(s);
-                    count_moved += 1
-                }
-                // Now we need to clone data from this ScopeSpan for our new ScopeSpans
-                let sl = ScopeLogs {
-                    scope: self.scope_logs[0].scope.clone(),
-                    schema_url: self.scope_logs[0].schema_url.clone(),
-                    log_records,
-                };
-                split_scope_logs.push(sl)
-            }
-        }
-        ResourceLogs {
-            scope_logs: split_scope_logs,
-            schema_url: self.schema_url.clone(),
-            resource: self.resource.clone(),
-        }
     }
 }
 

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod batch;
 pub mod debug;
+pub mod fanout;
 pub mod flush_control;
 pub mod generic_pipeline;
 pub mod payload;

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod batch;
+pub mod batch_resources;
 pub mod debug;
 pub mod fanout;
 pub mod flush_control;


### PR DESCRIPTION
This is the first step in supporting multiple exporters for the same pipeline. This includes a new fanout component that sits between the Pipeline, post batcher, and ahead of the sending queues for the exporters. It'll emit a message to multiple sending queues, cloning the message to all but the last one.

Follow on work will actually hook up multiple exporter sending queues to this, so this shouldn't change the existing behavior yet.

This takes a fairly naive approach to dual pipelines by automatically cloning the messages. This will have performance impacts at scale, so consider this initial implementation an alpha version. As we expand this support we'll look at performance optimizations to reduce the need to clone whenever possible.

Also: Moved BatchSizer and BatchSplittable impls for resource types to a separate file to reduce size/complexity of the pipeline file.
