### PR TITLE
Fix overflow on indefinite retry

### DIFF
--- a/src/exporters/awsemf/mod.rs
+++ b/src/exporters/awsemf/mod.rs
@@ -160,7 +160,7 @@ impl AwsEmfExporterConfigBuilder {
     }
 
     pub fn set_indefinite_retry(&mut self) {
-        self.config.retry_config.max_elapsed_time = Duration::from_secs(u64::MAX);
+        self.config.retry_config.indefinite_retry = true;
     }
 
     pub fn with_include_dimensions(mut self, include_dimensions: Vec<String>) -> Self {
@@ -746,6 +746,7 @@ mod tests {
                 initial_backoff: Duration::from_millis(10),
                 max_backoff: Duration::from_millis(50),
                 max_elapsed_time: Duration::from_millis(50),
+                indefinite_retry: false,
             });
 
         if let Some(log_retention) = &log_retention {

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -152,7 +152,7 @@ impl ClickhouseExporterConfigBuilder {
     }
 
     pub fn set_indefinite_retry(&mut self) {
-        self.retry_config.max_elapsed_time = Duration::from_secs(u64::MAX);
+        self.retry_config.indefinite_retry = true;
     }
 
     pub fn build(self) -> Result<ClickhouseExporterBuilder, BoxError> {

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -138,7 +138,7 @@ impl DatadogExporterConfigBuilder {
     }
 
     pub fn set_indefinite_retry(&mut self) {
-        self.retry_config.max_elapsed_time = Duration::from_secs(u64::MAX);
+        self.retry_config.indefinite_retry = true;
     }
 
     pub fn build(self) -> DatadogExporterBuilder {
@@ -370,6 +370,7 @@ mod tests {
                 initial_backoff: Duration::from_millis(10),
                 max_backoff: Duration::from_millis(50),
                 max_elapsed_time: Duration::from_millis(50),
+                indefinite_retry: false,
             })
             .build()
             .build(brx, None)

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -93,7 +93,7 @@ impl XRayExporterConfigBuilder {
     }
 
     pub fn set_indefinite_retry(&mut self) {
-        self.retry_config.max_elapsed_time = Duration::from_secs(u64::MAX);
+        self.retry_config.indefinite_retry = true;
     }
 
     pub fn build(self) -> XRayExporterBuilder {
@@ -542,6 +542,7 @@ mod tests {
                 initial_backoff: Duration::from_millis(10),
                 max_backoff: Duration::from_millis(50),
                 max_elapsed_time: Duration::from_millis(50),
+                indefinite_retry: false,
             })
             .build()
             .build(

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -92,10 +92,6 @@ pub(crate) struct ExporterConfigs {
 impl ExporterConfigs {
     /// Set all exporters to use indefinite retry (for Kafka offset tracking)
     pub(crate) fn set_indefinite_retry(&mut self) {
-        use std::time::Duration;
-
-        let indefinite_duration = Duration::from_secs(u64::MAX);
-
         for exporter in self
             .traces
             .iter_mut()
@@ -105,7 +101,7 @@ impl ExporterConfigs {
         {
             match exporter {
                 ExporterConfig::Otlp(config) => {
-                    config.retry_config.max_elapsed_time = indefinite_duration;
+                    config.retry_config.indefinite_retry = true;
                 }
                 ExporterConfig::Datadog(config) => {
                     config.set_indefinite_retry();


### PR DESCRIPTION
New boolean value to indicate we're in indefinite retry mode and add checked_add to ensure we never overflow regardless, because theoretically the user could also set to MAX INT.