### PR TITLE
Run CI on PRs and releases on the tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/processor-release.yml
+++ b/.github/workflows/processor-release.yml
@@ -1,8 +1,9 @@
 name: processor-release
 
 on:
-  release:
-    types: [ created ]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: release
 
 on:
-  release:
-    types: [ created ]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   release:


### PR DESCRIPTION
Updates the triggers for Github workflows:

## Run CI on Pull Requests (opened, reopened, synchronized)

This still requires owners to approve running actions for third-party PRs.

## Run release workflows on the tag push, not release action. 

While the docs state that the `$github.ref_name` should match the tag associated with the release, I noticed on the firelens project a couple of instances where that was not true. This broke the docker metadata tagging, meaning we didn't update the `latest` image tag. There appear to be other [reports](https://stackoverflow.com/a/77000256) of this too and they suggest switching to a different `$github` variable for the tag name. However, I'm not sure if that fixes the Docker metadata action.

We reference the release entity in the release workflow, so there could still be an issue if a tag was created, but not a release. However, I think that would be rare and it looks like it would hard fail the action instead of silently not pushing the tagged Docker image. Possibly future work to dig into this and switch to the github release variable, but pushing that for future work.