### PR TITLE
Move Kafka receiver behind rdkafka feature

### DIFF
--- a/src/init/activation.rs
+++ b/src/init/activation.rs
@@ -59,6 +59,7 @@ fn all_traces_receivers_disabled(rc: &HashMap<Receiver, ReceiverConfig>) -> bool
                     return false;
                 }
             }
+            #[cfg(feature = "rdkafka")]
             ReceiverConfig::Kafka(k) => {
                 if k.traces {
                     return false;
@@ -77,6 +78,7 @@ fn all_metrics_receivers_disabled(rc: &HashMap<Receiver, ReceiverConfig>) -> boo
                     return false;
                 }
             }
+            #[cfg(feature = "rdkafka")]
             ReceiverConfig::Kafka(k) => {
                 if k.metrics {
                     return false;
@@ -95,6 +97,7 @@ fn all_logs_receivers_disabled(rc: &HashMap<Receiver, ReceiverConfig>) -> bool {
                     return false;
                 }
             }
+            #[cfg(feature = "rdkafka")]
             ReceiverConfig::Kafka(k) => {
                 if k.logs {
                     return false;

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -19,7 +19,9 @@ use crate::init::datadog_exporter::DatadogRegion;
 use crate::init::pprof;
 use crate::init::wait;
 use crate::listener::Listener;
+#[cfg(feature = "rdkafka")]
 use crate::receivers::kafka::offset_ack_committer::KafkaOffsetCommitter;
+#[cfg(feature = "rdkafka")]
 use crate::receivers::kafka::receiver::KafkaReceiver;
 use crate::receivers::otlp::otlp_grpc::OTLPGrpcServer;
 use crate::receivers::otlp::otlp_http::OTLPHttpServer;
@@ -112,6 +114,7 @@ impl Agent {
         let mut receivers_task_set = JoinSet::new();
         let mut pipeline_task_set = JoinSet::new();
         let mut exporters_task_set = JoinSet::new();
+        #[cfg(feature = "rdkafka")]
         let mut kafka_offset_committer: Option<KafkaOffsetCommitter> = None;
 
         let receivers_cancel = CancellationToken::new();
@@ -136,20 +139,26 @@ impl Agent {
         let internal_metrics_otlp_output = OTLPOutput::new(internal_metrics_pipeline_in_tx);
 
         let rec_config = get_receivers_config(&config)?;
+        #[allow(unused_mut)]
         let mut exp_config = get_exporters_config(&config, &self.environment)?;
 
         // Check if Kafka receiver with offset tracking is enabled
         // Offset tracking is enabled when auto commit is disabled
+        #[cfg(feature = "rdkafka")]
         let kafka_offset_tracking_enabled = rec_config.iter().any(|(_, cfg)| {
+            #[cfg(feature = "rdkafka")]
             matches!(cfg, ReceiverConfig::Kafka(k) if !k.enable_auto_commit && !k.disable_exporter_indefinite_retry)
         });
 
         // Check if finite retry is explicitly enabled (when Kafka offset tracking with disable infinite retry is set)
+        #[cfg(feature = "rdkafka")]
         let finite_retry_enabled = rec_config.iter().any(|(_, cfg)| {
+            #[cfg(feature = "rdkafka")]
             matches!(cfg, ReceiverConfig::Kafka(k) if !k.enable_auto_commit && k.disable_exporter_indefinite_retry)
         });
 
         // Validate configuration: disable_exporter_indefinite_retry requires auto_commit to be disabled
+        #[cfg(feature = "rdkafka")]
         for (name, cfg) in &rec_config {
             if let ReceiverConfig::Kafka(k) = cfg {
                 if k.enable_auto_commit && k.disable_exporter_indefinite_retry {
@@ -168,6 +177,7 @@ impl Agent {
         // HTTP acknowledger will be created per exporter that needs it
 
         // If Kafka offset tracking is enabled, modify retry configs to be indefinite
+        #[cfg(feature = "rdkafka")]
         if kafka_offset_tracking_enabled {
             info!(
                 "Kafka offset tracking enabled - setting exporters to retry indefinitely to ensure no data loss. To disable this behavior, use --kafka-receiver-disable-exporter-indefinite-retry"
@@ -882,6 +892,7 @@ impl Agent {
                         });
                     }
                 }
+                #[cfg(feature = "rdkafka")]
                 ReceiverConfig::Kafka(config) => {
                     let mut kafka = KafkaReceiver::new(
                         config.clone(),
@@ -902,6 +913,7 @@ impl Agent {
 
         // Start the Kafka offset committer if we have one
         let mut kafka_offset_committer_task_set = JoinSet::new();
+        #[cfg(feature = "rdkafka")]
         if let Some(mut committer) = kafka_offset_committer {
             let cancel_token = kafka_offset_committer_cancel.clone();
             kafka_offset_committer_task_set.spawn(async move {

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -6,6 +6,7 @@ use crate::init::datadog_exporter::DatadogExporterArgs;
 use crate::init::file_exporter::FileExporterArgs;
 #[cfg(feature = "rdkafka")]
 use crate::init::kafka_exporter::KafkaExporterArgs;
+#[cfg(feature = "rdkafka")]
 use crate::init::kafka_receiver::KafkaReceiverArgs;
 use crate::init::otlp_exporter::OTLPExporterArgs;
 use crate::init::otlp_receiver::OTLPReceiverArgs;
@@ -256,6 +257,7 @@ impl FromStr for Receiver {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "otlp" => Ok(Receiver::Otlp),
+            #[cfg(feature = "rdkafka")]
             "kafka" => Ok(Receiver::Kafka),
             _ => Err("Unknown receiver"),
         }

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -19,6 +19,7 @@ use crate::init::otlp_exporter::{
 };
 use crate::init::parse::parse_bool_value;
 use crate::init::xray_exporter::XRayExporterArgs;
+#[cfg(feature = "rdkafka")]
 use crate::receivers::kafka::config::KafkaReceiverConfig;
 use crate::receivers::otlp::OTLPReceiverConfig;
 use figment::{Figment, providers::Env};
@@ -91,6 +92,7 @@ pub(crate) struct ExporterConfigs {
 
 impl ExporterConfigs {
     /// Set all exporters to use indefinite retry (for Kafka offset tracking)
+    #[allow(dead_code)] // Allowing for feature flagging Kafka support
     pub(crate) fn set_indefinite_retry(&mut self) {
         for exporter in self
             .traces
@@ -185,6 +187,7 @@ impl ExporterConfig {
             ExporterConfig::Clickhouse(_) => "clickhouse",
             ExporterConfig::Xray(_) => "awsxray",
             ExporterConfig::Awsemf(_) => "awsemf",
+            #[cfg(feature = "rdkafka")]
             ExporterConfig::Kafka(_) => "kafka",
         }
     }

--- a/src/receivers/mod.rs
+++ b/src/receivers/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "rdkafka")]
 pub mod kafka;
 pub mod otlp;
 pub mod otlp_output;


### PR DESCRIPTION
Completes: STR-3558

Move Kafka receiver behind the existing rdkafka flag. This should reduce the binary size for our average Lambda extension users. We'll likely find Lambda users that are triggering Lamba execution from MSK writes to topics or have need of the Kafka exporter. For them we should build a different Lambda layer that includes the Kafka dependency so they can opt-in to the increased image size and start times.