### PR TITLE
Use lz4-flex unsafe mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ pyo3 = { version = "0.24.1", optional = true }
 chrono = "0.4.40"
 serde = { version = "1.0.217", features = ["derive"] }
 thiserror = "2.0.12"
-lz4_flex = "0.11.3"
+lz4_flex = { version = "0.11.3", default-features = false,  features = [ "std" ]}
 cityhash-rs = "1.0.1"
 bstr = "1.12.0"
 indexmap = "2.9.0"


### PR DESCRIPTION
Disable default features for [lz4_flex](https://crates.io/crates/lz4_flex), which will enable the unsafe mode. The unsafe version is 10-15% faster on compression according to the perf tests. This matches what the clickhouse-rs crate uses, so we trust it's ok for use in the ClickHouse exporter here.

In our own high throughput testing this appears to provide a roughly 5% performance improvement.
