### PR TITLE
Simplify resource attribute handling and reduce clones

### DIFF
--- a/src/topology/generic_pipeline.rs
+++ b/src/topology/generic_pipeline.rs
@@ -94,18 +94,21 @@ pub fn build_attrs(resource_attributes: Vec<KeyValue>, attributes: &[KeyValue]) 
     if resource_attributes.is_empty() {
         return attributes.to_vec();
     }
-    // Let's retain the order and create a map of keys to reduce the number of iterations required to find/replace an existing key
-    let mut map = indexmap::IndexMap::<String, KeyValue>::new();
-    // Consume the owned resource_attributes without cloning
+    // Let's retain the order and create a map of keys to values (not KeyValue structs)
+    let mut map = indexmap::IndexMap::<String, Option<AnyValue>>::new();
     for attr in resource_attributes {
-        map.insert(attr.key.clone(), attr);
+        map.insert(attr.key, attr.value);
     }
 
     // Now iterate the new attributes and see if we already have a key or not
     for new_attr in attributes {
-        map.insert(new_attr.key.clone(), new_attr.clone());
+        map.insert(new_attr.key.clone(), new_attr.value.clone());
     }
-    map.into_values().collect()
+
+    // Reconstruct KeyValue structs from the map entries
+    map.into_iter()
+        .map(|(key, value)| KeyValue { key, value })
+        .collect()
 }
 
 #[cfg(not(feature = "pyo3"))]


### PR DESCRIPTION
This extracts the mutable resource method from the attribute building, allowing us to simplify the base code.

After this, we reduce the number of clones required here. From claude's summary, the following were reduced:
- ✅ N clones of the `Vec<KeyValue>` structure itself
- ✅ N × M clones of existing resource KeyValues  
- ✅ N × M clones from `map.values().cloned()`
- ✅ N × M clones of `String` keys
(N items in payload, M resource attributes)