### PR TITLE
Support numbers/bools as strings

### DIFF
--- a/src/init/clickhouse_exporter.rs
+++ b/src/init/clickhouse_exporter.rs
@@ -44,6 +44,7 @@ pub struct ClickhouseExporterArgs {
         long("clickhouse-exporter-user"),
         env = "ROTEL_CLICKHOUSE_EXPORTER_USER"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub user: Option<String>,
 
     /// Clickhouse Exporter password
@@ -51,6 +52,7 @@ pub struct ClickhouseExporterArgs {
         long("clickhouse-exporter-password"),
         env = "ROTEL_CLICKHOUSE_EXPORTER_PASSWORD"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub password: Option<String>,
 
     /// Clickhouse Exporter async insert

--- a/src/init/datadog_exporter.rs
+++ b/src/init/datadog_exporter.rs
@@ -27,6 +27,7 @@ pub struct DatadogExporterArgs {
         long("datadog-exporter-api-key"),
         env = "ROTEL_DATADOG_EXPORTER_API_KEY"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub api_key: Option<String>,
 }
 

--- a/src/init/kafka_exporter.rs
+++ b/src/init/kafka_exporter.rs
@@ -82,6 +82,7 @@ pub struct KafkaExporterArgs {
         env = "ROTEL_KAFKA_EXPORTER_CLIENT_ID",
         default_value = "rotel"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string")]
     pub client_id: String,
 
     /// Maximum message size in bytes
@@ -191,6 +192,7 @@ pub struct KafkaExporterArgs {
         long("kafka-exporter-sasl-username"),
         env = "ROTEL_KAFKA_EXPORTER_SASL_USERNAME"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub sasl_username: Option<String>,
 
     /// SASL password for authentication
@@ -199,6 +201,7 @@ pub struct KafkaExporterArgs {
         long("kafka-exporter-sasl-password"),
         env = "ROTEL_KAFKA_EXPORTER_SASL_PASSWORD"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub sasl_password: Option<String>,
 
     /// SASL mechanism

--- a/src/init/kafka_receiver.rs
+++ b/src/init/kafka_receiver.rs
@@ -82,6 +82,7 @@ pub struct KafkaReceiverArgs {
         env = "ROTEL_KAFKA_RECEIVER_GROUP_ID",
         default_value = "rotel-consumer"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string")]
     pub group_id: String,
 
     /// Client ID for the Kafka consumer
@@ -91,6 +92,7 @@ pub struct KafkaReceiverArgs {
         env = "ROTEL_KAFKA_RECEIVER_CLIENT_ID",
         default_value = "rotel"
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string")]
     pub client_id: String,
 
     /// Enable auto commit of offsets
@@ -214,6 +216,7 @@ pub struct KafkaReceiverArgs {
         env = "ROTEL_KAFKA_RECEIVER_SASL_USERNAME",
         default_value = None,
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub sasl_username: Option<String>,
 
     /// SASL password for authentication
@@ -223,6 +226,7 @@ pub struct KafkaReceiverArgs {
         env = "ROTEL_KAFKA_RECEIVER_SASL_PASSWORD",
         default_value = None,
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub sasl_password: Option<String>,
 
     /// SASL mechanism
@@ -273,6 +277,7 @@ pub struct KafkaReceiverArgs {
         env = "ROTEL_KAFKA_RECEIVER_SSL_KEY_PASSWORD",
         default_value = None,
     )]
+    #[serde(deserialize_with = "crate::init::parse::deser_into_string_opt")]
     pub ssl_key_password: Option<String>,
 
     /// Custom Kafka consumer configuration parameters (key=value pairs). These will override built-in options if conflicts exist.


### PR DESCRIPTION
The serde library will panic if it detects a number or boolean value when trying to parse to a String type. When using it to parse environment variables, we don't really have a lot of control over the origin value type. For example, if someone's Datadog API key were all digits:
```
ROTEL_EXPORTER_DD_API_KEY=1234
```
than it would fail to parse that, thinking that the type is an unsigned int.

Mark parameters that may have a number or boolean value with a custom deserializer method.

Completes: STR-3503