### PR TITLE
Skip internal metrics if not enabled

### DIFF
--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -427,6 +427,11 @@ impl Agent {
                 );
 
             for (cfg, is_internal_metrics) in combined_metrics_configs {
+                // Skip internal metrics if not enabled
+                if is_internal_metrics && !config.enable_internal_telemetry {
+                    continue;
+                }
+
                 let (metrics_pipeline_out_tx, metrics_pipeline_out_rx) =
                     bounded::<Vec<ResourceMetrics>>(self.sending_queue_size);
 


### PR DESCRIPTION
If internal telemetry is disabled, skip starting a pipeline for it. This avoids a warning when shutting down and not all exporters are cleanly stopped:

```
WARN Exporters did not exit on channel close, cancelling.
```