### PR TITLE
Fix multi-receivers

### DIFF
--- a/src/bin/rotel/main.rs
+++ b/src/bin/rotel/main.rs
@@ -96,8 +96,9 @@ fn main() -> ExitCode {
                 .split(",")
                 .map(|s| s.to_string().to_lowercase())
                 .collect();
-            if matches!(agent.receiver, Some(Receiver::Otlp))
-                || receivers.contains(&"otlp".to_string())
+            if (agent.receiver.is_none() && agent.receivers.is_none()) || // Defaults to OTLP
+                matches!(agent.receiver, Some(Receiver::Otlp)) ||
+                receivers.contains(&"otlp".to_string())
             {
                 port_map = match bind_endpoints(&[
                     agent.otlp_receiver.otlp_grpc_endpoint,

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -845,6 +845,7 @@ impl Agent {
                     info!(
                         grpc_endpoint = config.otlp_grpc_endpoint.to_string(),
                         http_endpoint = config.otlp_http_endpoint.to_string(),
+                        "OTLP receiver listening"
                     );
                     let grpc_srv = OTLPGrpcServer::builder()
                         .with_max_recv_msg_size_mib(config.otlp_grpc_max_recv_msg_size_mib as usize)

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -60,10 +60,10 @@ pub struct AgentRun {
     pub kafka_receiver: KafkaReceiverArgs,
 
     /// Single receiver (type)
-    #[arg(value_enum, long, env = "ROTEL_RECEIVER", default_value = "otlp")]
+    #[arg(value_enum, long, env = "ROTEL_RECEIVER")]
     pub receiver: Option<Receiver>,
 
-    /// Multiple exporters (name:type,...)
+    /// Multiple receivers (name:type,...)
     #[arg(value_enum, long, env = "ROTEL_RECEIVERS")]
     pub receivers: Option<String>,
 


### PR DESCRIPTION
Fixes the use of multiple receivers via the `--receivers` option flag. We have to remove the clap default since that automatically sets `--receiver`, which conflicts if you specify `--receivers`.
