### PR TITLE
Switch to nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,12 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
-            cross: false
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu
-            cross: false
           - target: aarch64-apple-darwin
             runner: macos-latest
             os: macos
-            cross: false
     runs-on: ${{ matrix.runner }}
 
     steps:
@@ -42,20 +39,17 @@ jobs:
         with:
           target: ${{ matrix.target }}
           rustflags: ""
-      - name: install cross
-        if: matrix.cross == true
-        run: |
-          cargo install cross
-          echo "CARGO_BIN=cross" >> $GITHUB_ENV
-      - name: set CARGO bin
-        if: matrix.cross == false
-        run: |
-          echo "CARGO_BIN=cargo" >> $GITHUB_ENV
-      - name: run test
-        run: |
-          $CARGO_BIN test --target ${{ matrix.target }} --verbose
+      - uses: taiki-e/install-action@nextest
+      - name: run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --target ${{ matrix.target }} --verbose
       - name: run test processor-sdk
-        run: $CARGO_BIN test --manifest-path ./rotel_python_processor_sdk/Cargo.toml --target ${{ matrix.target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --manifest-path ./rotel_python_processor_sdk/Cargo.toml --target ${{ matrix.target }}
 
   # Check formatting with rustfmt
   formatting:

--- a/.github/workflows/processor-release.yml
+++ b/.github/workflows/processor-release.yml
@@ -16,62 +16,50 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
-            cross: false
             python-version: "3.10"
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
-            cross: false
             python-version: 3.11
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
-            cross: false
             python-version: 3.12
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
-            cross: false
             python-version: 3.13
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu
-            cross: false
             python-version: "3.10"
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu
-            cross: false
             python-version: 3.11
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu
-            cross: false
             python-version: 3.12
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu
-            cross: false
             python-version: 3.13
           - target: aarch64-apple-darwin
             runner: macos-14
             os: macos
-            cross: false
             python-version: "3.10"
           - target: aarch64-apple-darwin
             runner: macos-14
             os: macos
-            cross: false
             python-version: 3.11
           - target: aarch64-apple-darwin
             runner: macos-14
             os: macos
-            cross: false
             python-version: 3.12
           - target: aarch64-apple-darwin
             runner: macos-14
             os: macos
-            cross: false
             python-version: 3.13
     env:
       TARGET: ${{ matrix.target }}
@@ -112,19 +100,17 @@ jobs:
         with:
           target: ${{ matrix.target }}
           rustflags: ""
-      - name: install cross
-        if: matrix.cross == true
-        run: |
-          cargo install cross
-          echo "CARGO_BIN=cross" >> $GITHUB_ENV
-      - name: set CARGO bin
-        if: matrix.cross == false
-        run: |
-          echo "CARGO_BIN=cargo" >> $GITHUB_ENV
+      - uses: taiki-e/install-action@nextest
       - name: run test processor-sdk
-        run: $CARGO_BIN test --manifest-path ./rotel_python_processor_sdk/Cargo.toml --target ${{ matrix.target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run --manifest-path ./rotel_python_processor_sdk/Cargo.toml --target ${{ matrix.target }}
       - name: build
-        run: $CARGO_BIN build --release --features pyo3 --locked --target ${{ matrix.target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --features pyo3 --locked --target ${{ matrix.target }}
       - name: upload build
         if: matrix.python-version == '3.13'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,12 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-22.04
             os: ubuntu
-            cross: false
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
             os: ubuntu
-            cross: false
           - target: aarch64-apple-darwin
             runner: macos-latest
             os: macos
-            cross: false
     steps:
       - uses: actions/checkout@v4
       - name: update apt cache on linux
@@ -41,19 +38,16 @@ jobs:
         with:
           target: ${{ matrix.target }}
           rustflags: ""
-      - name: install cross
-        if: matrix.cross == true
-        run: |
-          cargo install cross
-          echo "CARGO_BIN=cross" >> $GITHUB_ENV
-      - name: set CARGO bin
-        if: matrix.cross == false
-        run: |
-          echo "CARGO_BIN=cargo" >> $GITHUB_ENV
       - name: build
-        run: $CARGO_BIN build --release --locked --target ${{ matrix.target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --locked --target ${{ matrix.target }}
       - name: build clickhouse-ddl
-        run: $CARGO_BIN build --release --locked --target ${{ matrix.target }} --bin clickhouse-ddl
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --locked --target ${{ matrix.target }} --bin clickhouse-ddl
       - name: upload build
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
We have a few tests that modify environment variables to test our config parsing, but since envvars are global it seems like parallel tests can cause flapping tests. This switches to nextest, which seems like a better test runner and which [docs](https://nexte.st/docs/design/how-it-works/) seem to indicate that tests are run concurrently in different process spaces, alleviating the envvar issues.

This cleans up a few things here too:

* use the suggested nextest GH action installer
* removes the cross compile setup which we aren't currently using, since may use a different direction if we need to later
* uses `actions-rs/cargo` to run cargo commands, also suggestion from nextest docs/examples