### PR TITLE
Avoid dup of service name attr

### DIFF
--- a/src/exporters/clickhouse/transform_logs.rs
+++ b/src/exporters/clickhouse/transform_logs.rs
@@ -2,7 +2,7 @@ use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayload
 use crate::exporters::clickhouse::request_builder::TransformPayload;
 use crate::exporters::clickhouse::request_mapper::RequestType;
 use crate::exporters::clickhouse::schema::LogRecordRow;
-use crate::exporters::clickhouse::transformer::{Transformer, encode_id, find_attribute};
+use crate::exporters::clickhouse::transformer::{Transformer, encode_id, find_str_attribute};
 use crate::otlp::cvattr;
 use crate::otlp::cvattr::ConvertedAttrValue;
 use crate::topology::payload::{Message, MessageMetadata};
@@ -28,7 +28,7 @@ impl TransformPayload<ResourceLogs> for Transformer {
             for rl in message.payload {
                 let res_attrs = rl.resource.unwrap_or_default().attributes;
                 let res_attrs = cvattr::convert_into(res_attrs);
-                let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+                let service_name = find_str_attribute(SERVICE_NAME, &res_attrs);
                 let res_attrs_field = self.transform_attrs(&res_attrs);
 
                 let res_schema_url = rl.schema_url;

--- a/src/exporters/clickhouse/transform_metrics.rs
+++ b/src/exporters/clickhouse/transform_metrics.rs
@@ -5,7 +5,7 @@ use crate::exporters::clickhouse::schema::{
     MetricsExemplars, MetricsExpHistogramRow, MetricsGaugeRow, MetricsHistogramRow, MetricsMeta,
     MetricsSumRow, MetricsSummaryRow,
 };
-use crate::exporters::clickhouse::transformer::{Transformer, find_attribute};
+use crate::exporters::clickhouse::transformer::{Transformer, find_str_attribute};
 use crate::otlp::cvattr;
 use crate::topology::payload::{Message, MessageMetadata};
 use opentelemetry_proto::tonic::metrics::v1::exemplar::Value;
@@ -34,7 +34,7 @@ impl TransformPayload<ResourceMetrics> for Transformer {
             for rm in message.payload {
                 let res_attrs = rm.resource.unwrap_or_default().attributes;
                 let res_attrs = cvattr::convert_into(res_attrs);
-                let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+                let service_name = find_str_attribute(SERVICE_NAME, &res_attrs);
                 let res_attrs_field = self.transform_attrs(&res_attrs);
 
                 for sm in rm.scope_metrics {

--- a/src/exporters/clickhouse/transform_traces.rs
+++ b/src/exporters/clickhouse/transform_traces.rs
@@ -2,7 +2,7 @@ use crate::exporters::clickhouse::payload::{ClickhousePayload, ClickhousePayload
 use crate::exporters::clickhouse::request_builder::TransformPayload;
 use crate::exporters::clickhouse::request_mapper::RequestType;
 use crate::exporters::clickhouse::schema::SpanRow;
-use crate::exporters::clickhouse::transformer::{Transformer, encode_id, find_attribute};
+use crate::exporters::clickhouse::transformer::{Transformer, encode_id, find_str_attribute};
 use crate::otlp::cvattr;
 use crate::topology::payload::{Message, MessageMetadata};
 use opentelemetry_proto::tonic::trace::v1::span::SpanKind;
@@ -32,7 +32,7 @@ impl TransformPayload<ResourceSpans> for Transformer {
             for rs in message.payload {
                 let res_attrs = rs.resource.unwrap_or_default().attributes;
                 let res_attrs = cvattr::convert_into(res_attrs);
-                let service_name = find_attribute(SERVICE_NAME, &res_attrs);
+                let service_name = find_str_attribute(SERVICE_NAME, &res_attrs);
                 let res_attrs_field = self.transform_attrs(&res_attrs);
 
                 for ss in rs.scope_spans {

--- a/src/exporters/clickhouse/transformer.rs
+++ b/src/exporters/clickhouse/transformer.rs
@@ -1,7 +1,7 @@
 use crate::exporters::clickhouse::Compression;
 use crate::exporters::clickhouse::rowbinary::json::JsonType;
 use crate::exporters::clickhouse::schema::MapOrJson;
-use crate::otlp::cvattr::ConvertedAttrKeyValue;
+use crate::otlp::cvattr::{ConvertedAttrKeyValue, ConvertedAttrValue};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -101,12 +101,18 @@ impl Transformer {
     }
 }
 
-pub(crate) fn find_attribute(attr: &str, attributes: &[ConvertedAttrKeyValue]) -> String {
+pub(crate) fn find_str_attribute<'a>(
+    attr: &str,
+    attributes: &'a [ConvertedAttrKeyValue],
+) -> Cow<'a, str> {
     attributes
         .iter()
         .find(|kv| kv.0 == attr)
-        .map(|kv| kv.1.to_string())
-        .unwrap_or(String::new())
+        .map(|kv| match &kv.1 {
+            ConvertedAttrValue::String(s) => Cow::Borrowed(s.as_str()),
+            _ => Cow::Borrowed(""),
+        })
+        .unwrap_or(Cow::Borrowed(""))
 }
 
 pub(crate) fn encode_id<'a>(id: &[u8], out: &'a mut [u8]) -> &'a str {


### PR DESCRIPTION
A very small optimization to avoid a Display fmt call on a string attribute. When looking for the service name, only support service name types of string attributes -- others don't make sense. This allows us to return a copy-on-write string.
