### PR TITLE
Add automated RE process

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,140 @@
+name: Auto Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        id: validate
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          echo "Tag name: $TAG_NAME"
+
+          # Verify tag matches semver pattern
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ ERROR: Tag $TAG_NAME does not match semantic versioning pattern"
+            echo "Expected format: vX.Y.Z (e.g., v1.2.3)"
+            exit 1
+          fi
+
+          VERSION="${TAG_NAME#v}"
+          echo "Version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if release already exists
+        id: check_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+
+          # Check if release already exists
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "❌ ERROR: Release for tag $TAG_NAME already exists!"
+            echo "If you want to recreate the release, delete it first:"
+            echo "  gh release delete $TAG_NAME"
+            exit 1
+          fi
+
+          echo "✅ No existing release found for $TAG_NAME"
+
+      - name: Generate release notes
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          VERSION="${{ steps.validate.outputs.version }}"
+
+          # Get the previous tag
+          PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -2 | tail -1)
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous release found, this is the first release"
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
+          fi
+
+          echo "Generating release notes from $PREV_TAG to $TAG_NAME"
+
+          # Get list of merged PRs between tags
+          echo "Fetching merged PRs..."
+          PR_LIST=""
+
+          # Get merge commits between previous tag and current tag
+          MERGE_COMMITS=$(git log ${PREV_TAG}..${TAG_NAME} --merges --pretty=format:"%H %s" | grep "Merge pull request #" || echo "")
+
+          if [ -n "$MERGE_COMMITS" ]; then
+            while IFS= read -r commit_line; do
+              # Extract PR number from commit message (format: "Merge pull request #123 from ...")
+              PR_NUMBER=$(echo "$commit_line" | sed -n 's/.*Merge pull request #\([0-9]*\).*/\1/p')
+
+              if [ -n "$PR_NUMBER" ]; then
+                # Fetch PR details from GitHub API
+                PR_DATA=$(gh pr view "$PR_NUMBER" --json title,author --jq '{title: .title, author: .author.login}')
+                PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+                PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
+
+                # Add to PR list
+                PR_LIST="${PR_LIST}- ${PR_TITLE} by @${PR_AUTHOR} in [#${PR_NUMBER}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER})"$'\n'
+              fi
+            done <<< "$MERGE_COMMITS"
+          fi
+
+          # Generate basic release notes
+          cat > release_notes.md << EOF
+          ### What's Changed
+
+          EOF
+
+          # Add PR list if available
+          if [ -n "$PR_LIST" ]; then
+            echo "$PR_LIST" >> release_notes.md
+            echo "" >> release_notes.md
+          else
+            echo "No merged pull requests found in this release." >> release_notes.md
+            echo "" >> release_notes.md
+          fi
+
+          # Add full changelog link
+          cat >> release_notes.md << EOF
+          ### Full Changelog
+
+          [${PREV_TAG}...${TAG_NAME}](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG_NAME})
+
+          ### Installation
+
+          Download the appropriate binary for your platform from the assets below.
+
+          For detailed installation instructions, see the [README](https://github.com/${{ github.repository }}/blob/main/README.md).
+          EOF
+
+          echo "release_notes_file=release_notes.md" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.PAT_RELEASE_ENGINEER }}
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          VERSION="${{ steps.validate.outputs.version }}"
+
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes-file "${{ steps.release_notes.outputs.release_notes_file }}" \
+            --draft=false \
+            --prerelease=false
+
+          echo "✅ Successfully created release $TAG_NAME"
+          echo "The release workflow will now be triggered to build and upload artifacts."

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,118 @@
+name: Auto Tag on Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  auto-tag:
+    # Only run if PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if PR is a version bump
+        id: check
+        run: |
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          echo "PR branch: $PR_BRANCH"
+
+          # Check if branch matches pattern re/bump-for-*
+          if [[ "$PR_BRANCH" =~ ^re/bump-for-(.+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            echo "This is a version bump PR for version: $VERSION"
+            echo "is_version_bump=true" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "This is not a version bump PR"
+            echo "is_version_bump=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for no-auto-tag label
+        id: check_label
+        if: steps.check.outputs.is_version_bump == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Get PR labels
+          LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name')
+
+          if echo "$LABELS" | grep -q "no-auto-tag"; then
+            echo "PR has 'no-auto-tag' label - skipping automatic tagging"
+            echo "skip_tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "PR does not have 'no-auto-tag' label - will create tag"
+            echo "skip_tag=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if tag already exists
+        if: steps.check.outputs.is_version_bump == 'true' && steps.check_label.outputs.skip_tag == 'false'
+        run: |
+          TAG_NAME="v${{ steps.check.outputs.version }}"
+          echo "Checking if tag $TAG_NAME already exists..."
+
+          # Fetch all tags from remote
+          git fetch --tags
+
+          # Check if tag exists locally or remotely
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "❌ ERROR: Tag $TAG_NAME already exists!"
+            echo "This usually means:"
+            echo "  1. A release for this version was already created"
+            echo "  2. The version in Cargo.toml was not bumped correctly"
+            echo ""
+            echo "To fix this:"
+            echo "  - If the tag is incorrect, delete it: git push --delete origin $TAG_NAME"
+            echo "  - If the version is wrong, create a new version bump PR with the correct version"
+            exit 1
+          fi
+
+          echo "✅ Tag $TAG_NAME does not exist, safe to create"
+
+      - name: Configure git
+        if: steps.check.outputs.is_version_bump == 'true' && steps.check_label.outputs.skip_tag == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Clear git credentials
+        if: steps.check.outputs.is_version_bump == 'true' && steps.check_label.outputs.skip_tag == 'false'
+        run: |
+          git config --unset-all http.https://github.com/.extraheader || true
+          git config --global --unset-all credential.helper || true
+          git config --local --unset-all credential.helper || true
+
+      - name: Create and push tag
+        if: steps.check.outputs.is_version_bump == 'true' && steps.check_label.outputs.skip_tag == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_RELEASE_ENGINEER }}
+        run: |
+          TAG_NAME="v${{ steps.check.outputs.version }}"
+          echo "Creating tag: $TAG_NAME"
+
+          # Create annotated tag
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+
+          # Push tag
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$TAG_NAME"
+
+          echo "✅ Successfully created and pushed tag $TAG_NAME"
+          echo "This will trigger the release workflow."
+
+      - name: Skip tagging notification
+        if: steps.check.outputs.is_version_bump == 'true' && steps.check_label.outputs.skip_tag == 'true'
+        run: |
+          echo "⏭️ Skipping automatic tagging due to 'no-auto-tag' label"
+          echo "To create a release manually, run:"
+          echo "  git tag v${{ steps.check.outputs.version }}"
+          echo "  git push origin v${{ steps.check.outputs.version }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,114 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Read current version and calculate new version
+        id: version
+        run: |
+          # Read current version from Cargo.toml
+          CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "Current version: $CURRENT_VERSION"
+
+          # Split version into parts
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+          # Bump version based on input
+          case "${{ github.event.inputs.bump_type }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "New version: $NEW_VERSION"
+
+          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create branch
+        run: |
+          BRANCH_NAME="re/bump-for-${{ steps.version.outputs.new }}"
+          echo "Creating branch: $BRANCH_NAME"
+          git checkout -b "$BRANCH_NAME"
+          echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Update Cargo.toml version
+        run: |
+          sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.new }}"/' Cargo.toml
+          echo "Updated Cargo.toml to version ${{ steps.version.outputs.new }}"
+
+      - name: Run cargo check to update Cargo.lock
+        run: cargo check
+
+      - name: Commit and push changes
+        run: |
+          git add Cargo.toml Cargo.lock
+          git commit -m "Bump version to ${{ steps.version.outputs.new }}"
+          git push origin "${{ env.branch }}"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.PAT_RELEASE_ENGINEER }}
+        run: |
+          gh pr create \
+            --title "Release: Bump version to ${{ steps.version.outputs.new }}" \
+            --assignee "${{ github.actor }}" \
+            --body "This PR bumps the version from ${{ steps.version.outputs.current }} to ${{ steps.version.outputs.new }}.
+
+          **Bump type:** ${{ github.event.inputs.bump_type }}
+
+          After merging this PR, a tag \`v${{ steps.version.outputs.new }}\` will be automatically created and pushed, which will trigger the release workflow.
+
+          If you want to prevent automatic tagging, add the \`no-auto-tag\` label to this PR before merging." \
+            --base main \
+            --head "${{ env.branch }}"

--- a/.github/workflows/processor-release.yml
+++ b/.github/workflows/processor-release.yml
@@ -1,9 +1,8 @@
 name: processor-release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
   release:
@@ -121,11 +120,13 @@ jobs:
       - name: tar
         run: tar --directory=target/${{ matrix.target }}/release -czf archive.tar.gz rotel
       - name: upload
-        run: |
-          id=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq .id)
-          curl --fail-with-body -sS  -X POST --data-binary @"archive.tar.gz" -H 'Content-Type: application/octet-stream' -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://uploads.github.com/repos/${{ github.repository }}/releases/$id/assets?name=rotel_py_processor_${{matrix.python-version}}_${{ github.ref_name }}_${{ matrix.target }}.tar.gz"
         env:
+          REF_NAME: ${{ github.event.release.tag_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          id=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/releases/tags/${REF_NAME} --jq .id)
+          curl --fail-with-body -sS  -X POST --data-binary @"archive.tar.gz" -H 'Content-Type: application/octet-stream' -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://uploads.github.com/repos/${{ github.repository }}/releases/$id/assets?name=rotel_py_processor_${{matrix.python-version}}_${REF_NAME}_${{ matrix.target }}.tar.gz"
+
   docker-push:
     name: docker push
     runs-on: ubuntu-latest
@@ -159,7 +160,6 @@ jobs:
             type=sha
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -174,6 +174,6 @@ jobs:
           context: .
           file: Dockerfile.python-processor
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [created]
 
 jobs:
   release:
@@ -26,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check version matches tag
         env:
-          REF_NAME: ${{ github.ref_name }}
+          REF_NAME: ${{ github.event.release.tag_name }}
         run: |
           TAG_VERSION="${REF_NAME#v}"
           if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -73,12 +72,12 @@ jobs:
       - name: tar
         run: tar --directory=target/${{ matrix.target }}/release -czf archive.tar.gz rotel
       - name: upload
-        if: github.event_name != 'pull_request'
-        run: |
-          id=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq .id)
-          curl --fail-with-body -sS  -X POST --data-binary @"archive.tar.gz" -H 'Content-Type: application/octet-stream' -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://uploads.github.com/repos/${{ github.repository }}/releases/$id/assets?name=rotel_${{ github.ref_name }}_${{ matrix.target }}.tar.gz"
         env:
+          REF_NAME: ${{ github.event.release.tag_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          id=$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository }}/releases/tags/${REF_NAME} --jq .id)
+          curl --fail-with-body -sS  -X POST --data-binary @"archive.tar.gz" -H 'Content-Type: application/octet-stream' -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://uploads.github.com/repos/${{ github.repository }}/releases/$id/assets?name=rotel_${REF_NAME}_${{ matrix.target }}.tar.gz"
 
   docker-push-rotel:
     name: docker push rotel
@@ -113,7 +112,6 @@ jobs:
             type=sha
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -127,7 +125,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -164,7 +162,6 @@ jobs:
             type=sha
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -179,6 +176,6 @@ jobs:
           context: .
           file: Dockerfile.clickhouse-ddl
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1245,3 +1245,7 @@ your thoughts and ideas. See you there! 🚀
 ## Developing
 
 See the [DEVELOPING.md](DEVELOPING.md) doc for building and development instructions.
+
+## Releasing
+
+For information about creating releases, see [RELEASING.md](RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,128 @@
+# Releasing
+
+This document describes the automated release process for Rotel.
+
+## Overview
+
+Rotel uses an automated release workflow powered by GitHub Actions. The process is designed to be simple and consistent, requiring minimal manual intervention.
+
+## Release Workflow
+
+The release process consists of three main GitHub Actions workflows:
+
+1. **Bump Version** (`bump-version.yml`) - Manually triggered to create a version bump PR
+2. **Auto Tag** (`auto-tag.yml`) - Automatically creates a git tag when a version bump PR is merged
+3. **Auto Release** (`auto-release.yml`) - Automatically creates a GitHub release when a tag is pushed
+
+### Step-by-Step Process
+
+#### 1. Trigger a Version Bump
+
+To start a release, manually trigger the **Bump Version** workflow from the GitHub Actions tab:
+
+1. Go to **Actions** → **Bump Version**
+2. Click **Run workflow**
+3. Select the bump type:
+   - `patch` - for bug fixes (e.g., 0.1.0 → 0.1.1)
+   - `minor` - for new features (e.g., 0.1.0 → 0.2.0)
+   - `major` - for breaking changes (e.g., 0.1.0 → 1.0.0)
+4. Click **Run workflow**
+
+This will:
+- Read the current version from `Cargo.toml`
+- Calculate the new version based on your selection
+- Create a new branch named `re/bump-for-<version>`
+- Update `Cargo.toml` with the new version
+- Run `cargo check` to update `Cargo.lock`
+- Create a pull request with these changes
+
+#### 2. Review and Merge the Version Bump PR
+
+The workflow will create a PR titled "Release: Bump version to X.Y.Z". Review the PR to ensure:
+
+- The version number is correct
+- `Cargo.toml` and `Cargo.lock` are properly updated
+- Any other necessary changes are included
+
+When ready, merge the PR.
+
+**Optional: Skip Automatic Tagging**
+
+If you want to prevent automatic tagging after merging (e.g., you need to make additional changes first), add the `no-auto-tag` label to the PR before merging. You can then manually create the tag later:
+
+```bash
+git tag v<version>
+git push origin v<version>
+```
+
+#### 3. Automatic Tagging
+
+When the version bump PR is merged, the **Auto Tag** workflow automatically:
+
+- Detects that a version bump PR was merged (based on the `re/bump-for-*` branch name)
+- Checks if the tag already exists (fails if it does)
+- Creates an annotated tag `v<version>`
+- Pushes the tag to GitHub
+
+#### 4. Automatic Release Creation
+
+When the tag is pushed, the **Auto Release** workflow automatically:
+
+- Validates the tag format (must be `vX.Y.Z`)
+- Checks if a release already exists (fails if it does)
+- Generates release notes from merged PRs since the last release
+- Creates a GitHub release with the generated notes
+
+The release workflow (if configured) can then build and upload release artifacts.
+
+## Requirements
+
+### GitHub Secrets
+
+The workflows require the following secret to be configured in your repository:
+
+- `PAT_RELEASE_ENGINEER` - A GitHub Personal Access Token with the following permissions:
+  - `contents: write` - for creating tags and releases
+  - `pull-requests: write` - for creating pull requests
+
+This token is used instead of the default `GITHUB_TOKEN` to ensure that the tag push triggers the release workflow (GitHub Actions tokens don't trigger other workflows by design).
+
+## Manual Release Process
+
+If you need to create a release manually (e.g., the automated workflow fails), follow these steps:
+
+### 1. Update the Version
+
+```bash
+# Edit Cargo.toml and update the version number
+vim Cargo.toml
+
+# Update Cargo.lock
+cargo check
+
+# Commit the changes
+git add Cargo.toml Cargo.lock
+git commit -m "Bump version to X.Y.Z"
+git push origin main
+```
+
+### 2. Create and Push the Tag
+
+```bash
+# Create an annotated tag
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+
+# Push the tag
+git push origin vX.Y.Z
+```
+
+### 3. Create the Release
+
+```bash
+# Using GitHub CLI
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --generate-notes
+```
+
+Or create the release manually through the GitHub web interface.


### PR DESCRIPTION
This brings in the same release automation scripts that were added in rotel-lambda-forwarder. The RELEASING.md has more info, but the basic process is:

- Run the workflow Bump Version from the Actions menu
- It will auto-bump the version in Cargo.toml and create a PR
- Merging that PR will auto-tag the repo with the same version
- The tag push will kick off the creation of a release.
- The created release will kick off the build and upload of the assets
- Release notes will be populated as necessary

So the one step is bumping the version, the other steps follow automatically.