### PR TITLE
Support multiple exporters for a pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ To quickly get started with Rotel you can leverage the bundled [Python](https://
 follow these steps:
 
 1. **Running Rotel**
-    - We use the prebuilt docker image for this example, but you can also download a binary from the
-      [releases](https://github.com/streamfold/rotel/releases) page.
-    - Execute Rotel with the following arguments. To debug metrics or logs, add
-      an additional `--debug-log metrics|logs`.
+   - We use the prebuilt docker image for this example, but you can also download a binary from the
+     [releases](https://github.com/streamfold/rotel/releases) page.
+   - Execute Rotel with the following arguments. To debug metrics or logs, add
+     an additional `--debug-log metrics|logs`.
 
    ```bash
    docker run -ti -p 4317-4318:4317-4318 streamfold/rotel --debug-log traces --exporter blackhole
    ```
 
-    - Rotel is now listening on localhost:4317 (gRPC) and localhost:4318 (HTTP).
+   - Rotel is now listening on localhost:4317 (gRPC) and localhost:4318 (HTTP).
 
 2. **Verify**
-    - Send OTLP traces to Rotel and verify that it is receiving data:
+   - Send OTLP traces to Rotel and verify that it is receiving data:
 
    ```bash
    go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest
@@ -77,7 +77,7 @@ follow these steps:
    telemetrygen traces --otlp-insecure --duration 5s
    ```
 
-    - Check the output from Rotel and you should see several "Received traces" log lines.
+   - Check the output from Rotel and you should see several "Received traces" log lines.
 
 ## Configuration
 
@@ -95,7 +95,7 @@ variable `ROTEL_OTLP_GRPC_ENDPOINT=localhost:5317`.
 Any option above that does not contain a default is considered false or unset by default.
 
 | Option                            | Default              | Options                                                            |
-|-----------------------------------|----------------------|--------------------------------------------------------------------|
+| --------------------------------- | -------------------- | ------------------------------------------------------------------ |
 | --daemon                          |                      |                                                                    |
 | --log-format                      | text                 | json                                                               |
 | --pid-file                        | /tmp/rotel-agent.pid |                                                                    |
@@ -124,7 +124,7 @@ See the section for [Multiple Exporters](#multiple-exporters) for how to configu
 The OTLP exporter is the default, or can be explicitly selected with `--exporter otlp`.
 
 | Option                                 | Default | Options    |
-|----------------------------------------|---------|------------|
+| -------------------------------------- | ------- | ---------- |
 | --otlp-exporter-endpoint               |         |            |
 | --otlp-exporter-protocol               | grpc    | grpc, http |
 | --otlp-exporter-custom-headers         |         |            |
@@ -192,7 +192,7 @@ The Datadog exporter can be selected by passing `--exporter datadog`. The Datado
 moment. For more information, see the [Datadog Exporter](src/exporters/datadog/README.md) docs.
 
 | Option                             | Default | Options                |
-|------------------------------------|---------|------------------------|
+| ---------------------------------- | ------- | ---------------------- |
 | --datadog-exporter-region          | us1     | us1, us3, us5, eu, ap1 |
 | --datadog-exporter-custom-endpoint |         |                        |
 | --datadog-exporter-api-key         |         |                        |
@@ -206,7 +206,7 @@ logs,
 and traces.
 
 | Option                                | Default | Options     |
-|---------------------------------------|---------|-------------|
+| ------------------------------------- | ------- | ----------- |
 | --clickhouse-exporter-endpoint        |         |             |
 | --clickhouse-exporter-database        | otel    |             |
 | --clickhouse-exporter-table-prefix    | otel    |             |
@@ -259,7 +259,7 @@ are
 automatically sourced from Rotel's environment on startup.
 
 | Option                             | Default   | Options          |
-|------------------------------------|-----------|------------------|
+| ---------------------------------- | --------- | ---------------- |
 | --awsxray-exporter-region          | us-east-1 | aws region codes |
 | --awsxray-exporter-custom-endpoint |           |                  |
 
@@ -277,7 +277,7 @@ AWS Credentials including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_
 are automatically sourced from Rotel's environment on startup.
 
 | Option                                                 | Default          | Options          |
-|--------------------------------------------------------|------------------|------------------|
+| ------------------------------------------------------ | ---------------- | ---------------- |
 | --awsemf-exporter-region                               | us-east-1        | aws region codes |
 | --awsemf-exporter-custom-endpoint                      |                  |                  |
 | --awsemf-exporter-log-group-name                       | /metrics/default |                  |
@@ -335,7 +335,7 @@ The Kafka exporter can be selected by passing `--exporter kafka`. The Kafka expo
 logs, and traces.
 
 | Option                                                    | Default           | Options                                                                     |
-|-----------------------------------------------------------|-------------------|-----------------------------------------------------------------------------|
+| --------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------- |
 | --kafka-exporter-brokers                                  | localhost:9092    |                                                                             |
 | --kafka-exporter-traces-topic                             | otlp_traces       |                                                                             |
 | --kafka-exporter-metrics-topic                            | otlp_metrics      |                                                                             |
@@ -482,7 +482,7 @@ out as periodic files on the local filesystem. Currently **Parquet** and
 **JSON** formats are supported.
 
 | Option                              | Default    | Description                                                                                                  |
-|-------------------------------------|------------|--------------------------------------------------------------------------------------------------------------|
+| ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------ |
 | --file-exporter-format              | parquet    | `parquet` or `json`                                                                                          |
 | --file-exporter-output-dir          | /tmp/rotel | Directory to place output files                                                                              |
 | --file-exporter-flush-interval      | 5s         | How often to flush accumulated telemetry to a new file (accepts Go-style durations like `30s`, `2m`, `1h`)   |
@@ -509,7 +509,7 @@ To enable the Kafka receiver, you must specify which telemetry types to consume 
 - `--kafka-receiver-logs` to consume logs
 
 | Option                                     | Default        | Options                                              |
-|--------------------------------------------|----------------|------------------------------------------------------|
+| ------------------------------------------ | -------------- | ---------------------------------------------------- |
 | --kafka-receiver-brokers                   | localhost:9092 | Kafka broker addresses (comma-separated)             |
 | --kafka-receiver-traces-topic              | otlp_traces    | Topic name for traces                                |
 | --kafka-receiver-metrics-topic             | otlp_metrics   | Topic name for metrics                               |
@@ -557,9 +557,9 @@ The Kafka receiver acts as a consumer and supports standard Kafka consumer confi
 **Offset Management:**
 
 - `--kafka-receiver-auto-offset-reset`: Controls behavior when no initial offset exists or the current offset is invalid
-    - `earliest`: Start consuming from the beginning of the topic
-    - `latest`: Start consuming from the end of the topic (default)
-    - `error`: Throw an error if no offset is found
+  - `earliest`: Start consuming from the beginning of the topic
+  - `latest`: Start consuming from the end of the topic (default)
+  - `error`: Throw an error if no offset is found
 
 **Session and Heartbeat Configuration:**
 
@@ -577,8 +577,8 @@ The Kafka receiver acts as a consumer and supports standard Kafka consumer confi
 
 - `--kafka-receiver-check-crcs`: Enables CRC32 checking of consumed messages for data integrity
 - `--kafka-receiver-isolation-level`: Controls which messages are visible to the consumer
-    - `read-uncommitted`: Read all messages including those from uncommitted transactions
-    - `read-committed`: Only read messages from committed transactions (default)
+  - `read-uncommitted`: Read all messages including those from uncommitted transactions
+  - `read-committed`: Only read messages from committed transactions (default)
 
 #### Security Configuration
 
@@ -663,7 +663,7 @@ logs,
 or traces). For example, `--traces-batch-max-size` will override the batch max size for traces only.
 
 | Option           | Default | Options |
-|------------------|---------|---------|
+| ---------------- | ------- | ------- |
 | --batch-max-size | 8192    |         |
 | --batch-timeout  | 200ms   |         |
 
@@ -702,8 +702,8 @@ All options should be represented as string time durations.
 ### Internal telemetry
 
 Rotel records a number of internal metrics that can help observe Rotel behavior during runtime. This telemetry is
-opt-in and must be enabled with `--enable-internal-telemetry`. Telemetry is sent to the OTLP exporter metric endpoint
-that you have configured.
+opt-in and must be enabled with `--enable-internal-telemetry`. Telemetry is sent to the exporters configured
+with the `--exporters-internal-metrics` option.
 
 **NOTE**: Internal telemetry is not sent to any outside sources and you are in full control of where this data is
 exported to.
@@ -717,7 +717,7 @@ to receive data via OTLP and consume from Kafka topics at the same time.
 The following configuration parameters enable multiple receivers:
 
 | Option      | Default | Options                           |
-|-------------|---------|-----------------------------------|
+| ----------- | ------- | --------------------------------- |
 | --receiver  | otlp    | otlp, kafka                       |
 | --receivers |         | comma-separated list (otlp,kafka) |
 
@@ -798,17 +798,18 @@ rotel start --exporter otlp --otlp-exporter-endpoint localhost:4317
 
 Rotel can be configured to support exporting to multiple destinations across multiple exporter types.
 
-The following additional configuration parameters set up support for multiple exporters. Similar to the options above,
-all
-CLI arguments can be passed as environment variables as well. It is not possible to set `--exporter` and `--exporters`
-at the same time.
+The following additional configuration parameters set up support for multiple
+exporters. Similar to the options above, all CLI arguments can be passed as
+environment variables as well. It is not possible to set `--exporter` and
+`--exporters` at the same time.
 
-| Option              | Default | Options                          |
-|---------------------|---------|----------------------------------|
-| --exporters         |         | name:type pairs, comma-separated |
-| --exporters-traces  |         | exporter name                    |
-| --exporters-metrics |         | exporter name                    |
-| --exporters-logs    |         | exporter name                    |
+| Option                       | Default | Options                          |
+| ---------------------------- | ------- | -------------------------------- |
+| --exporters                  |         | name:type pairs, comma-separated |
+| --exporters-traces           |         | exporter name                    |
+| --exporters-metrics          |         | exporter name                    |
+| --exporters-logs             |         | exporter name                    |
+| --exporters-internal-metrics |         | exporter name                    |
 
 First start by defining the set of exporters that you would like to use, optionally specifying a custom name for them
 to differentiate their configuration options. For example, to export logs and metrics to two separate ClickHouse nodes
@@ -818,19 +819,17 @@ while exporting traces to Datadog, we'll use the following `--exporters` argumen
 --exporters logging:clickhouse,stats:clickhouse,datadog
 ```
 
-The argument form of `--exporters` takes `name:type` pairs separated by commas, where the first part is a custom name
-and
-the second part is the type of exporter. You can exclude the name if there is a single exporter by that name, which
-means
-the name is the same as the exporter type.
+The argument form of `--exporters` takes `name:type` pairs separated by commas,
+where the first part is a custom name and the second part is the type of
+exporter. You can exclude the name if there is a single exporter by that name,
+which means the name is the same as the exporter type.
 
-Second, you then must set environment variables of the form `ROTEL_EXPORTER_{NAME}_{PARAMETER}` to configure the
-multiple
-exporters. These variable names are dynamic and use the custom name to differentiate settings for similar exporter
-types.
-Therefore, there are no CLI argument alternatives for them at the moment. The `{PARAMETER}` fields match the
-configuration
-options for the given exporter type.
+Second, you then must set environment variables of the form
+`ROTEL_EXPORTER_{NAME}_{PARAMETER}` to configure the multiple exporters. These
+variable names are dynamic and use the custom name to differentiate settings for
+similar exporter types. Therefore, there are no CLI argument alternatives for
+them at the moment. The `{PARAMETER}` fields match the configuration options for
+the given exporter type.
 
 Using our example above, the user must set, at a minimum, the following environment variables. (For ClickHouse Cloud you
 would need to include a username/password, but we are skipping those for brevity.)
@@ -852,8 +851,19 @@ Alternatively, the following environment variables would do the same:
 - `ROTEL_EXPORTERS_METRICS=stats`
 - `ROTEL_EXPORTERS_LOGS=logging`
 
-_NOTE: At the moment, only a single exporter can be set for any telemetry type. This constraint will be relaxed in the
-future._
+You can send telemetry to multiple exporters by listing multiple comma-separated in the exporters configuration. Telemetry
+is sent sequentially to the sending queues for each exporter in-order. That means if one exporter is generating back pressure
+it may impact the other exporters.
+
+For example, to send logs to both the stats and logging clickhouse exporters,
+you would instead set the `ROTEL_EXPORTERS_LOGS` environment variable to:
+
+- `ROTEL_EXPORTERS_LOGS=stats,logging`
+
+>[!NOTE]
+> Sending telemetry to multiple exporters at once is currently in alpha. The telemetry is copied between the
+> multiple exporter queues which may cause additional memory use under large volumes. This is an area of
+> improvement as we expand on this capability.
 
 ### Full example
 
@@ -917,7 +927,7 @@ rotel_python_processor_sdk directory.
 Current prebuilt processors include...
 
 | Name                 | Supported telemetry types |
-|----------------------|---------------------------|
+| -------------------- | ------------------------- |
 | Attributes Processor | logs, metrics, traces,    |
 | Redaction Processor  | logs, metrics, traces     |
 

--- a/src/init/activation.rs
+++ b/src/init/activation.rs
@@ -25,13 +25,13 @@ impl TelemetryActivation {
         let mut activation = TelemetryActivation::default();
 
         // Update based on exporters
-        if exporter_config.traces.is_none() {
+        if exporter_config.traces.is_empty() {
             activation.traces = TelemetryState::NoListeners;
         }
-        if exporter_config.metrics.is_none() {
+        if exporter_config.metrics.is_empty() {
             activation.metrics = TelemetryState::NoListeners;
         }
-        if exporter_config.logs.is_none() {
+        if exporter_config.logs.is_empty() {
             activation.logs = TelemetryState::NoListeners;
         }
 

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -114,26 +114,18 @@ impl Agent {
 
         let (trace_pipeline_in_tx, trace_pipeline_in_rx) =
             bounded::<Message<ResourceSpans>>(max(4, num_cpus));
-        let (trace_pipeline_out_tx, trace_pipeline_out_rx) =
-            bounded::<Vec<ResourceSpans>>(self.sending_queue_size);
         let trace_otlp_output = OTLPOutput::new(trace_pipeline_in_tx);
 
         let (metrics_pipeline_in_tx, metrics_pipeline_in_rx) =
             bounded::<Message<ResourceMetrics>>(max(4, num_cpus));
-        let (metrics_pipeline_out_tx, metrics_pipeline_out_rx) =
-            bounded::<Vec<ResourceMetrics>>(self.sending_queue_size);
         let metrics_otlp_output = OTLPOutput::new(metrics_pipeline_in_tx);
 
         let (logs_pipeline_in_tx, logs_pipeline_in_rx) =
             bounded::<Message<ResourceLogs>>(max(4, num_cpus));
-        let (logs_pipeline_out_tx, logs_pipeline_out_rx) =
-            bounded::<Vec<ResourceLogs>>(self.sending_queue_size);
         let logs_otlp_output = OTLPOutput::new(logs_pipeline_in_tx);
 
         let (internal_metrics_pipeline_in_tx, internal_metrics_pipeline_in_rx) =
             bounded::<Message<ResourceMetrics>>(max(4, num_cpus));
-        let (internal_metrics_pipeline_out_tx, internal_metrics_pipeline_out_rx) =
-            bounded::<Vec<ResourceMetrics>>(self.sending_queue_size);
         let internal_metrics_otlp_output = OTLPOutput::new(internal_metrics_pipeline_in_tx);
 
         let rec_config = get_receivers_config(&config)?;
@@ -235,7 +227,14 @@ impl Agent {
 
         // AWS-XRay only supports a batch size of 50 segments
         let mut trace_batch_config = build_traces_batch_config(config.batch.clone());
-        if let Some(ExporterConfig::Xray(_)) = exp_config.traces {
+        // Check if AWS X-Ray is configured for traces
+        let has_xray_exporter = exp_config
+            .traces
+            .iter()
+            .any(|cfg| matches!(cfg, ExporterConfig::Xray(_)));
+
+        if has_xray_exporter {
+            // TODO: This splitting can move to the xray exporter: https://github.com/streamfold/rotel/issues/210
             if trace_batch_config.max_size > 50 {
                 info!(
                     "AWS X-Ray only supports a batch size of 50 segments, setting batch max size to 50"
@@ -272,131 +271,142 @@ impl Agent {
         // Build the exporters now
         //
 
+        let mut trace_fanout = FanoutBuilder::new();
+        let mut metrics_fanout = FanoutBuilder::new();
+        let mut logs_fanout = FanoutBuilder::new();
+        let mut internal_metrics_fanout = FanoutBuilder::new();
+
         //
         // TRACES
         //
         if activation.traces == TelemetryState::Active {
-            match exp_config.traces {
-                Some(ExporterConfig::Otlp(exp_config)) => {
-                    let traces = otlp::exporter::build_traces_exporter(
-                        exp_config,
-                        trace_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
+            for cfg in exp_config.traces {
+                let (trace_pipeline_out_tx, trace_pipeline_out_rx) =
+                    bounded::<Vec<ResourceSpans>>(self.sending_queue_size);
+                trace_fanout = trace_fanout.add_tx(trace_pipeline_out_tx);
 
-                    start_otlp_exporter(
-                        &mut exporters_task_set,
-                        "otlp_traces",
-                        traces,
-                        exporters_cancel.clone(),
-                    );
-                }
-                Some(ExporterConfig::Clickhouse(cfg_builder)) => {
-                    let builder = cfg_builder.build()?;
-
-                    let exp = builder.build_traces_exporter(
-                        trace_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exp.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = e,
-                                exporter_type = "clickhouse_traces",
-                                "Clickhouse exporter returned from run loop with error."
-                            );
-                        }
-
-                        Ok(())
-                    });
-                }
-                Some(ExporterConfig::Datadog(cfg_builder)) => {
-                    let builder = cfg_builder.build();
-
-                    let exp = builder.build(
-                        trace_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exp.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = e,
-                                "Datadog exporter returned from run loop with error."
-                            );
-                        }
-
-                        Ok(())
-                    });
-                }
-                Some(ExporterConfig::Xray(cfg_builder)) => {
-                    let config = AwsConfig::from_env();
-                    let builder = cfg_builder.build();
-                    let exp = builder.build(
-                        trace_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                        "production".to_string(),
-                        config,
-                    )?;
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exp.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = e,
-                                "AWS X-Ray exporter returned from run loop with error."
-                            );
-                        }
-                        Ok(())
-                    });
-                }
-                Some(ExporterConfig::Blackhole) => {
-                    let mut exp = BlackholeExporter::new(trace_pipeline_out_rx);
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        exp.start(token).await;
-                        Ok(())
-                    });
-                }
-                #[cfg(feature = "rdkafka")]
-                Some(ExporterConfig::Kafka(kafka_config)) => {
-                    let mut traces_exporter =
-                        build_traces_exporter(kafka_config, trace_pipeline_out_rx)?;
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        traces_exporter.start(token).await;
-                        Ok(())
-                    });
-                }
-                #[cfg(feature = "file_exporter")]
-                Some(ExporterConfig::File(config)) => {
-                    let exporter =
-                        crate::exporters::file::FileExporterBuilder::build_traces_exporter(
-                            &config,
+                match cfg {
+                    ExporterConfig::Otlp(exp_config) => {
+                        let traces = otlp::exporter::build_traces_exporter(
+                            exp_config,
                             trace_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                         )?;
 
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exporter.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = %e,
-                                exporter_type = "file_traces",
-                                "File exporter returned from run loop with error."
-                            );
-                        }
-                        Ok(())
-                    });
+                        start_otlp_exporter(
+                            &mut exporters_task_set,
+                            "otlp_traces",
+                            traces,
+                            exporters_cancel.clone(),
+                        );
+                    }
+                    ExporterConfig::Clickhouse(cfg_builder) => {
+                        let builder = cfg_builder.build()?;
+
+                        let exp = builder.build_traces_exporter(
+                            trace_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                        )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exp.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = e,
+                                    exporter_type = "clickhouse_traces",
+                                    "Clickhouse exporter returned from run loop with error."
+                                );
+                            }
+
+                            Ok(())
+                        });
+                    }
+                    ExporterConfig::Datadog(cfg_builder) => {
+                        let builder = cfg_builder.build();
+
+                        let exp = builder.build(
+                            trace_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                        )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exp.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = e,
+                                    "Datadog exporter returned from run loop with error."
+                                );
+                            }
+
+                            Ok(())
+                        });
+                    }
+                    ExporterConfig::Xray(cfg_builder) => {
+                        let config = AwsConfig::from_env();
+                        let builder = cfg_builder.build();
+                        let exp = builder.build(
+                            trace_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                            "production".to_string(),
+                            config,
+                        )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exp.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = e,
+                                    "AWS X-Ray exporter returned from run loop with error."
+                                );
+                            }
+                            Ok(())
+                        });
+                    }
+                    ExporterConfig::Blackhole => {
+                        let mut exp = BlackholeExporter::new(trace_pipeline_out_rx);
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            exp.start(token).await;
+                            Ok(())
+                        });
+                    }
+                    #[cfg(feature = "rdkafka")]
+                    ExporterConfig::Kafka(kafka_config) => {
+                        let mut traces_exporter =
+                            build_traces_exporter(kafka_config, trace_pipeline_out_rx)?;
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            traces_exporter.start(token).await;
+                            Ok(())
+                        });
+                    }
+                    #[cfg(feature = "file_exporter")]
+                    ExporterConfig::File(config) => {
+                        let exporter =
+                            crate::exporters::file::FileExporterBuilder::build_traces_exporter(
+                                &config,
+                                trace_pipeline_out_rx,
+                            )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exporter.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = %e,
+                                    exporter_type = "file_traces",
+                                    "File exporter returned from run loop with error."
+                                );
+                            }
+                            Ok(())
+                        });
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
 
@@ -404,124 +414,138 @@ impl Agent {
         // METRICS
         //
         if activation.metrics == TelemetryState::Active {
-            match exp_config.metrics {
-                Some(ExporterConfig::Otlp(exp_config)) => {
-                    let metrics = otlp::exporter::build_metrics_exporter(
-                        exp_config.clone(),
-                        metrics_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
+            // Combine both metrics and internal_metrics exporters into single pass
+            let combined_metrics_configs = exp_config
+                .metrics
+                .into_iter()
+                .map(|cfg| (cfg, false))
+                .chain(exp_config.internal_metrics.into_iter().map(|cfg| (cfg, true)));
 
-                    start_otlp_exporter(
-                        &mut exporters_task_set,
-                        "otlp_metrics",
-                        metrics,
-                        exporters_cancel.clone(),
-                    );
+            for (cfg, is_internal_metrics) in combined_metrics_configs {
+                let (metrics_pipeline_out_tx, metrics_pipeline_out_rx) =
+                    bounded::<Vec<ResourceMetrics>>(self.sending_queue_size);
 
-                    // TODO: Allow internal metrics pipeline to be configured separately?
-                    if config.enable_internal_telemetry {
-                        let internal_metrics = otlp::exporter::build_internal_metrics_exporter(
-                            exp_config,
-                            internal_metrics_pipeline_out_rx,
-                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                        )?;
+                if is_internal_metrics {
+                    internal_metrics_fanout =
+                        internal_metrics_fanout.add_tx(metrics_pipeline_out_tx);
+                } else {
+                    metrics_fanout = metrics_fanout.add_tx(metrics_pipeline_out_tx);
+                }
+
+                let telemetry_type = match is_internal_metrics {
+                    true => "internal_metrics",
+                    false => "metrics",
+                };
+
+                match cfg {
+                    ExporterConfig::Otlp(exp_config) => {
+                        let metrics = match is_internal_metrics {
+                            true => otlp::exporter::build_internal_metrics_exporter(
+                                exp_config.clone(),
+                                metrics_pipeline_out_rx,
+                                self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                            )?,
+                            false => otlp::exporter::build_metrics_exporter(
+                                exp_config.clone(),
+                                metrics_pipeline_out_rx,
+                                self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                            )?,
+                        };
 
                         start_otlp_exporter(
                             &mut exporters_task_set,
-                            "otlp_internal_metrics",
-                            internal_metrics,
+                            telemetry_type,
+                            metrics,
                             exporters_cancel.clone(),
                         );
                     }
-                }
-                Some(ExporterConfig::Clickhouse(cfg_builder)) => {
-                    let builder = cfg_builder.build()?;
+                    ExporterConfig::Clickhouse(cfg_builder) => {
+                        let builder = cfg_builder.build()?;
 
-                    let exp = builder.build_metrics_exporter(
-                        metrics_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exp.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = e,
-                                exporter_type = "clickhouse_metrics",
-                                "Clickhouse exporter returned from run loop with error."
-                            );
-                        }
-
-                        Ok(())
-                    });
-                }
-                Some(ExporterConfig::Blackhole) => {
-                    let mut exp = BlackholeExporter::new(metrics_pipeline_out_rx);
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        exp.start(token).await;
-                        Ok(())
-                    });
-                }
-                #[cfg(feature = "rdkafka")]
-                Some(ExporterConfig::Kafka(kafka_config)) => {
-                    let mut metrics_exporter =
-                        build_metrics_exporter(kafka_config, metrics_pipeline_out_rx)?;
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        metrics_exporter.start(token).await;
-                        Ok(())
-                    });
-                }
-                #[cfg(feature = "file_exporter")]
-                Some(ExporterConfig::File(config)) => {
-                    let exporter =
-                        crate::exporters::file::FileExporterBuilder::build_metrics_exporter(
-                            &config,
+                        let exp = builder.build_metrics_exporter(
                             metrics_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                         )?;
 
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exporter.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = %e,
-                                exporter_type = "file_metrics",
-                                "File exporter returned from run loop with error."
-                            );
-                        }
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exp.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = e,
+                                    exporter_type = "clickhouse_metrics",
+                                    "Clickhouse exporter returned from run loop with error."
+                                );
+                            }
 
-                        Ok(())
-                    });
+                            Ok(())
+                        });
+                    }
+                    ExporterConfig::Blackhole => {
+                        let mut exp = BlackholeExporter::new(metrics_pipeline_out_rx);
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            exp.start(token).await;
+                            Ok(())
+                        });
+                    }
+                    #[cfg(feature = "rdkafka")]
+                    ExporterConfig::Kafka(kafka_config) => {
+                        let mut metrics_exporter =
+                            build_metrics_exporter(kafka_config, metrics_pipeline_out_rx)?;
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            metrics_exporter.start(token).await;
+                            Ok(())
+                        });
+                    }
+                    #[cfg(feature = "file_exporter")]
+                    ExporterConfig::File(config) => {
+                        let exporter =
+                            crate::exporters::file::FileExporterBuilder::build_metrics_exporter(
+                                &config,
+                                metrics_pipeline_out_rx,
+                            )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exporter.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = %e,
+                                    exporter_type = "file_metrics",
+                                    "File exporter returned from run loop with error."
+                                );
+                            }
+
+                            Ok(())
+                        });
+                    }
+                    ExporterConfig::Awsemf(cfg_builder) => {
+                        let config = AwsConfig::from_env();
+                        let builder = cfg_builder.build();
+                        let exp = builder.build(
+                            metrics_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                            config,
+                        )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exp.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = e,
+                                    "AWS EMF exporter returned from run loop with error."
+                                );
+                            }
+
+                            Ok(())
+                        });
+                    }
+                    _ => {}
                 }
-
-                Some(ExporterConfig::Awsemf(cfg_builder)) => {
-                    let config = AwsConfig::from_env();
-                    let builder = cfg_builder.build();
-                    let exp = builder.build(
-                        metrics_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                        config,
-                    )?;
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exp.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = e,
-                                "AWS EMF exporter returned from run loop with error."
-                            );
-                        }
-
-                        Ok(())
-                    });
-                }
-                _ => {}
             }
         }
 
@@ -529,90 +553,95 @@ impl Agent {
         // LOGS
         //
         if activation.logs == TelemetryState::Active {
-            match exp_config.logs {
-                Some(ExporterConfig::Otlp(exp_config)) => {
-                    let logs = otlp::exporter::build_logs_exporter(
-                        exp_config,
-                        logs_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
+            for cfg in exp_config.logs {
+                let (logs_pipeline_out_tx, logs_pipeline_out_rx) =
+                    bounded::<Vec<ResourceLogs>>(self.sending_queue_size);
+                logs_fanout = logs_fanout.add_tx(logs_pipeline_out_tx);
 
-                    start_otlp_exporter(
-                        &mut exporters_task_set,
-                        "otlp_logs",
-                        logs,
-                        exporters_cancel.clone(),
-                    );
-                }
-                Some(ExporterConfig::Clickhouse(cfg_builder)) => {
-                    let builder = cfg_builder.build()?;
-
-                    let exp = builder.build_logs_exporter(
-                        logs_pipeline_out_rx,
-                        self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
-                    )?;
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exp.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = e,
-                                exporter_type = "clickhouse_logs",
-                                "Clickhouse exporter returned from run loop with error."
-                            );
-                        }
-
-                        Ok(())
-                    });
-                }
-                Some(ExporterConfig::Blackhole) => {
-                    let mut exp = BlackholeExporter::new(logs_pipeline_out_rx);
-
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        exp.start(token).await;
-                        Ok(())
-                    });
-                }
-                #[cfg(feature = "rdkafka")]
-                Some(ExporterConfig::Kafka(kafka_config)) => {
-                    let mut logs_exporter =
-                        build_logs_exporter(kafka_config, logs_pipeline_out_rx)?;
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        logs_exporter.start(token).await;
-                        Ok(())
-                    });
-                }
-                #[cfg(feature = "file_exporter")]
-                Some(ExporterConfig::File(config)) => {
-                    let exporter =
-                        crate::exporters::file::FileExporterBuilder::build_logs_exporter(
-                            &config,
+                match cfg {
+                    ExporterConfig::Otlp(exp_config) => {
+                        let logs = otlp::exporter::build_logs_exporter(
+                            exp_config,
                             logs_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
                         )?;
 
-                    let token = exporters_cancel.clone();
-                    exporters_task_set.spawn(async move {
-                        let res = exporter.start(token).await;
-                        if let Err(e) = res {
-                            error!(
-                                error = %e,
-                                exporter_type = "file_logs",
-                                "File exporter returned from run loop with error."
-                            );
-                        }
-                        Ok(())
-                    });
+                        start_otlp_exporter(
+                            &mut exporters_task_set,
+                            "otlp_logs",
+                            logs,
+                            exporters_cancel.clone(),
+                        );
+                    }
+                    ExporterConfig::Clickhouse(cfg_builder) => {
+                        let builder = cfg_builder.build()?;
+
+                        let exp = builder.build_logs_exporter(
+                            logs_pipeline_out_rx,
+                            self.exporters_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                        )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exp.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = e,
+                                    exporter_type = "clickhouse_logs",
+                                    "Clickhouse exporter returned from run loop with error."
+                                );
+                            }
+
+                            Ok(())
+                        });
+                    }
+                    ExporterConfig::Blackhole => {
+                        let mut exp = BlackholeExporter::new(logs_pipeline_out_rx);
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            exp.start(token).await;
+                            Ok(())
+                        });
+                    }
+                    #[cfg(feature = "rdkafka")]
+                    ExporterConfig::Kafka(kafka_config) => {
+                        let mut logs_exporter =
+                            build_logs_exporter(kafka_config, logs_pipeline_out_rx)?;
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            logs_exporter.start(token).await;
+                            Ok(())
+                        });
+                    }
+                    #[cfg(feature = "file_exporter")]
+                    ExporterConfig::File(config) => {
+                        let exporter =
+                            crate::exporters::file::FileExporterBuilder::build_logs_exporter(
+                                &config,
+                                logs_pipeline_out_rx,
+                            )?;
+
+                        let token = exporters_cancel.clone();
+                        exporters_task_set.spawn(async move {
+                            let res = exporter.start(token).await;
+                            if let Err(e) = res {
+                                error!(
+                                    error = %e,
+                                    exporter_type = "file_logs",
+                                    "File exporter returned from run loop with error."
+                                );
+                            }
+                            Ok(())
+                        });
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
 
         if traces_output.is_some() {
-            let trace_fanout = FanoutBuilder::new()
-                .add_tx(trace_pipeline_out_tx)
+            let trace_fanout = trace_fanout
                 .build()
                 .expect("Failed to build trace fanout with single consumer");
 
@@ -638,8 +667,7 @@ impl Agent {
         }
 
         if metrics_output.is_some() {
-            let metrics_fanout = FanoutBuilder::new()
-                .add_tx(metrics_pipeline_out_tx)
+            let metrics_fanout = metrics_fanout
                 .build()
                 .expect("Failed to build metrics fanout with single consumer");
 
@@ -665,8 +693,7 @@ impl Agent {
         }
 
         if logs_output.is_some() {
-            let logs_fanout = FanoutBuilder::new()
-                .add_tx(logs_pipeline_out_tx)
+            let logs_fanout = logs_fanout
                 .build()
                 .expect("Failed to build logs fanout with single consumer");
 
@@ -692,8 +719,7 @@ impl Agent {
         }
 
         if internal_metrics_output.is_some() {
-            let internal_metrics_fanout = FanoutBuilder::new()
-                .add_tx(internal_metrics_pipeline_out_tx)
+            let internal_metrics_fanout = internal_metrics_fanout
                 .build()
                 .expect("Failed to build internal metrics fanout with single consumer");
 

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -419,7 +419,12 @@ impl Agent {
                 .metrics
                 .into_iter()
                 .map(|cfg| (cfg, false))
-                .chain(exp_config.internal_metrics.into_iter().map(|cfg| (cfg, true)));
+                .chain(
+                    exp_config
+                        .internal_metrics
+                        .into_iter()
+                        .map(|cfg| (cfg, true)),
+                );
 
             for (cfg, is_internal_metrics) in combined_metrics_configs {
                 let (metrics_pipeline_out_tx, metrics_pipeline_out_rx) =

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -100,6 +100,10 @@ pub struct AgentRun {
     #[arg(long, env = "ROTEL_EXPORTERS_LOGS")]
     pub exporters_logs: Option<String>,
 
+    /// Internal metrics exporters
+    #[arg(long, env = "ROTEL_EXPORTERS_INTERNAL_METRICS")]
+    pub exporters_internal_metrics: Option<String>,
+
     #[command(flatten)]
     pub otlp_exporter: OTLPExporterArgs,
 
@@ -152,6 +156,7 @@ impl Default for AgentRun {
             exporters_traces: None,
             exporters_metrics: None,
             exporters_logs: None,
+            exporters_internal_metrics: None,
             otlp_exporter: OTLPExporterArgs::default(),
             datadog_exporter: DatadogExporterArgs::default(),
             clickhouse_exporter: ClickhouseExporterArgs::default(),

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -851,18 +851,15 @@ mod tests {
         let mut env_manager = EnvManager::new();
         env_manager.set_var("ROTEL_EXPORTER_DD_API_KEY", "test-api-key");
         env_manager.set_var("ROTEL_EXPORTER_DD_REGION", "us1");
-        
+
         let config = AgentRun {
             exporters_traces: Some("bh,dd".to_string()),
             ..AgentRun::default()
         };
 
-        let result = get_multi_exporter_config(
-            &config,
-            "dd:datadog,bh:blackhole".to_string(),
-            "production",
-        );
-        
+        let result =
+            get_multi_exporter_config(&config, "dd:datadog,bh:blackhole".to_string(), "production");
+
         assert!(result.is_ok());
         let exporters = result.unwrap();
 


### PR DESCRIPTION
This connects multiple exporters to a single pipeline using the fanout component added previously. Configuration is handled following the multiple exporters [RFC](https://github.com/streamfold/rotel/discussions/104).

As mentioned, this approach is an early stab at an implementation. It naively copies the messages for all but one exporter, meaning there will be additional memory pressure under large volumes. This is an area we intend to improve upon.

Completes: STR-3492