### PR TITLE
Kafka receiver/exporter encoding and decoding wrapper changes for compatibility.

### DIFF
--- a/src/exporters/kafka/request_builder.rs
+++ b/src/exporters/kafka/request_builder.rs
@@ -4,8 +4,44 @@ use crate::exporters::kafka::config::SerializationFormat;
 use crate::exporters::kafka::errors::Result;
 use crate::topology::payload::OTLPFrom;
 use bytes::Bytes;
+use opentelemetry_proto::tonic::logs::v1::{LogsData, ResourceLogs};
+use opentelemetry_proto::tonic::metrics::v1::{MetricsData, ResourceMetrics};
+use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, TracesData};
 use prost::Message;
 use serde::Serialize;
+
+/// Trait for converting resources to their corresponding *Data wrapper types
+pub trait ToDataWrapper: Sized {
+    type DataType: Serialize;
+    fn to_data_wrapper(resources: Vec<Self>) -> Self::DataType;
+}
+
+impl ToDataWrapper for ResourceSpans {
+    type DataType = TracesData;
+    fn to_data_wrapper(resources: Vec<Self>) -> Self::DataType {
+        TracesData {
+            resource_spans: resources,
+        }
+    }
+}
+
+impl ToDataWrapper for ResourceMetrics {
+    type DataType = MetricsData;
+    fn to_data_wrapper(resources: Vec<Self>) -> Self::DataType {
+        MetricsData {
+            resource_metrics: resources,
+        }
+    }
+}
+
+impl ToDataWrapper for ResourceLogs {
+    type DataType = LogsData;
+    fn to_data_wrapper(resources: Vec<Self>) -> Self::DataType {
+        LogsData {
+            resource_logs: resources,
+        }
+    }
+}
 
 /// Generic builder for creating Kafka messages from telemetry data
 #[derive(Clone)]
@@ -16,7 +52,7 @@ pub struct KafkaRequestBuilder<Resource, Request> {
 
 impl<Resource, Request> KafkaRequestBuilder<Resource, Request>
 where
-    Resource: Message + Serialize + Clone,
+    Resource: Message + Serialize + Clone + ToDataWrapper,
     Request: Message + OTLPFrom<Vec<Resource>> + Serialize,
 {
     /// Create a new request builder
@@ -30,22 +66,24 @@ where
     /// Build message from telemetry resources
     pub fn build_message(&self, resources: Vec<Resource>) -> Result<Bytes> {
         let payload = match self.serialization_format {
-            SerializationFormat::Json => self.serialize_json(resources.as_slice())?,
-            SerializationFormat::Protobuf => self.serialize_protobuf(resources.as_slice())?,
+            SerializationFormat::Json => self.serialize_json(resources)?,
+            SerializationFormat::Protobuf => self.serialize_protobuf(resources)?,
         };
         Ok(payload)
     }
 
-    /// Serialize data as JSON
-    fn serialize_json(&self, data: &[Resource]) -> Result<Bytes> {
-        let json = serde_json::to_vec(data)?;
+    /// Serialize data as JSON using the *Data wrapper types
+    fn serialize_json(&self, resources: Vec<Resource>) -> Result<Bytes> {
+        // For JSON format, wrap resources in TracesData/MetricsData/LogsData structure
+        let data_wrapper = Resource::to_data_wrapper(resources);
+        let json = serde_json::to_vec(&data_wrapper)?;
         Ok(Bytes::from(json))
     }
 
     /// Serialize resources as protobuf using OTLP service request format
-    fn serialize_protobuf(&self, resources: &[Resource]) -> Result<Bytes> {
+    fn serialize_protobuf(&self, resources: Vec<Resource>) -> Result<Bytes> {
         // Create OTLP service request using OTLPFrom trait
-        let request = Request::otlp_from(resources.to_vec());
+        let request = Request::otlp_from(resources);
 
         let mut buf = Vec::new();
         request.encode(&mut buf)?;
@@ -58,7 +96,6 @@ mod tests {
     use super::*;
     use crate::exporters::kafka::config::SerializationFormat;
     use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
-    use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 
     #[test]
     fn test_json_serialization() {


### PR DESCRIPTION
Completes: STR-3609

For better compatibility with other OTLP collectors that support Kafka receivers and exporters we're remove the ExportXXXServiceRequest wrapper and using the TracesData/MetricsData/LogsData wrapper type. Protobuf encoding will continue to use the ExportServiceRequest wrapper types.