### PR TITLE
Clickhouse Exporter: Remove flattening, just use json object

### DIFF
--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -713,19 +713,19 @@ mod tests {
         if depth == 0 {
             return vec![
                 KeyValue {
-                    key: "leaf.string".to_string(),
+                    key: "leaf-string".to_string(),
                     value: Some(AnyValue {
                         value: Some(AnyValueValue::StringValue("leaf_value".to_string())),
                     }),
                 },
                 KeyValue {
-                    key: "leaf.int".to_string(),
+                    key: "leaf-int".to_string(),
                     value: Some(AnyValue {
                         value: Some(AnyValueValue::IntValue(42)),
                     }),
                 },
                 KeyValue {
-                    key: "leaf.bool".to_string(),
+                    key: "leaf-bool".to_string(),
                     value: Some(AnyValue {
                         value: Some(AnyValueValue::BoolValue(true)),
                     }),
@@ -742,7 +742,7 @@ mod tests {
                 value: Some(AnyValueValue::KvlistValue(KeyValueList {
                     values: vec![
                         KeyValue {
-                            key: format!("array_item_{}.key", i),
+                            key: format!("array_item_{}-key", i),
                             value: Some(AnyValue {
                                 value: Some(AnyValueValue::StringValue(format!(
                                     "array_value_{}",
@@ -751,7 +751,7 @@ mod tests {
                             }),
                         },
                         KeyValue {
-                            key: format!("array_item_{}.nested", i),
+                            key: format!("array_item_{}-nested", i),
                             value: Some(AnyValue {
                                 value: Some(AnyValueValue::KvlistValue(KeyValueList {
                                     values: vec![
@@ -783,7 +783,7 @@ mod tests {
 
         vec![
             KeyValue {
-                key: format!("level{}.string", depth),
+                key: format!("level{}-string", depth),
                 value: Some(AnyValue {
                     value: Some(AnyValueValue::StringValue(format!(
                         "value_at_depth_{}",
@@ -792,7 +792,7 @@ mod tests {
                 }),
             },
             KeyValue {
-                key: format!("level{}.nested_kv", depth),
+                key: format!("level{}-nested_kv", depth),
                 value: Some(AnyValue {
                     value: Some(AnyValueValue::KvlistValue(KeyValueList {
                         values: child_attrs,
@@ -800,7 +800,7 @@ mod tests {
                 }),
             },
             KeyValue {
-                key: format!("level{}.array_of_maps", depth),
+                key: format!("level{}-array_of_maps", depth),
                 value: Some(AnyValue {
                     value: Some(AnyValueValue::ArrayValue(ArrayValue {
                         values: array_items,
@@ -808,7 +808,7 @@ mod tests {
                 }),
             },
             KeyValue {
-                key: format!("level{}.double", depth),
+                key: format!("level{}-double", depth),
                 value: Some(AnyValue {
                     value: Some(AnyValueValue::DoubleValue(depth as f64 * 3.14)),
                 }),

--- a/src/exporters/clickhouse/rowbinary/json.rs
+++ b/src/exporters/clickhouse/rowbinary/json.rs
@@ -73,8 +73,7 @@ pub fn anyvalue_to_jsontype<'a>(
 ///   In flat mode (`max_depth = None`) only depth-0 arrays are preserved; elements at
 ///   depth ≥ 1 are flattened (complex types → JSON strings).
 /// - `KvlistValue`: converted to `JsonType::Object` only in explicit nested mode
-///   (`max_depth = Some(n)`) and when `depth <= n`. In flat mode it is always a JSON string
-///   because KvList flattening is handled at the transformer level via path expansion.
+///   (`max_depth = Some(n)`) and when `depth <= n`. In flat mode it is always a JSON string.
 fn anyvalue_to_jsontype_nested<'a>(
     value: &'a AnyValue,
     depth: usize,
@@ -110,8 +109,7 @@ fn anyvalue_to_jsontype_nested<'a>(
 
         Some(Value::KvlistValue(kv)) => {
             // KvList is only converted to Object in explicit nested mode and within depth.
-            // Flat mode always serialises it as a JSON string; the transformer handles
-            // top-level KvList flattening via dotted-path expansion instead.
+            // Flat mode always serialises it as a JSON string.
             let within_depth = match max_depth {
                 None => false,
                 Some(d) => depth <= d,

--- a/src/exporters/clickhouse/transform_traces.rs
+++ b/src/exporters/clickhouse/transform_traces.rs
@@ -433,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    fn test_kvlist_flattening_in_spans() {
+    fn test_kvlist_nesting_in_spans() {
         use opentelemetry_proto::tonic::common::v1::KeyValueList;
         use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueValue;
 
@@ -526,7 +526,7 @@ mod tests {
             ..Default::default()
         };
 
-        // Transform and verify it succeeds with flattened attributes
+        // Transform and verify it succeeds with nested KvlistValue attributes
         let (result, _metadata) = transformer.transform(vec![Message {
             payload: vec![resource_spans],
             metadata: None,
@@ -540,7 +540,7 @@ mod tests {
 
         let payloads = result.unwrap();
         assert_eq!(payloads.len(), 1);
-        // The actual flattening is verified by the transformer tests
+        // The actual nesting behavior is verified by the transformer tests
         // This test ensures the integration works end-to-end
     }
 }

--- a/src/exporters/clickhouse/transformer.rs
+++ b/src/exporters/clickhouse/transformer.rs
@@ -87,47 +87,19 @@ impl Transformer {
         &self,
         attrs: &'a [KeyValue],
     ) -> HashMap<Cow<'a, str>, JsonType<'a>> {
-        let mut hm = HashMap::new();
-        self.flatten_keyvalues_borrowed(attrs, String::new(), &mut hm);
-        hm
-    }
-
-    fn flatten_keyvalues_borrowed<'a>(
-        &self,
-        attrs: &'a [KeyValue],
-        prefix: String,
-        result: &mut HashMap<Cow<'a, str>, JsonType<'a>>,
-    ) {
         use crate::exporters::clickhouse::rowbinary::json::anyvalue_to_jsontype;
-        use opentelemetry_proto::tonic::common::v1::any_value::Value;
-
+        let mut hm = HashMap::new();
         for kv in attrs {
             if let Some(any_value) = &kv.value {
-                match &any_value.value {
-                    Some(Value::KvlistValue(kvlist)) => {
-                        let full_key = if prefix.is_empty() {
-                            kv.key.clone()
-                        } else {
-                            format!("{}.{}", prefix, kv.key)
-                        };
-                        self.flatten_keyvalues_borrowed(&kvlist.values, full_key, result);
-                    }
-                    Some(_) => {
-                        // Optimize for common case: avoid clone when prefix is empty
-                        let key = if prefix.is_empty() {
-                            Cow::Borrowed(kv.key.as_str())
-                        } else {
-                            Cow::Owned(format!("{}.{}", prefix, kv.key))
-                        };
-                        result.insert(
-                            key,
-                            anyvalue_to_jsontype(any_value, Some(self.nested_kv_max_depth)),
-                        );
-                    }
-                    None => {}
+                if any_value.value.is_some() {
+                    hm.insert(
+                        Cow::Borrowed(kv.key.as_str()),
+                        anyvalue_to_jsontype(any_value, Some(self.nested_kv_max_depth)),
+                    );
                 }
             }
         }
+        hm
     }
 
     pub(crate) fn transform_attrs_kv_owned(&self, attrs: &[KeyValue]) -> MapOrJson<'static> {
@@ -138,46 +110,22 @@ impl Transformer {
     }
 
     fn build_json_attrs_kv_owned(&self, attrs: &[KeyValue]) -> HashMap<String, JsonType<'static>> {
-        let mut hm = HashMap::new();
-        self.flatten_keyvalues_owned(attrs, String::new(), &mut hm);
-        hm
-    }
-
-    fn flatten_keyvalues_owned(
-        &self,
-        attrs: &[KeyValue],
-        prefix: String,
-        result: &mut HashMap<String, JsonType<'static>>,
-    ) {
         use crate::exporters::clickhouse::rowbinary::json::anyvalue_to_jsontype_owned;
-        use opentelemetry_proto::tonic::common::v1::any_value::Value;
-
+        let mut hm = HashMap::new();
         for kv in attrs {
-            let full_key = if prefix.is_empty() {
-                kv.key.clone()
-            } else {
-                format!("{}.{}", prefix, kv.key)
-            };
-
             if let Some(any_value) = &kv.value {
-                match &any_value.value {
-                    Some(Value::KvlistValue(kvlist)) => {
-                        // Recursively flatten nested key-value lists
-                        self.flatten_keyvalues_owned(&kvlist.values, full_key, result);
-                    }
-                    Some(_) => {
-                        result.insert(
-                            full_key,
-                            anyvalue_to_jsontype_owned(
-                                any_value.clone(),
-                                Some(self.nested_kv_max_depth),
-                            ),
-                        );
-                    }
-                    None => {}
+                if any_value.value.is_some() {
+                    hm.insert(
+                        kv.key.clone(),
+                        anyvalue_to_jsontype_owned(
+                            any_value.clone(),
+                            Some(self.nested_kv_max_depth),
+                        ),
+                    );
                 }
             }
         }
+        hm
     }
 
     fn anyvalue_to_string(
@@ -550,23 +498,32 @@ mod tests {
 
         match result {
             MapOrJson::Json(map) => {
-                assert_eq!(map.len(), 3);
+                assert_eq!(map.len(), 2);
                 assert!(map.contains_key("simple"));
-                assert!(map.contains_key("metadata.region"));
-                assert!(map.contains_key("metadata.zone"));
-                assert!(!map.contains_key("metadata"));
+                // metadata is preserved as a nested Object, not flattened
+                match map.get("metadata") {
+                    Some(JsonType::Object(entries)) => {
+                        assert_eq!(entries.len(), 2);
+                        assert!(entries.iter().any(|(k, _)| k.as_ref() == "region"));
+                        assert!(entries.iter().any(|(k, _)| k.as_ref() == "zone"));
+                    }
+                    other => panic!("Expected metadata to be JsonType::Object, got {:?}", other),
+                }
+                assert!(!map.contains_key("metadata.region"));
+                assert!(!map.contains_key("metadata.zone"));
             }
             _ => panic!("Expected JSON variant"),
         }
     }
 
     #[test]
-    fn test_transform_attrs_kv_flatten_nested_kvlist() {
+    fn test_transform_attrs_kv_nested_kvlist() {
         use opentelemetry_proto::tonic::common::v1::AnyValue;
         use opentelemetry_proto::tonic::common::v1::KeyValueList;
         use opentelemetry_proto::tonic::common::v1::any_value::Value;
 
-        let transformer = Transformer::new(Compression::None, true);
+        // Use nested_kv_max_depth=2 so all three levels are converted to Objects.
+        let transformer = Transformer::new(Compression::None, true).with_nested_kv_max_depth(2);
 
         let attrs = vec![KeyValue {
             key: "outer".to_string(),
@@ -601,18 +558,41 @@ mod tests {
 
         match result {
             MapOrJson::Json(map) => {
-                assert_eq!(map.len(), 2);
-                assert!(map.contains_key("outer.middle.inner"));
-                assert!(map.contains_key("outer.sibling"));
-                assert!(!map.contains_key("outer"));
-                assert!(!map.contains_key("outer.middle"));
+                assert_eq!(map.len(), 1);
+                // outer is preserved as a nested Object
+                match map.get("outer") {
+                    Some(JsonType::Object(outer_entries)) => {
+                        assert_eq!(outer_entries.len(), 2);
+                        // middle is itself a nested Object
+                        let middle = outer_entries.iter().find(|(k, _)| k.as_ref() == "middle");
+                        match middle {
+                            Some((_, JsonType::Object(middle_entries))) => {
+                                assert_eq!(middle_entries.len(), 1);
+                                assert!(middle_entries.iter().any(|(k, _)| k.as_ref() == "inner"));
+                            }
+                            other => {
+                                panic!("Expected middle to be JsonType::Object, got {:?}", other)
+                            }
+                        }
+                        let sibling = outer_entries.iter().find(|(k, _)| k.as_ref() == "sibling");
+                        match sibling {
+                            Some((_, JsonType::Int(42))) => {}
+                            other => {
+                                panic!("Expected sibling to be JsonType::Int(42), got {:?}", other)
+                            }
+                        }
+                    }
+                    other => panic!("Expected outer to be JsonType::Object, got {:?}", other),
+                }
+                assert!(!map.contains_key("outer.middle.inner"));
+                assert!(!map.contains_key("outer.sibling"));
             }
             _ => panic!("Expected JSON variant"),
         }
     }
 
     #[test]
-    fn test_transform_attrs_kv_owned_flatten_kvlist() {
+    fn test_transform_attrs_kv_owned_kvlist() {
         use opentelemetry_proto::tonic::common::v1::AnyValue;
         use opentelemetry_proto::tonic::common::v1::KeyValueList;
         use opentelemetry_proto::tonic::common::v1::any_value::Value;
@@ -653,11 +633,19 @@ mod tests {
 
         match result {
             MapOrJson::JsonOwned(map) => {
-                assert_eq!(map.len(), 3);
+                assert_eq!(map.len(), 2);
                 assert!(map.contains_key("simple"));
-                assert!(map.contains_key("metadata.region"));
-                assert!(map.contains_key("metadata.zone"));
-                assert!(!map.contains_key("metadata"));
+                // metadata is preserved as a nested Object, not flattened
+                match map.get("metadata") {
+                    Some(JsonType::Object(entries)) => {
+                        assert_eq!(entries.len(), 2);
+                        assert!(entries.iter().any(|(k, _)| k.as_ref() == "region"));
+                        assert!(entries.iter().any(|(k, _)| k.as_ref() == "zone"));
+                    }
+                    other => panic!("Expected metadata to be JsonType::Object, got {:?}", other),
+                }
+                assert!(!map.contains_key("metadata.region"));
+                assert!(!map.contains_key("metadata.zone"));
             }
             _ => panic!("Expected JsonOwned variant"),
         }


### PR DESCRIPTION
Now that we've added encoding support for JSON objects, rely on that encoding for all key/value entries. Previously we used a flattening approach for nested k/v's, but that isn't necessary with the JSON object support. This will better respect the k/v depth option for all nested types.