### PR TITLE
Release: Bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "rotel"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arrow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rotel"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 homepage = "https://github.com/streamfold/rotel"
 readme = "README.md"


### PR DESCRIPTION
This PR bumps the version from 0.1.5 to 0.1.6.

**Bump type:** patch

After merging this PR, a tag `v0.1.6` will be automatically created and pushed, which will trigger the release workflow.

If you want to prevent automatic tagging, add the `no-auto-tag` label to this PR before merging.