### PR TITLE
Add a flush sub to logs_rx forwarder + biased loop

### DIFF
--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -28,8 +28,7 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "pyo3")]
 use tower::BoxError;
-use tracing::log::warn;
-use tracing::{Level, debug, error};
+use tracing::{Level, debug, error, warn};
 
 //#[derive(Clone)]
 #[allow(dead_code)] // for the sake of the pyo3 feature
@@ -421,6 +420,11 @@ where
                     match resp {
                         (Some(req), listener) => {
                             debug!("received force flush in pipeline: {:?}", req);
+                            let recv_len = self.receiver.len();
+                            if recv_len > 0 {
+                                warn!(receiver_len = recv_len, "received flush on pipeline with pending messages");
+                            }
+
                             batch_timer.reset();
 
                             // Flush pending future if it exists


### PR DESCRIPTION
During extended testing of the lambda-forwarder with a low-volume cloudwatch log group we hit periodic request timeouts. Adding a flush subscriber and marking the logs_rx select loop biased means that the select should drain logs in the logs_rx before selecting on the flush broadcast.

Added a log line in case we enter the flush and there are pending messages on the channel.

Improvement from lambda monitoring after deploying fix at 17:08:

<img width="1070" height="305" alt="Selection_105" src="https://github.com/user-attachments/assets/23d3e5f1-cfca-4682-8900-fc01e812fd59" />
