### PR TITLE
[POC] Add export group failover and Kafka DLQ replay routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,10 @@ harness = false
 name = "encode_otlp_trace_bench"
 harness = false
 
+[[bench]]
+name = "export_group"
+harness = false
+
 [[bin]]
 name = "rotel"
 

--- a/benches/export_group.rs
+++ b/benches/export_group.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Benchmarks for the ExportGroup<T> hot path.
+//
+// Bench A: baseline — one exporter channel, always acks (no group overhead).
+// Bench B: group CLOSED — 2-member group, primary (m0) always acks.
+// Bench C: group OPEN steady-state — 2-member group pre-tripped, m1 always acks.
+// Bench D: group retry worst-case — m0 always nacks, m1 acks (2× clones per batch).
+//
+// Acceptance target: B and C within ~15% of A on per-batch throughput.
+// Numbers are reported in the PR; D is informational only.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+use rotel::bounded_channel::{BoundedReceiver, bounded};
+use rotel::topology::export_group::ExportGroupBuilder;
+use rotel::topology::payload::{Ack, ExporterError, Message};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use utilities::otlp::FakeOTLP;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_batch(resource_spans: &[ResourceSpans]) -> Vec<Message<ResourceSpans>> {
+    resource_spans
+        .iter()
+        .cloned()
+        .map(|rs| Message::new(None, vec![rs], None))
+        .collect()
+}
+
+/// Spawn a task that drains `rx`, always acks the forwarder metadata, and loops.
+fn spawn_always_ack(rt: &Runtime, rx: BoundedReceiver<Vec<Message<ResourceSpans>>>) {
+    let mut rx = rx;
+    rt.spawn(async move {
+        loop {
+            match rx.next().await {
+                None => break,
+                Some(batch) => {
+                    for msg in &batch {
+                        if let Some(meta) = &msg.metadata {
+                            let _ = meta.ack().await;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Spawn a task that drains `rx`, always nacks the forwarder metadata, and loops.
+fn spawn_always_nack(rt: &Runtime, rx: BoundedReceiver<Vec<Message<ResourceSpans>>>) {
+    let mut rx = rx;
+    rt.spawn(async move {
+        loop {
+            match rx.next().await {
+                None => break,
+                Some(batch) => {
+                    for msg in &batch {
+                        if let Some(meta) = &msg.metadata {
+                            let _ = meta.nack(ExporterError::Cancelled).await;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+// ─── Bench A: baseline (no group) ────────────────────────────────────────────
+
+fn bench_baseline(c: &mut Criterion, spans: &[ResourceSpans], label: &str) {
+    let rt = Runtime::new().unwrap();
+    let (tx, rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    spawn_always_ack(&rt, rx);
+
+    let batch = make_batch(spans);
+    let batch_bytes = spans
+        .iter()
+        .map(|s| prost::Message::encoded_len(s))
+        .sum::<usize>() as u64;
+
+    let mut group = c.benchmark_group("export_group");
+    group.throughput(Throughput::Bytes(batch_bytes));
+    group.bench_function(BenchmarkId::new("A_baseline", label), |b| {
+        b.to_async(&rt).iter(|| async {
+            tx.send(criterion::black_box(batch.clone())).await.unwrap();
+        });
+    });
+    group.finish();
+}
+
+// ─── Bench B: group CLOSED (m0 always acks) ──────────────────────────────────
+
+fn bench_group_closed(c: &mut Criterion, spans: &[ResourceSpans], label: &str) {
+    let rt = Runtime::new().unwrap();
+    let _guard = rt.enter();
+    let (m0_tx, m0_rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    let (m1_tx, _m1_rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    spawn_always_ack(&rt, m0_rx);
+
+    let group = ExportGroupBuilder::<ResourceSpans>::new(256)
+        .add_member(m0_tx)
+        .add_member(m1_tx)
+        .trip_after(100)
+        .probe_after(Duration::from_secs(30))
+        .build();
+    let sender = group.sender();
+
+    let batch = make_batch(spans);
+    let batch_bytes = spans
+        .iter()
+        .map(|s| prost::Message::encoded_len(s))
+        .sum::<usize>() as u64;
+
+    let mut crit_group = c.benchmark_group("export_group");
+    crit_group.throughput(Throughput::Bytes(batch_bytes));
+    crit_group.bench_function(BenchmarkId::new("B_group_closed", label), |b| {
+        b.to_async(&rt).iter(|| async {
+            sender
+                .send(criterion::black_box(batch.clone()))
+                .await
+                .unwrap();
+        });
+    });
+    crit_group.finish();
+}
+
+// ─── Bench C: group OPEN steady-state (m1 always acks, active=1) ─────────────
+
+fn bench_group_open(c: &mut Criterion, spans: &[ResourceSpans], label: &str) {
+    let rt = Runtime::new().unwrap();
+    let _guard = rt.enter();
+    let (m0_tx, _m0_rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    let (m1_tx, m1_rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    // Drop m0_rx so sends to m0 fail → breaker trips on the first batch.
+    drop(_m0_rx);
+    spawn_always_ack(&rt, m1_rx);
+
+    let group = ExportGroupBuilder::<ResourceSpans>::new(256)
+        .add_member(m0_tx)
+        .add_member(m1_tx)
+        .trip_after(1) // trip after first nack
+        .probe_after(Duration::from_secs(3600)) // disable probe during bench
+        .build();
+    let mut active_rx = group.subscribe_active();
+    let sender = group.sender();
+
+    // Prime: send one batch to trip the breaker (m0 closed → immediate nack → walk to m1).
+    rt.block_on(async {
+        let prime = make_batch(spans);
+        sender.send(prime).await.unwrap();
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+    });
+
+    let batch = make_batch(spans);
+    let batch_bytes = spans
+        .iter()
+        .map(|s| prost::Message::encoded_len(s))
+        .sum::<usize>() as u64;
+
+    let mut crit_group = c.benchmark_group("export_group");
+    crit_group.throughput(Throughput::Bytes(batch_bytes));
+    crit_group.bench_function(BenchmarkId::new("C_group_open", label), |b| {
+        b.to_async(&rt).iter(|| async {
+            sender
+                .send(criterion::black_box(batch.clone()))
+                .await
+                .unwrap();
+        });
+    });
+    crit_group.finish();
+}
+
+// ─── Bench D: retry worst-case (m0 nacks → m1 acks, 2× clones) ───────────────
+
+fn bench_group_retry(c: &mut Criterion, spans: &[ResourceSpans], label: &str) {
+    let rt = Runtime::new().unwrap();
+    let _guard = rt.enter();
+    let (m0_tx, m0_rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    let (m1_tx, m1_rx) = bounded::<Vec<Message<ResourceSpans>>>(256);
+    spawn_always_nack(&rt, m0_rx);
+    spawn_always_ack(&rt, m1_rx);
+
+    let group = ExportGroupBuilder::<ResourceSpans>::new(256)
+        .add_member(m0_tx)
+        .add_member(m1_tx)
+        .trip_after(u32::MAX) // never trip; always retry
+        .probe_after(Duration::ZERO)
+        .build();
+    let sender = group.sender();
+
+    let batch = make_batch(spans);
+    let batch_bytes = spans
+        .iter()
+        .map(|s| prost::Message::encoded_len(s))
+        .sum::<usize>() as u64;
+
+    let mut crit_group = c.benchmark_group("export_group");
+    crit_group.throughput(Throughput::Bytes(batch_bytes));
+    crit_group.bench_function(BenchmarkId::new("D_group_retry", label), |b| {
+        b.to_async(&rt).iter(|| async {
+            sender
+                .send(criterion::black_box(batch.clone()))
+                .await
+                .unwrap();
+        });
+    });
+    crit_group.finish();
+}
+
+// ─── entry point ─────────────────────────────────────────────────────────────
+
+fn export_group_benchmarks(c: &mut Criterion) {
+    let small_req = FakeOTLP::trace_service_request();
+    let medium_req = FakeOTLP::trace_service_request_with_spans(1, 10);
+    let large_req = FakeOTLP::trace_service_request_with_spans(1, 100);
+
+    let cases: &[(&str, &[ResourceSpans])] = &[
+        ("small", &small_req.resource_spans),
+        ("medium", &medium_req.resource_spans),
+        ("large", &large_req.resource_spans),
+    ];
+
+    for (label, spans) in cases {
+        bench_baseline(c, spans, label);
+        bench_group_closed(c, spans, label);
+        bench_group_open(c, spans, label);
+        bench_group_retry(c, spans, label);
+    }
+}
+
+criterion_group!(benches, export_group_benchmarks);
+criterion_main!(benches);

--- a/examples/fallback-dlq/README.md
+++ b/examples/fallback-dlq/README.md
@@ -1,0 +1,111 @@
+# Rotel Fallback DLQ Example
+
+This example demonstrates how to configure Rotel for high availability using a Kafka-based Dead Letter Queue (DLQ) for fallback and automatic recovery.
+
+## What this demonstrates
+
+1.  **Normal Path**: OTLP data is received by Rotel and exported directly to ClickHouse.
+2.  **Fallback Path**: When ClickHouse is unavailable, Rotel automatically falls back to exporting data to Kafka (the DLQ).
+3.  **Recovery Path**: The same Rotel process consumes from the Kafka DLQ and replays the data to ClickHouse once it's back online.
+
+## Architecture
+
+```mermaid
+graph TD
+    App[OTLP App] -->|OTLP HTTP/gRPC| Rotel
+    
+    subgraph Rotel [Rotel Agent]
+        Receiver[OTLP Receiver]
+        ExportGroup{Export Group: live}
+        KafkaReceiver[Kafka Receiver]
+        
+        Receiver --> ExportGroup
+        ExportGroup -->|Primary| CH[ClickHouse Exporter: ch]
+        ExportGroup -->|Fallback| DLQ[Kafka Exporter: dlq]
+        
+        KafkaReceiver -->|Replay| CH_Replay[ClickHouse Exporter: ch_replay]
+    end
+    
+    CH --> ClickHouse[(ClickHouse)]
+    CH_Replay --> ClickHouse
+    DLQ --> Kafka((Kafka DLQ))
+    Kafka --> KafkaReceiver
+```
+
+### Why `ch_replay` exists
+
+Rotel's Kafka receiver supports offset tracking, which ensures that messages are only committed after they have been successfully exported. However, to prevent data loss during recovery, Kafka receiver targets are configured to retry indefinitely. 
+
+Rotel validation rules prohibit an exporter from being both a member of an export group (which has its own failover logic) and a target of a Kafka receiver with offset tracking. To work around this, we define two logical exporters:
+- `ch`: The primary member of the `live` export group.
+- `ch_replay`: The target for the Kafka recovery receiver.
+
+Both point to the same physical ClickHouse endpoint.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with Compose plugin.
+- [mise](https://mise.jdx.sh/) task runner.
+- Rust toolchain (to build Rotel).
+
+## Runbook
+
+Follow this flow to see fallback and recovery in action.
+
+```bash
+cd examples/fallback-dlq
+mise run reset
+mise run up
+mise run build
+mise run ddl
+```
+
+In terminal 1, start Rotel. This stays in the foreground so you can watch fallback and replay logs.
+
+```bash
+mise run rotel:start
+```
+
+In terminal 2, send data while ClickHouse is healthy and verify it landed in ClickHouse.
+
+```bash
+mise run send
+mise run verify:clickhouse
+```
+
+Stop ClickHouse, send more data, then verify Kafka received the fallback data.
+
+```bash
+mise run clickhouse:stop
+mise run send
+mise run verify:kafka
+```
+
+Observe the Rotel logs. You should see ClickHouse export errors and Rotel falling back to the `dlq` (Kafka) exporter. The Kafka receiver will also start attempting to replay this data but will be held in a retry loop because ClickHouse is down.
+
+Restart ClickHouse, wait for replay, then verify ClickHouse row counts and Kafka consumer offsets.
+
+```bash
+mise run clickhouse:start
+sleep 10
+mise run verify:clickhouse
+mise run verify:kafka
+```
+
+To stop containers but keep data:
+
+```bash
+mise run down
+```
+
+To stop containers and remove data/offsets:
+
+```bash
+mise run reset
+```
+
+## Troubleshooting
+
+- **Config Rejected**: If Rotel fails to start with a configuration error, ensure that `ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_*` points to `ch_replay` and NOT `ch`.
+- **Missing Tables**: If ClickHouse inserts fail, ensure you ran `mise run ddl`.
+- **Kafka Connection**: If Rotel cannot connect to Kafka, check `KAFKA_ADVERTISED_LISTENERS` in `docker-compose.yml` exposes `localhost:9092`.

--- a/examples/fallback-dlq/docker-compose.yml
+++ b/examples/fallback-dlq/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  kafka:
+    image: apache/kafka:3.7.0
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_NODE_ID=1
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_LISTENERS=PLAINTEXT://:29092,CONTROLLER://:29093,EXTERNAL://:9092
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,EXTERNAL://localhost:9092
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:29093
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - CLUSTER_ID=4L6g3nShT-eMCtK--X86sw
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_LOG_DIRS=/tmp/kraft-combined-logs
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_NUM_PARTITIONS=1
+      - KAFKA_DEFAULT_REPLICATION_FACTOR=1
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.4
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=password
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144

--- a/examples/fallback-dlq/mise.toml
+++ b/examples/fallback-dlq/mise.toml
@@ -1,0 +1,89 @@
+[tasks]
+build = { run = "cd ../.. && cargo build --release --bins --target-dir target", description = "Build rotel and helper binaries" }
+up = { run = "docker compose up -d", description = "Start Kafka and ClickHouse" }
+down = { run = "docker compose down", description = "Stop Kafka and ClickHouse" }
+reset = { run = "docker compose down -v --remove-orphans", description = "Reset all data and offsets" }
+
+ddl = { run = [
+    "curl -s -u default:password --data 'CREATE DATABASE IF NOT EXISTS otel' http://localhost:8123/",
+    "../../target/release/clickhouse-ddl create --endpoint localhost:8123 --user default --password password --traces --metrics --logs"
+], description = "Apply ClickHouse DDL" }
+
+send = { run = [
+    "../../target/release/generate-otlp traces --http-endpoint localhost:4318 --resources 1 --items 1",
+    "../../target/release/generate-otlp metrics --http-endpoint localhost:4318 --resources 1 --items 1",
+    "../../target/release/generate-otlp logs --http-endpoint localhost:4318 --resources 1 --items 1"
+], description = "Send test OTLP data" }
+
+"clickhouse:stop" = { run = "docker compose stop clickhouse", description = "Simulate ClickHouse failure" }
+"clickhouse:start" = { run = "docker compose start clickhouse", description = "Recover ClickHouse" }
+
+"verify:clickhouse" = { run = """
+    echo "--- Traces ---"
+    curl -s -u default:password --data "SELECT count() FROM otel.otel_traces" http://localhost:8123/
+    echo "--- Metrics (Gauge) ---"
+    curl -s -u default:password --data "SELECT count() FROM otel.otel_metrics_gauge" http://localhost:8123/
+    echo "--- Logs ---"
+    curl -s -u default:password --data "SELECT count() FROM otel.otel_logs" http://localhost:8123/
+""", description = "Verify row counts in ClickHouse" }
+
+"verify:kafka" = { run = [
+    "docker compose exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:29092 --describe --topic otlp_traces",
+    "docker compose exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:29092 --describe --topic otlp_metrics",
+    "docker compose exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server kafka:29092 --describe --topic otlp_logs",
+    "docker compose exec kafka /opt/kafka/bin/kafka-consumer-groups.sh --bootstrap-server kafka:29092 --describe --group rotel-dlq-recovery"
+], description = "Inspect Kafka topics and consumer group" }
+
+[tasks."rotel:start"]
+run = "../../target/release/rotel --log-format text start"
+description = "Start Rotel agent in foreground"
+
+[tasks."rotel:start".env]
+# Rotel Configuration
+ROTEL_RECEIVERS = "otlp,kafka"
+ROTEL_EXPORTERS = "ch:clickhouse,ch_replay:clickhouse,dlq:kafka"
+
+# Pipeline Exporters
+ROTEL_EXPORTERS_TRACES = "ch,ch_replay,dlq"
+ROTEL_EXPORTERS_METRICS = "ch,ch_replay,dlq"
+ROTEL_EXPORTERS_LOGS = "ch,ch_replay,dlq"
+
+# Export Groups
+ROTEL_EXPORT_GROUPS_TRACES = "live=ch,dlq"
+ROTEL_EXPORT_GROUPS_METRICS = "live=ch,dlq"
+ROTEL_EXPORT_GROUPS_LOGS = "live=ch,dlq"
+
+# ClickHouse Exporters (both point to the same endpoint)
+ROTEL_EXPORTER_CH_ENDPOINT = "http://localhost:8123"
+ROTEL_EXPORTER_CH_USER = "default"
+ROTEL_EXPORTER_CH_PASSWORD = "password"
+ROTEL_EXPORTER_CH_REPLAY_ENDPOINT = "http://localhost:8123"
+ROTEL_EXPORTER_CH_REPLAY_USER = "default"
+ROTEL_EXPORTER_CH_REPLAY_PASSWORD = "password"
+
+# Kafka Exporter (named `dlq:kafka`, so use the named-exporter env prefix)
+ROTEL_EXPORTER_DLQ_BROKERS = "localhost:9092"
+ROTEL_EXPORTER_DLQ_TRACES_TOPIC = "otlp_traces"
+ROTEL_EXPORTER_DLQ_METRICS_TOPIC = "otlp_metrics"
+ROTEL_EXPORTER_DLQ_LOGS_TOPIC = "otlp_logs"
+
+# Kafka Receiver
+ROTEL_KAFKA_RECEIVER_BROKERS = "localhost:9092"
+ROTEL_KAFKA_RECEIVER_TRACES = "true"
+ROTEL_KAFKA_RECEIVER_METRICS = "true"
+ROTEL_KAFKA_RECEIVER_LOGS = "true"
+ROTEL_KAFKA_RECEIVER_TRACES_TOPIC = "otlp_traces"
+ROTEL_KAFKA_RECEIVER_METRICS_TOPIC = "otlp_metrics"
+ROTEL_KAFKA_RECEIVER_LOGS_TOPIC = "otlp_logs"
+ROTEL_KAFKA_RECEIVER_GROUP_ID = "rotel-dlq-recovery"
+ROTEL_KAFKA_RECEIVER_AUTO_OFFSET_RESET = "earliest"
+
+# Kafka Receiver Targets (must be ch_replay to allow offset tracking)
+ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_TRACES = "ch_replay"
+ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_METRICS = "ch_replay"
+ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_LOGS = "ch_replay"
+
+# Demo-specific tuning
+ROTEL_EXPORT_GROUP_TRIP_AFTER = "1"
+ROTEL_EXPORT_GROUP_PROBE_AFTER = "5s"
+ROTEL_EXPORT_GROUP_MEMBER_RETRY_MAX_ELAPSED_TIME = "2s"

--- a/src/exporters/awsemf/mod.rs
+++ b/src/exporters/awsemf/mod.rs
@@ -86,7 +86,7 @@ pub struct AwsEmfExporterConfig {
 }
 
 pub struct AwsEmfExporterConfigBuilder {
-    config: AwsEmfExporterConfig,
+    pub(crate) config: AwsEmfExporterConfig,
 }
 
 impl AwsEmfExporterConfigBuilder {

--- a/src/exporters/clickhouse/mod.rs
+++ b/src/exporters/clickhouse/mod.rs
@@ -62,7 +62,7 @@ pub enum Compression {
 
 #[derive(Clone)]
 pub struct ClickhouseExporterConfigBuilder {
-    retry_config: RetryConfig,
+    pub(crate) retry_config: RetryConfig,
     compression: Compression,
     endpoint: String,
     database: String,
@@ -98,6 +98,27 @@ pub type ExporterType<'a, Resource> = Exporter<
 >;
 
 impl ClickhouseExporterConfigBuilder {
+    /// Convenience constructor with a standard retry configuration (5s → 30s backoff, 300s budget).
+    /// When used as an export-group member the group's `member_retry_max_elapsed_time` cap
+    /// (default 20s) takes precedence and overrides `max_elapsed_time` at startup.
+    pub fn with_defaults(
+        endpoint: String,
+        database: String,
+        table_prefix: String,
+    ) -> ClickhouseExporterConfigBuilder {
+        Self::new(
+            endpoint,
+            database,
+            table_prefix,
+            RetryConfig {
+                initial_backoff: Duration::from_secs(5),
+                max_backoff: Duration::from_secs(30),
+                max_elapsed_time: Duration::from_secs(300),
+                indefinite_retry: false,
+            },
+        )
+    }
+
     pub fn new(
         endpoint: String,
         database: String,
@@ -151,6 +172,11 @@ impl ClickhouseExporterConfigBuilder {
 
     pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
         self.request_timeout = timeout;
+        self
+    }
+
+    pub fn with_retry_max_elapsed_time(mut self, max_elapsed_time: Duration) -> Self {
+        self.retry_config.max_elapsed_time = max_elapsed_time;
         self
     }
 

--- a/src/exporters/datadog/mod.rs
+++ b/src/exporters/datadog/mod.rs
@@ -87,7 +87,7 @@ pub struct DatadogExporterConfigBuilder {
     api_token: String,
     environment: String,
     hostname: String,
-    retry_config: RetryConfig,
+    pub(crate) retry_config: RetryConfig,
 }
 
 pub struct DatadogExporterBuilder {

--- a/src/exporters/xray/mod.rs
+++ b/src/exporters/xray/mod.rs
@@ -64,7 +64,7 @@ type ExporterType<'a, Resource> = Exporter<
 pub struct XRayExporterConfigBuilder {
     region: Region,
     custom_endpoint: Option<String>,
-    retry_config: RetryConfig,
+    pub(crate) retry_config: RetryConfig,
 }
 
 impl XRayExporterConfigBuilder {

--- a/src/init/agent.rs
+++ b/src/init/agent.rs
@@ -1,5 +1,5 @@
 use crate::aws_api::creds::AwsCredsProvider;
-use crate::bounded_channel::{BoundedReceiver, bounded};
+use crate::bounded_channel::{BoundedReceiver, BoundedSender, bounded};
 use crate::crypto::init_crypto_provider;
 use crate::exporters::blackhole::BlackholeExporter;
 use crate::exporters::datadog::Region;
@@ -11,8 +11,10 @@ use crate::init::args::{AgentRun, DebugLogParam, Receiver};
 use crate::init::batch::{
     build_logs_batch_config, build_metrics_batch_config, build_traces_batch_config,
 };
+#[cfg(feature = "rdkafka")]
+use crate::init::config::validate_receiver_targets;
 use crate::init::config::{
-    ExporterConfig, ReceiverConfig, get_exporters_config, get_receivers_config,
+    ExportGroupConfig, ExporterConfig, ReceiverConfig, get_exporters_config, get_receivers_config,
 };
 use crate::init::datadog_exporter::DatadogRegion;
 #[cfg(feature = "pprof")]
@@ -36,6 +38,7 @@ use crate::receivers::otlp::otlp_http::OTLPHttpServer;
 use crate::receivers::otlp_output::OTLPOutput;
 use crate::topology::batch::BatchSizer;
 use crate::topology::debug::DebugLogger;
+use crate::topology::export_group::ExportGroupBuilder;
 use crate::topology::fanout::FanoutBuilder;
 use crate::topology::flush_control::{FlushSubscriber, conditional_flush};
 use crate::topology::payload::Message;
@@ -48,9 +51,13 @@ use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, Temporality};
 use std::cmp::max;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::net::SocketAddr;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
 use std::time::Duration;
 use tokio::select;
 use tokio::task::JoinSet;
@@ -181,6 +188,9 @@ impl Agent {
         #[allow(unused_mut)]
         let mut exp_config = get_exporters_config(&config, &self.environment)?;
 
+        #[cfg(feature = "rdkafka")]
+        validate_receiver_targets(&rec_config, &exp_config)?;
+
         // Check if Kafka receiver with offset tracking is enabled
         // Offset tracking is enabled when auto commit is disabled
         #[cfg(feature = "rdkafka")]
@@ -195,6 +205,9 @@ impl Agent {
             #[cfg(feature = "rdkafka")]
             matches!(cfg, ReceiverConfig::Kafka(k) if !k.enable_auto_commit && k.disable_exporter_indefinite_retry)
         });
+
+        #[cfg(feature = "rdkafka")]
+        let kafka_target_exporters = kafka_receiver_target_exporters(&rec_config);
 
         // Validate configuration: disable_exporter_indefinite_retry requires auto_commit to be disabled
         #[cfg(feature = "rdkafka")]
@@ -221,7 +234,15 @@ impl Agent {
             info!(
                 "Kafka offset tracking enabled - setting exporters to retry indefinitely to ensure no data loss. To disable this behavior, use --kafka-receiver-disable-exporter-indefinite-retry"
             );
-            exp_config.set_indefinite_retry();
+            if kafka_target_exporters.has_targets() {
+                exp_config.set_indefinite_retry_for_targets(
+                    &kafka_target_exporters.traces,
+                    &kafka_target_exporters.metrics,
+                    &kafka_target_exporters.logs,
+                );
+            } else {
+                exp_config.set_indefinite_retry();
+            }
         }
 
         // Check if file receiver with offset tracking is enabled (indefinite retry not disabled)
@@ -268,6 +289,25 @@ impl Agent {
         let mut metrics_output = None;
         let mut logs_output = None;
         let mut internal_metrics_output = None;
+
+        #[cfg(feature = "rdkafka")]
+        let (kafka_target_traces_output, kafka_target_traces_rx) =
+            new_optional_pipeline_output::<ResourceSpans>(
+                !kafka_target_exporters.traces.is_empty(),
+                max(4, num_cpus),
+            );
+        #[cfg(feature = "rdkafka")]
+        let (kafka_target_metrics_output, kafka_target_metrics_rx) =
+            new_optional_pipeline_output::<ResourceMetrics>(
+                !kafka_target_exporters.metrics.is_empty(),
+                max(4, num_cpus),
+            );
+        #[cfg(feature = "rdkafka")]
+        let (kafka_target_logs_output, kafka_target_logs_rx) =
+            new_optional_pipeline_output::<ResourceLogs>(
+                !kafka_target_exporters.logs.is_empty(),
+                max(4, num_cpus),
+            );
 
         let otlp_rec_enabled = rec_config.contains_key(&Receiver::Otlp);
         // Only notify user if we have an otlp receiver
@@ -397,15 +437,31 @@ impl Agent {
         let mut metrics_fanout = FanoutBuilder::new("metrics");
         let mut logs_fanout = FanoutBuilder::new("logs");
         let mut internal_metrics_fanout = FanoutBuilder::new("internal_metrics");
+        let mut trace_senders = HashMap::new();
+        let mut metrics_senders = HashMap::new();
+        let mut logs_senders = HashMap::new();
 
         //
         // TRACES
         //
         if activation.traces == TelemetryState::Active {
-            for cfg in exp_config.traces {
-                let (trace_pipeline_out_tx, trace_pipeline_out_rx) =
-                    bounded::<Vec<Message<ResourceSpans>>>(self.sending_queue_size);
-                trace_fanout = trace_fanout.add_tx(cfg.name(), trace_pipeline_out_tx);
+            let (mut trace_channels, trace_member_retry_cap) = setup_pipeline_channels(
+                &exp_config.trace_groups,
+                &exp_config.trace_names,
+                &mut trace_fanout,
+                "traces",
+                self.sending_queue_size,
+            );
+            trace_senders = clone_channel_senders(&trace_channels);
+
+            for (name, mut cfg) in exp_config.trace_names.into_iter().zip(exp_config.traces) {
+                let (_, trace_pipeline_out_rx) = trace_channels
+                    .remove(&name)
+                    .expect("channel pre-allocated above");
+
+                if let Some(&cap) = trace_member_retry_cap.get(&name) {
+                    cfg.cap_retry_elapsed_time(cap);
+                }
 
                 match cfg {
                     ExporterConfig::Otlp(exp_config) => {
@@ -541,33 +597,51 @@ impl Agent {
         // METRICS
         //
         if activation.metrics == TelemetryState::Active {
-            // Combine both metrics and internal_metrics exporters into single pass
+            let (mut metrics_channels, metrics_member_retry_cap) = setup_pipeline_channels(
+                &exp_config.metric_groups,
+                &exp_config.metric_names,
+                &mut metrics_fanout,
+                "metrics",
+                self.sending_queue_size,
+            );
+            metrics_senders = clone_channel_senders(&metrics_channels);
+
+            // Combine metrics and internal_metrics exporters for spawning.
             let combined_metrics_configs = exp_config
-                .metrics
+                .metric_names
                 .into_iter()
-                .map(|cfg| (cfg, false))
+                .zip(exp_config.metrics)
+                .map(|(name, cfg)| (name, cfg, false))
                 .chain(
                     exp_config
-                        .internal_metrics
+                        .internal_metric_names
                         .into_iter()
-                        .map(|cfg| (cfg, true)),
+                        .zip(exp_config.internal_metrics)
+                        .map(|(name, cfg)| (name, cfg, true)),
                 );
 
-            for (cfg, is_internal_metrics) in combined_metrics_configs {
+            for (name, mut cfg, is_internal_metrics) in combined_metrics_configs {
                 // Skip internal metrics if not enabled
                 if is_internal_metrics && !config.enable_internal_telemetry {
                     continue;
                 }
 
-                let (metrics_pipeline_out_tx, metrics_pipeline_out_rx) =
-                    bounded::<Vec<Message<ResourceMetrics>>>(self.sending_queue_size);
-
-                if is_internal_metrics {
+                let metrics_pipeline_out_rx = if is_internal_metrics {
+                    // Internal metrics are never grouped; create channel inline.
+                    let (internal_tx, internal_rx) =
+                        bounded::<Vec<Message<ResourceMetrics>>>(self.sending_queue_size);
                     internal_metrics_fanout =
-                        internal_metrics_fanout.add_tx(cfg.name(), metrics_pipeline_out_tx);
+                        internal_metrics_fanout.add_tx(cfg.name(), internal_tx);
+                    internal_rx
                 } else {
-                    metrics_fanout = metrics_fanout.add_tx(cfg.name(), metrics_pipeline_out_tx);
-                }
+                    if let Some(&cap) = metrics_member_retry_cap.get(&name) {
+                        cfg.cap_retry_elapsed_time(cap);
+                    }
+                    let (_, rx) = metrics_channels
+                        .remove(&name)
+                        .expect("channel pre-allocated above");
+                    rx
+                };
 
                 let telemetry_type = match is_internal_metrics {
                     true => "internal_metrics",
@@ -697,10 +771,23 @@ impl Agent {
         // LOGS
         //
         if activation.logs == TelemetryState::Active {
-            for cfg in exp_config.logs {
-                let (logs_pipeline_out_tx, logs_pipeline_out_rx) =
-                    bounded::<Vec<Message<ResourceLogs>>>(self.sending_queue_size);
-                logs_fanout = logs_fanout.add_tx(cfg.name(), logs_pipeline_out_tx);
+            let (mut logs_channels, logs_member_retry_cap) = setup_pipeline_channels(
+                &exp_config.log_groups,
+                &exp_config.log_names,
+                &mut logs_fanout,
+                "logs",
+                self.sending_queue_size,
+            );
+            logs_senders = clone_channel_senders(&logs_channels);
+
+            for (name, mut cfg) in exp_config.log_names.into_iter().zip(exp_config.logs) {
+                let (_, logs_pipeline_out_rx) = logs_channels
+                    .remove(&name)
+                    .expect("channel pre-allocated above");
+
+                if let Some(&cap) = logs_member_retry_cap.get(&name) {
+                    cfg.cap_retry_elapsed_time(cap);
+                }
 
                 match cfg {
                     ExporterConfig::Otlp(exp_config) => {
@@ -898,6 +985,114 @@ impl Agent {
                 .spawn(async move { logs_pipeline.start(dbg_log, pipeline_cancel).await });
         }
 
+        #[cfg(feature = "rdkafka")]
+        if let Some(kafka_target_traces_rx) = kafka_target_traces_rx {
+            let trace_fanout =
+                build_target_fanout(&kafka_target_exporters.traces, &trace_senders, "traces")?;
+
+            let trace_processors = Processors::initialize(config.otlp_with_trace_processor.clone())
+                .map_err(|e| format!("Failed to initialize trace processors: {}", e))?
+                .initialize_rust(config.rust_trace_processor.clone())
+                .map_err(|e| format!("Failed to initialize Rust trace processors: {}", e))?
+                .initialize_async_rust(config.async_rust_trace_processor.clone())
+                .map_err(|e| format!("Failed to initialize async Rust trace processors: {}", e))?
+                .set_async_preserve_on_panic(config.async_processor_preserve_on_panic);
+
+            let mut trace_pipeline = topology::generic_pipeline::Pipeline::new(
+                "traces",
+                kafka_target_traces_rx,
+                trace_fanout,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                build_traces_batch_config(config.batch.clone()),
+                trace_processors,
+                resource_attributes.clone(),
+            );
+
+            let log_traces = config.debug_log.contains(&DebugLogParam::Traces);
+            let dbg_log = DebugLogger::new(
+                log_traces
+                    .then_some(config.debug_log_verbosity)
+                    .map(|v| v.into()),
+            );
+
+            let pipeline_cancel = pipeline_cancel.clone();
+            pipeline_task_set
+                .spawn(async move { trace_pipeline.start(dbg_log, pipeline_cancel).await });
+        }
+
+        #[cfg(feature = "rdkafka")]
+        if let Some(kafka_target_metrics_rx) = kafka_target_metrics_rx {
+            let metrics_fanout =
+                build_target_fanout(&kafka_target_exporters.metrics, &metrics_senders, "metrics")?;
+
+            let metrics_processors =
+                Processors::initialize(config.otlp_with_metrics_processor.clone())
+                    .map_err(|e| format!("Failed to initialize metrics processors: {}", e))?
+                    .initialize_rust(config.rust_metrics_processor.clone())
+                    .map_err(|e| format!("Failed to initialize Rust metrics processors: {}", e))?
+                    .initialize_async_rust(config.async_rust_metrics_processor.clone())
+                    .map_err(|e| {
+                        format!("Failed to initialize async Rust metrics processors: {}", e)
+                    })?
+                    .set_async_preserve_on_panic(config.async_processor_preserve_on_panic);
+
+            let mut metrics_pipeline = topology::generic_pipeline::Pipeline::new(
+                "metrics",
+                kafka_target_metrics_rx,
+                metrics_fanout,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                build_metrics_batch_config(config.batch.clone()),
+                metrics_processors,
+                resource_attributes.clone(),
+            );
+
+            let log_metrics = config.debug_log.contains(&DebugLogParam::Metrics);
+            let dbg_log = DebugLogger::new(
+                log_metrics
+                    .then_some(config.debug_log_verbosity)
+                    .map(|v| v.into()),
+            );
+
+            let pipeline_cancel = pipeline_cancel.clone();
+            pipeline_task_set
+                .spawn(async move { metrics_pipeline.start(dbg_log, pipeline_cancel).await });
+        }
+
+        #[cfg(feature = "rdkafka")]
+        if let Some(kafka_target_logs_rx) = kafka_target_logs_rx {
+            let logs_fanout =
+                build_target_fanout(&kafka_target_exporters.logs, &logs_senders, "logs")?;
+
+            let logs_processors = Processors::initialize(config.otlp_with_logs_processor.clone())
+                .map_err(|e| format!("Failed to initialize logs processors: {}", e))?
+                .initialize_rust(config.rust_logs_processor.clone())
+                .map_err(|e| format!("Failed to initialize Rust logs processors: {}", e))?
+                .initialize_async_rust(config.async_rust_logs_processor.clone())
+                .map_err(|e| format!("Failed to initialize async Rust logs processors: {}", e))?
+                .set_async_preserve_on_panic(config.async_processor_preserve_on_panic);
+
+            let mut logs_pipeline = topology::generic_pipeline::Pipeline::new(
+                "logs",
+                kafka_target_logs_rx,
+                logs_fanout,
+                pipeline_flush_sub.as_mut().map(|sub| sub.subscribe()),
+                build_logs_batch_config(config.batch.clone()),
+                logs_processors,
+                resource_attributes.clone(),
+            );
+
+            let log_logs = config.debug_log.contains(&DebugLogParam::Logs);
+            let dbg_log = DebugLogger::new(
+                log_logs
+                    .then_some(config.debug_log_verbosity)
+                    .map(|v| v.into()),
+            );
+
+            let pipeline_cancel = pipeline_cancel.clone();
+            pipeline_task_set
+                .spawn(async move { logs_pipeline.start(dbg_log, pipeline_cancel).await });
+        }
+
         if internal_metrics_output.is_some() {
             let internal_metrics_fanout = internal_metrics_fanout
                 .build()
@@ -980,11 +1175,21 @@ impl Agent {
                 }
                 #[cfg(feature = "rdkafka")]
                 ReceiverConfig::Kafka(config) => {
+                    let kafka_traces_output = kafka_target_traces_output
+                        .clone()
+                        .or_else(|| traces_output.clone());
+                    let kafka_metrics_output = kafka_target_metrics_output
+                        .clone()
+                        .or_else(|| metrics_output.clone());
+                    let kafka_logs_output = kafka_target_logs_output
+                        .clone()
+                        .or_else(|| logs_output.clone());
+
                     let mut kafka = KafkaReceiver::new(
                         config.clone(),
-                        traces_output.clone(),
-                        metrics_output.clone(),
-                        logs_output.clone(),
+                        kafka_traces_output,
+                        kafka_metrics_output,
+                        kafka_logs_output,
                         finite_retry_enabled,
                     )?;
 
@@ -1365,6 +1570,232 @@ impl Agent {
 
         Ok(())
     }
+}
+
+#[cfg(feature = "rdkafka")]
+#[derive(Default)]
+struct ReceiverTargetExporters {
+    traces: Vec<String>,
+    metrics: Vec<String>,
+    logs: Vec<String>,
+}
+
+#[cfg(feature = "rdkafka")]
+impl ReceiverTargetExporters {
+    fn has_targets(&self) -> bool {
+        !(self.traces.is_empty() && self.metrics.is_empty() && self.logs.is_empty())
+    }
+}
+
+#[cfg(feature = "rdkafka")]
+fn kafka_receiver_target_exporters(
+    rec_config: &HashMap<Receiver, ReceiverConfig>,
+) -> ReceiverTargetExporters {
+    let mut targets = ReceiverTargetExporters::default();
+    for config in rec_config.values() {
+        let ReceiverConfig::Kafka(config) = config else {
+            continue;
+        };
+
+        if let Some(trace_targets) = &config.target_exporters_traces {
+            targets.traces.extend(trace_targets.iter().cloned());
+        }
+        if let Some(metric_targets) = &config.target_exporters_metrics {
+            targets.metrics.extend(metric_targets.iter().cloned());
+        }
+        if let Some(log_targets) = &config.target_exporters_logs {
+            targets.logs.extend(log_targets.iter().cloned());
+        }
+    }
+    targets
+}
+
+fn new_optional_pipeline_output<T>(
+    enabled: bool,
+    capacity: usize,
+) -> (
+    Option<OTLPOutput<Message<T>>>,
+    Option<BoundedReceiver<Message<T>>>,
+) {
+    if !enabled {
+        return (None, None);
+    }
+
+    let (tx, rx) = bounded(capacity);
+    (Some(OTLPOutput::new(tx)), Some(rx))
+}
+
+fn clone_channel_senders<T>(
+    channels: &HashMap<
+        String,
+        (
+            BoundedSender<Vec<Message<T>>>,
+            BoundedReceiver<Vec<Message<T>>>,
+        ),
+    >,
+) -> HashMap<String, BoundedSender<Vec<Message<T>>>> {
+    channels
+        .iter()
+        .map(|(name, (tx, _))| (name.clone(), tx.clone()))
+        .collect()
+}
+
+fn build_target_fanout<T>(
+    targets: &[String],
+    senders: &HashMap<String, BoundedSender<Vec<Message<T>>>>,
+    telemetry_type: &'static str,
+) -> Result<topology::fanout::Fanout<Vec<Message<T>>>, Box<dyn Error + Send + Sync>>
+where
+    T: Send + 'static,
+{
+    let mut fanout = FanoutBuilder::new(telemetry_type);
+    for target in targets {
+        let Some(sender) = senders.get(target) else {
+            return Err(format!("Target exporter '{}' was not initialized", target).into());
+        };
+        fanout = fanout.add_tx(leak_config_name(target), sender.clone());
+    }
+    Ok(fanout.build()?)
+}
+
+fn leak_config_name(name: &str) -> &'static str {
+    Box::leak(name.to_string().into_boxed_str())
+}
+
+/// For each export group: builds an `ExportGroup` task, registers its sender with `fanout`,
+/// and returns (group_name, active_atomic) pairs for telemetry gauge registration.
+/// Member rx values stay in `channels` for the caller to use when spawning exporters.
+fn wire_export_groups<T>(
+    groups: &[ExportGroupConfig],
+    channels: &mut HashMap<
+        String,
+        (
+            BoundedSender<Vec<Message<T>>>,
+            BoundedReceiver<Vec<Message<T>>>,
+        ),
+    >,
+    fanout: &mut FanoutBuilder<Vec<Message<T>>>,
+    telemetry_type: &'static str,
+    sending_queue_size: usize,
+) -> Vec<(String, Arc<AtomicU32>)>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    let mut atomics = Vec::new();
+    for group in groups {
+        let mut builder = ExportGroupBuilder::<T>::new(sending_queue_size)
+            .trip_after(group.trip_after)
+            .probe_after(group.probe_after);
+
+        for member_name in &group.members {
+            if let Some((tx, _)) = channels.get(member_name) {
+                builder = builder.add_member(tx.clone());
+            }
+        }
+
+        let export_group = builder.build();
+        let active = export_group.active_atomic();
+
+        // Group names are configured once at startup; leaking is acceptable.
+        let static_name: &'static str = Box::leak(group.name.clone().into_boxed_str());
+        *fanout = std::mem::replace(fanout, FanoutBuilder::new(telemetry_type))
+            .add_tx(static_name, export_group.sender());
+
+        atomics.push((group.name.clone(), active));
+    }
+    atomics
+}
+
+/// Registers an ObservableGauge for each export group's active-member index.
+fn register_group_gauges(atomics: Vec<(String, Arc<AtomicU32>)>, telemetry_type: &'static str) {
+    for (group_name, active_atomic) in atomics {
+        global::meter("export_group")
+            .u64_observable_gauge("rotel_export_group_active")
+            .with_callback(move |observer| {
+                observer.observe(
+                    active_atomic.load(Ordering::Relaxed) as u64,
+                    &[
+                        opentelemetry::KeyValue::new("telemetry_type", telemetry_type),
+                        opentelemetry::KeyValue::new("group_name", group_name.clone()),
+                    ],
+                );
+            })
+            .build();
+    }
+}
+
+/// Prepares channel plumbing for one telemetry pipeline's export groups:
+///   1. Pre-allocates (tx, rx) pairs for every exporter.
+///   2. Builds retry-cap map from group configs.
+///   3. Wires export groups (spawns tasks, registers senders with fanout).
+///   4. Registers non-grouped exporters directly with the fanout.
+///   5. Registers ObservableGauges for each group's active-member index.
+///
+/// Returns `(channels, retry_cap)` for use during exporter spawning.
+fn setup_pipeline_channels<T: Clone + Send + Sync + 'static>(
+    groups: &[ExportGroupConfig],
+    exporter_names: &[String],
+    fanout: &mut FanoutBuilder<Vec<Message<T>>>,
+    telemetry_type: &'static str,
+    sending_queue_size: usize,
+) -> (
+    HashMap<
+        String,
+        (
+            BoundedSender<Vec<Message<T>>>,
+            BoundedReceiver<Vec<Message<T>>>,
+        ),
+    >,
+    HashMap<String, Duration>,
+) {
+    let grouped_members: HashSet<&str> = groups
+        .iter()
+        .flat_map(|g| g.members.iter().map(|m| m.as_str()))
+        .collect();
+
+    let member_retry_cap: HashMap<String, Duration> = groups
+        .iter()
+        .flat_map(|g| {
+            g.members
+                .iter()
+                .map(move |m| (m.clone(), g.member_retry_max_elapsed_time))
+        })
+        .collect();
+
+    let mut channels: HashMap<
+        String,
+        (
+            BoundedSender<Vec<Message<T>>>,
+            BoundedReceiver<Vec<Message<T>>>,
+        ),
+    > = HashMap::new();
+    for exporter_name in exporter_names {
+        let (tx, rx) = bounded(sending_queue_size);
+        channels.insert(exporter_name.clone(), (tx, rx));
+    }
+
+    let atomics = wire_export_groups(
+        groups,
+        &mut channels,
+        fanout,
+        telemetry_type,
+        sending_queue_size,
+    );
+
+    for exporter_name in exporter_names {
+        if grouped_members.contains(exporter_name.as_str()) {
+            continue;
+        }
+        let Some((tx, _)) = channels.get(exporter_name.as_str()) else {
+            continue;
+        };
+        *fanout = std::mem::replace(fanout, FanoutBuilder::new(telemetry_type))
+            .add_tx(leak_config_name(exporter_name), tx.clone());
+    }
+
+    register_group_gauges(atomics, telemetry_type);
+
+    (channels, member_retry_cap)
 }
 
 fn start_otlp_exporter<Resource, Request, Response>(

--- a/src/init/args.rs
+++ b/src/init/args.rs
@@ -166,6 +166,38 @@ pub struct AgentRun {
     #[arg(long, env = "ROTEL_EXPORTERS_INTERNAL_METRICS")]
     pub exporters_internal_metrics: Option<String>,
 
+    /// Trace export groups. Format: <name>=<member1>,<member2>[;<name2>=<m3>,<m4>...]
+    /// Each group name must be unique; members must be declared in --exporters-traces.
+    #[arg(long, env = "ROTEL_EXPORT_GROUPS_TRACES")]
+    pub export_groups_traces: Option<String>,
+
+    /// Metrics export groups. Format: <name>=<member1>,<member2>[;<name2>=<m3>,<m4>...]
+    #[arg(long, env = "ROTEL_EXPORT_GROUPS_METRICS")]
+    pub export_groups_metrics: Option<String>,
+
+    /// Logs export groups. Format: <name>=<member1>,<member2>[;<name2>=<m3>,<m4>...]
+    #[arg(long, env = "ROTEL_EXPORT_GROUPS_LOGS")]
+    pub export_groups_logs: Option<String>,
+
+    /// Consecutive nacks of the active group member required to trip the circuit breaker
+    #[arg(long, env = "ROTEL_EXPORT_GROUP_TRIP_AFTER", default_value_t = 3)]
+    pub export_group_trip_after: u32,
+
+    /// Probe interval after tripping; member[0] is retested after this duration.
+    /// Use "0s" to disable auto-recovery.
+    #[arg(long, env = "ROTEL_EXPORT_GROUP_PROBE_AFTER", default_value = "30s")]
+    pub export_group_probe_after: humantime::Duration,
+
+    /// Maximum total time an export group member may spend retrying a single batch before
+    /// the group records a nack and advances to the next member. Keeping this short ensures
+    /// the circuit breaker can trip quickly on a degraded primary.
+    #[arg(
+        long,
+        env = "ROTEL_EXPORT_GROUP_MEMBER_RETRY_MAX_ELAPSED_TIME",
+        default_value = "20s"
+    )]
+    pub export_group_member_retry_max_elapsed_time: humantime::Duration,
+
     #[command(flatten)]
     pub otlp_exporter: OTLPExporterArgs,
 
@@ -233,6 +265,12 @@ impl Default for AgentRun {
             exporters_metrics: None,
             exporters_logs: None,
             exporters_internal_metrics: None,
+            export_groups_traces: None,
+            export_groups_metrics: None,
+            export_groups_logs: None,
+            export_group_trip_after: 3,
+            export_group_probe_after: std::time::Duration::from_secs(30).into(),
+            export_group_member_retry_max_elapsed_time: std::time::Duration::from_secs(20).into(),
             otlp_exporter: OTLPExporterArgs::default(),
             datadog_exporter: DatadogExporterArgs::default(),
             clickhouse_exporter: ClickhouseExporterArgs::default(),

--- a/src/init/config.rs
+++ b/src/init/config.rs
@@ -31,9 +31,10 @@ use crate::receivers::kmsg::config::KmsgReceiverConfig;
 use crate::receivers::otlp::OTLPReceiverConfig;
 use figment::{Figment, providers::Env};
 use gethostname::gethostname;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
+use std::time::Duration;
 use tower::BoxError;
 use tracing::error;
 
@@ -89,12 +90,35 @@ impl ExporterMap {
     }
 }
 
+/// Configuration for an ordered export group (circuit-breaker + per-batch retry).
+pub(crate) struct ExportGroupConfig {
+    /// Logical name used to register the group's sender with the fanout.
+    pub(crate) name: String,
+    /// Ordered list of member exporter names (priority order; [0] is primary).
+    pub(crate) members: Vec<String>,
+    /// Consecutive nacks of the active member before tripping.
+    pub(crate) trip_after: u32,
+    /// Time between probe attempts after tripping; `Duration::ZERO` disables auto-recovery.
+    pub(crate) probe_after: Duration,
+    /// Cap applied to each member exporter's retry `max_elapsed_time`. A short cap (e.g. 20s)
+    /// ensures the group can nack quickly and advance to the next member rather than waiting for
+    /// the exporter's own full retry budget to exhaust.
+    pub(crate) member_retry_max_elapsed_time: Duration,
+}
+
 #[derive(Default)]
 pub(crate) struct ExporterConfigs {
     pub(crate) metrics: Vec<ExporterConfig>,
     pub(crate) logs: Vec<ExporterConfig>,
     pub(crate) traces: Vec<ExporterConfig>,
     pub(crate) internal_metrics: Vec<ExporterConfig>,
+    pub(crate) metric_names: Vec<String>,
+    pub(crate) log_names: Vec<String>,
+    pub(crate) trace_names: Vec<String>,
+    pub(crate) internal_metric_names: Vec<String>,
+    pub(crate) trace_groups: Vec<ExportGroupConfig>,
+    pub(crate) metric_groups: Vec<ExportGroupConfig>,
+    pub(crate) log_groups: Vec<ExportGroupConfig>,
 }
 
 impl ExporterConfigs {
@@ -127,6 +151,70 @@ impl ExporterConfigs {
                 // Kafka is already maxint reties and we don't need to worry about this for file.
                 _ => {}
             }
+        }
+    }
+
+    #[cfg(feature = "rdkafka")]
+    pub(crate) fn set_indefinite_retry_for_targets(
+        &mut self,
+        trace_targets: &[String],
+        metric_targets: &[String],
+        log_targets: &[String],
+    ) {
+        set_indefinite_retry_for_named_exporters(
+            &mut self.traces,
+            &self.trace_names,
+            trace_targets,
+        );
+        set_indefinite_retry_for_named_exporters(
+            &mut self.metrics,
+            &self.metric_names,
+            metric_targets,
+        );
+        set_indefinite_retry_for_named_exporters(&mut self.logs, &self.log_names, log_targets);
+    }
+
+    pub(crate) fn exporter_by_name<'a>(
+        exporters: &'a [ExporterConfig],
+        names: &[String],
+        name: &str,
+    ) -> Option<&'a ExporterConfig> {
+        names
+            .iter()
+            .zip(exporters.iter())
+            .find_map(|(exporter_name, exporter)| (exporter_name == name).then_some(exporter))
+    }
+}
+
+#[cfg(feature = "rdkafka")]
+fn set_indefinite_retry_for_named_exporters(
+    exporters: &mut [ExporterConfig],
+    names: &[String],
+    targets: &[String],
+) {
+    let targets: HashSet<&str> = targets.iter().map(|target| target.as_str()).collect();
+    for (name, exporter) in names.iter().zip(exporters.iter_mut()) {
+        if !targets.contains(name.as_str()) {
+            continue;
+        }
+
+        match exporter {
+            ExporterConfig::Otlp(config) => {
+                config.retry_config.indefinite_retry = true;
+            }
+            ExporterConfig::Datadog(config) => {
+                config.set_indefinite_retry();
+            }
+            ExporterConfig::Xray(config) => {
+                config.set_indefinite_retry();
+            }
+            ExporterConfig::Awsemf(config) => {
+                config.set_indefinite_retry();
+            }
+            ExporterConfig::Clickhouse(config) => {
+                config.set_indefinite_retry();
+            }
+            _ => {}
         }
     }
 }
@@ -199,6 +287,27 @@ impl ExporterConfig {
             ExporterConfig::Kafka(_) => "kafka",
             #[cfg(feature = "file_exporter")]
             ExporterConfig::File(_) => "file",
+        }
+    }
+
+    fn retry_config_mut(&mut self) -> Option<&mut crate::exporters::http::retry::RetryConfig> {
+        match self {
+            ExporterConfig::Otlp(c) => Some(&mut c.retry_config),
+            ExporterConfig::Datadog(c) => Some(&mut c.retry_config),
+            ExporterConfig::Clickhouse(c) => Some(&mut c.retry_config),
+            ExporterConfig::Xray(c) => Some(&mut c.retry_config),
+            ExporterConfig::Awsemf(c) => Some(&mut c.config.retry_config),
+            // Kafka, Blackhole, File have no HTTP retry config.
+            _ => None,
+        }
+    }
+
+    /// Reduce the exporter's internal retry `max_elapsed_time` to at most `cap`.
+    /// Applied to group members so the circuit-breaker can nack quickly rather than
+    /// waiting for the exporter's own full retry budget.
+    pub(crate) fn cap_retry_elapsed_time(&mut self, cap: Duration) {
+        if let Some(rc) = self.retry_config_mut() {
+            rc.max_elapsed_time = rc.max_elapsed_time.min(cap);
         }
     }
 }
@@ -476,6 +585,87 @@ pub(crate) fn get_exporters_config(
     )
 }
 
+#[cfg(feature = "rdkafka")]
+pub(crate) fn validate_receiver_targets(
+    receiver_config: &HashMap<Receiver, ReceiverConfig>,
+    exporter_config: &ExporterConfigs,
+) -> Result<(), BoxError> {
+    for config in receiver_config.values() {
+        let ReceiverConfig::Kafka(config) = config else {
+            continue;
+        };
+
+        validate_kafka_targets(
+            "traces",
+            &config.target_exporters_traces,
+            &exporter_config.traces,
+            &exporter_config.trace_names,
+            &exporter_config.trace_groups,
+            !config.enable_auto_commit && !config.disable_exporter_indefinite_retry,
+        )?;
+        validate_kafka_targets(
+            "metrics",
+            &config.target_exporters_metrics,
+            &exporter_config.metrics,
+            &exporter_config.metric_names,
+            &exporter_config.metric_groups,
+            !config.enable_auto_commit && !config.disable_exporter_indefinite_retry,
+        )?;
+        validate_kafka_targets(
+            "logs",
+            &config.target_exporters_logs,
+            &exporter_config.logs,
+            &exporter_config.log_names,
+            &exporter_config.log_groups,
+            !config.enable_auto_commit && !config.disable_exporter_indefinite_retry,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "rdkafka")]
+fn validate_kafka_targets(
+    pipeline: &str,
+    targets: &Option<Vec<String>>,
+    exporters: &[ExporterConfig],
+    names: &[String],
+    groups: &[ExportGroupConfig],
+    offset_tracking_enabled: bool,
+) -> Result<(), BoxError> {
+    let Some(targets) = targets else {
+        return Ok(());
+    };
+
+    for target in targets {
+        let Some(exporter) = ExporterConfigs::exporter_by_name(exporters, names, target) else {
+            return Err(format!(
+                "Kafka receiver target exporter '{}' is not declared in --exporters-{}",
+                target, pipeline
+            )
+            .into());
+        };
+
+        if matches!(exporter, ExporterConfig::Kafka(_)) {
+            return Err(format!(
+                "Kafka receiver target exporter '{}' for {} cannot be a Kafka exporter",
+                target, pipeline
+            )
+            .into());
+        }
+
+        if offset_tracking_enabled && groups.iter().any(|group| group.members.contains(target)) {
+            return Err(format!(
+                "Kafka receiver target exporter '{}' for {} is also an export-group member; define a separate logical exporter for DLQ replay so live failover can use finite retry while replay uses indefinite retry",
+                target, pipeline
+            )
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
 fn get_multi_exporter_config(
     config: &AgentRun,
     exporters: String,
@@ -487,6 +677,7 @@ fn get_multi_exporter_config(
 
     if let Some(traces_exps) = &config.exporters_traces {
         let sp: Vec<&str> = traces_exps.split(",").collect();
+        cfg.trace_names = sp.iter().map(|exp| exp.to_string()).collect();
 
         cfg.traces = sp
             .into_iter()
@@ -506,6 +697,7 @@ fn get_multi_exporter_config(
 
     if let Some(metrics_exps) = &config.exporters_metrics {
         let sp: Vec<&str> = metrics_exps.split(",").collect();
+        cfg.metric_names = sp.iter().map(|exp| exp.to_string()).collect();
 
         cfg.metrics = sp
             .into_iter()
@@ -525,6 +717,7 @@ fn get_multi_exporter_config(
 
     if let Some(logs_exps) = &config.exporters_logs {
         let sp: Vec<&str> = logs_exps.split(",").collect();
+        cfg.log_names = sp.iter().map(|exp| exp.to_string()).collect();
 
         cfg.logs = sp
             .into_iter()
@@ -544,6 +737,7 @@ fn get_multi_exporter_config(
 
     if let Some(internal_metrics_exps) = &config.exporters_internal_metrics {
         let sp: Vec<&str> = internal_metrics_exps.split(",").collect();
+        cfg.internal_metric_names = sp.iter().map(|exp| exp.to_string()).collect();
 
         cfg.internal_metrics = sp
             .into_iter()
@@ -567,6 +761,33 @@ fn get_multi_exporter_config(
             .collect::<Result<Vec<ExporterConfig>, BoxError>>()?;
     }
 
+    // Parse and validate export groups.
+    let trip_after = config.export_group_trip_after;
+    let probe_after: Duration = config.export_group_probe_after.into();
+    let member_retry_max_elapsed_time: Duration =
+        config.export_group_member_retry_max_elapsed_time.into();
+
+    let parse_groups = |groups_str: &str, pipeline: &str, exporter_names: &[String]| {
+        parse_and_validate_groups(
+            groups_str,
+            pipeline,
+            exporter_names,
+            trip_after,
+            probe_after,
+            member_retry_max_elapsed_time,
+        )
+    };
+
+    if let Some(s) = &config.export_groups_traces {
+        cfg.trace_groups = parse_groups(s, "traces", &cfg.trace_names)?;
+    }
+    if let Some(s) = &config.export_groups_metrics {
+        cfg.metric_groups = parse_groups(s, "metrics", &cfg.metric_names)?;
+    }
+    if let Some(s) = &config.export_groups_logs {
+        cfg.log_groups = parse_groups(s, "logs", &cfg.log_names)?;
+    }
+
     // Internal metrics do not count here, we need at least one actual pipeline
     if cfg.traces.is_empty() && cfg.metrics.is_empty() && cfg.logs.is_empty() {
         return Err(
@@ -576,6 +797,99 @@ fn get_multi_exporter_config(
     }
 
     Ok(cfg)
+}
+
+/// Parse a groups string of the form `name=m0,m1[;name2=m2,m3...]` and validate
+/// against the already-resolved exporter list for this pipeline.
+fn parse_and_validate_groups(
+    groups_str: &str,
+    pipeline: &str,
+    pipeline_exporter_names: &[String],
+    trip_after: u32,
+    probe_after: Duration,
+    member_retry_max_elapsed_time: Duration,
+) -> Result<Vec<ExportGroupConfig>, BoxError> {
+    let raw = parse_export_groups(groups_str)?;
+
+    let exporter_names: HashSet<&str> = pipeline_exporter_names
+        .iter()
+        .map(|name| name.as_str())
+        .collect();
+
+    let mut seen_group_names: HashSet<String> = HashSet::new();
+    let mut seen_members: HashSet<String> = HashSet::new();
+
+    let mut groups = Vec::new();
+    for (name, members) in raw {
+        if !seen_group_names.insert(name.clone()) {
+            return Err(format!(
+                "ExportGroup[{}]: duplicate group name in {} pipeline",
+                name, pipeline
+            )
+            .into());
+        }
+        if members.len() < 2 {
+            return Err(format!(
+                "ExportGroup[{}]: must have at least 2 members, found {}",
+                name,
+                members.len()
+            )
+            .into());
+        }
+        for member in &members {
+            if !exporter_names.contains(member.as_str()) {
+                return Err(format!(
+                    "ExportGroup[{}]: member '{}' is not declared in --exporters-{}",
+                    name, member, pipeline
+                )
+                .into());
+            }
+            if !seen_members.insert(member.clone()) {
+                return Err(format!(
+                    "ExportGroup[{}]: member '{}' appears in more than one group for the {} pipeline",
+                    name, member, pipeline
+                )
+                .into());
+            }
+        }
+        groups.push(ExportGroupConfig {
+            name,
+            members,
+            trip_after,
+            probe_after,
+            member_retry_max_elapsed_time,
+        });
+    }
+    Ok(groups)
+}
+
+/// Parse `name=m0,m1[;name2=m2,m3...]` into a `Vec<(name, Vec<member>)>`.
+fn parse_export_groups(s: &str) -> Result<Vec<(String, Vec<String>)>, BoxError> {
+    let mut result = Vec::new();
+    for group_str in s.split(';') {
+        let group_str = group_str.trim();
+        if group_str.is_empty() {
+            continue;
+        }
+        let pos = group_str.find('=').ok_or_else(|| {
+            format!(
+                "ExportGroup: invalid format '{}'; expected name=m0,m1",
+                group_str
+            )
+        })?;
+        let name = group_str[..pos].trim().to_string();
+        if name.is_empty() {
+            return Err(format!("ExportGroup: empty group name in '{}'", group_str).into());
+        }
+        let members_str = group_str[pos + 1..].trim();
+        let members: Vec<String> = members_str
+            .split(',')
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty())
+            .collect();
+        result.push((name, members));
+    }
+    Ok(result)
 }
 
 fn args_from_env_prefix(exporter_type: &str, prefix: &str) -> Result<ExporterArgs, BoxError> {
@@ -770,6 +1084,15 @@ fn get_single_exporter_config(
             )?);
         }
     }
+
+    cfg.trace_names = cfg.traces.iter().map(|e| e.name().to_string()).collect();
+    cfg.metric_names = cfg.metrics.iter().map(|e| e.name().to_string()).collect();
+    cfg.log_names = cfg.logs.iter().map(|e| e.name().to_string()).collect();
+    cfg.internal_metric_names = cfg
+        .internal_metrics
+        .iter()
+        .map(|e| e.name().to_string())
+        .collect();
 
     Ok(cfg)
 }
@@ -1291,5 +1614,101 @@ mod tests {
             }
             _ => panic!("Expected Clickhouse exporter"),
         }
+    }
+
+    #[cfg(feature = "rdkafka")]
+    fn kafka_receiver_config_with_trace_target(target: &str) -> AgentRun {
+        AgentRun {
+            receivers: Some("kafka".to_string()),
+            exporters: Some("ch:clickhouse,ch_replay:clickhouse,dlq:kafka".to_string()),
+            exporters_traces: Some("ch,ch_replay,dlq".to_string()),
+            export_groups_traces: Some("live=ch,dlq".to_string()),
+            kafka_receiver: crate::init::kafka_receiver::KafkaReceiverArgs {
+                traces: true,
+                target_exporters_traces: Some(target.to_string()),
+                ..Default::default()
+            },
+            ..AgentRun::default()
+        }
+    }
+
+    #[cfg(feature = "rdkafka")]
+    #[test]
+    fn test_kafka_receiver_target_accepts_clickhouse_exporter() {
+        let mut env_manager = EnvManager::new();
+        env_manager.set_var("ROTEL_EXPORTER_CH_ENDPOINT", "http://localhost:8123");
+        env_manager.set_var("ROTEL_EXPORTER_CH_REPLAY_ENDPOINT", "http://localhost:8123");
+
+        let config = kafka_receiver_config_with_trace_target("ch_replay");
+        let receivers = get_receivers_config(&config, false).unwrap();
+        let exporters = get_exporters_config(&config, "production").unwrap();
+
+        validate_receiver_targets(&receivers, &exporters).unwrap();
+    }
+
+    #[cfg(feature = "rdkafka")]
+    #[test]
+    fn test_kafka_receiver_target_accepts_group_member_without_offset_tracking() {
+        let mut env_manager = EnvManager::new();
+        env_manager.set_var("ROTEL_EXPORTER_CH_ENDPOINT", "http://localhost:8123");
+        env_manager.set_var("ROTEL_EXPORTER_CH_REPLAY_ENDPOINT", "http://localhost:8123");
+
+        let mut config = kafka_receiver_config_with_trace_target("ch");
+        config.kafka_receiver.enable_auto_commit = true;
+        let receivers = get_receivers_config(&config, false).unwrap();
+        let exporters = get_exporters_config(&config, "production").unwrap();
+
+        validate_receiver_targets(&receivers, &exporters).unwrap();
+    }
+
+    #[cfg(feature = "rdkafka")]
+    #[test]
+    fn test_kafka_receiver_target_rejects_group_member_with_offset_tracking() {
+        let mut env_manager = EnvManager::new();
+        env_manager.set_var("ROTEL_EXPORTER_CH_ENDPOINT", "http://localhost:8123");
+        env_manager.set_var("ROTEL_EXPORTER_CH_REPLAY_ENDPOINT", "http://localhost:8123");
+
+        let config = kafka_receiver_config_with_trace_target("ch");
+        let receivers = get_receivers_config(&config, false).unwrap();
+        let exporters = get_exporters_config(&config, "production").unwrap();
+
+        let err = validate_receiver_targets(&receivers, &exporters).unwrap_err();
+        assert!(err.to_string().contains("is also an export-group member"));
+    }
+
+    #[cfg(feature = "rdkafka")]
+    #[test]
+    fn test_kafka_receiver_target_rejects_unknown_exporter() {
+        let mut env_manager = EnvManager::new();
+        env_manager.set_var("ROTEL_EXPORTER_CH_ENDPOINT", "http://localhost:8123");
+        env_manager.set_var("ROTEL_EXPORTER_CH_REPLAY_ENDPOINT", "http://localhost:8123");
+
+        let config = kafka_receiver_config_with_trace_target("missing");
+        let receivers = get_receivers_config(&config, false).unwrap();
+        let exporters = get_exporters_config(&config, "production").unwrap();
+
+        let err = validate_receiver_targets(&receivers, &exporters).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("target exporter 'missing' is not declared")
+        );
+    }
+
+    #[cfg(feature = "rdkafka")]
+    #[test]
+    fn test_kafka_receiver_target_rejects_kafka_exporter() {
+        let mut env_manager = EnvManager::new();
+        env_manager.set_var("ROTEL_EXPORTER_CH_ENDPOINT", "http://localhost:8123");
+        env_manager.set_var("ROTEL_EXPORTER_CH_REPLAY_ENDPOINT", "http://localhost:8123");
+
+        let config = kafka_receiver_config_with_trace_target("dlq");
+        let receivers = get_receivers_config(&config, false).unwrap();
+        let exporters = get_exporters_config(&config, "production").unwrap();
+
+        let err = validate_receiver_targets(&receivers, &exporters).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("target exporter 'dlq' for traces cannot be a Kafka exporter")
+        );
     }
 }

--- a/src/init/kafka_receiver.rs
+++ b/src/init/kafka_receiver.rs
@@ -66,6 +66,27 @@ pub struct KafkaReceiverArgs {
     )]
     pub logs: bool,
 
+    /// Trace exporters targeted by this Kafka receiver. Defaults to the normal traces pipeline.
+    #[arg(
+        long("kafka-receiver-target-exporters-traces"),
+        env = "ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_TRACES"
+    )]
+    pub target_exporters_traces: Option<String>,
+
+    /// Metrics exporters targeted by this Kafka receiver. Defaults to the normal metrics pipeline.
+    #[arg(
+        long("kafka-receiver-target-exporters-metrics"),
+        env = "ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_METRICS"
+    )]
+    pub target_exporters_metrics: Option<String>,
+
+    /// Logs exporters targeted by this Kafka receiver. Defaults to the normal logs pipeline.
+    #[arg(
+        long("kafka-receiver-target-exporters-logs"),
+        env = "ROTEL_KAFKA_RECEIVER_TARGET_EXPORTERS_LOGS"
+    )]
+    pub target_exporters_logs: Option<String>,
+
     /// Deserialization format
     #[arg(
         id("KAFKA_RECEIVER_FORMAT"),
@@ -305,6 +326,9 @@ impl KafkaReceiverArgs {
             .with_traces(self.traces)
             .with_metrics(self.metrics)
             .with_logs(self.logs)
+            .with_target_exporters_traces(parse_target_exporters(&self.target_exporters_traces)?)
+            .with_target_exporters_metrics(parse_target_exporters(&self.target_exporters_metrics)?)
+            .with_target_exporters_logs(parse_target_exporters(&self.target_exporters_logs)?)
             .with_deserialization_format(self.format)
             .with_client_id(self.client_id.clone())
             .with_auto_commit(self.enable_auto_commit, self.auto_commit_interval_ms)
@@ -370,8 +394,27 @@ impl KafkaReceiverArgs {
     }
 }
 
+fn parse_target_exporters(targets: &Option<String>) -> Result<Option<Vec<String>>, BoxError> {
+    let Some(targets) = targets else {
+        return Ok(None);
+    };
+
+    let parsed: Vec<String> = targets
+        .split(',')
+        .map(|target| target.trim().to_string())
+        .filter(|target| !target.is_empty())
+        .collect();
+
+    if parsed.is_empty() {
+        return Err("Kafka receiver target exporters cannot be empty".into());
+    }
+
+    Ok(Some(parsed))
+}
+
 #[cfg(test)]
 mod tests {
+    use super::KafkaReceiverArgs;
     use crate::receivers::kafka::config::{AutoOffsetReset, IsolationLevel, SaslMechanism};
 
     #[test]
@@ -406,5 +449,29 @@ mod tests {
 
         let read_committed = serde_json::from_str::<IsolationLevel>("\"read-committed\"").unwrap();
         assert_eq!(read_committed, IsolationLevel::ReadCommitted);
+    }
+
+    #[test]
+    fn test_kafka_receiver_target_exporters_default_to_none() {
+        let config = KafkaReceiverArgs::default().build_config().unwrap();
+
+        assert!(config.target_exporters_traces.is_none());
+        assert!(config.target_exporters_metrics.is_none());
+        assert!(config.target_exporters_logs.is_none());
+    }
+
+    #[test]
+    fn test_kafka_receiver_target_exporters_parse_csv() {
+        let args = KafkaReceiverArgs {
+            target_exporters_traces: Some("ch, otlp".to_string()),
+            ..Default::default()
+        };
+
+        let config = args.build_config().unwrap();
+
+        assert_eq!(
+            Some(vec!["ch".to_string(), "otlp".to_string()]),
+            config.target_exporters_traces
+        );
     }
 }

--- a/src/receivers/kafka/config.rs
+++ b/src/receivers/kafka/config.rs
@@ -125,6 +125,15 @@ pub struct KafkaReceiverConfig {
     /// Enable consuming logs
     pub logs: bool,
 
+    /// Optional trace exporter targets for this receiver.
+    pub target_exporters_traces: Option<Vec<String>>,
+
+    /// Optional metrics exporter targets for this receiver.
+    pub target_exporters_metrics: Option<Vec<String>>,
+
+    /// Optional logs exporter targets for this receiver.
+    pub target_exporters_logs: Option<Vec<String>>,
+
     /// Deserialization format for incoming messages
     pub deserialization_format: DeserializationFormat,
 
@@ -220,6 +229,9 @@ impl Default for KafkaReceiverConfig {
             traces: false,
             metrics: false,
             logs: false,
+            target_exporters_traces: None,
+            target_exporters_metrics: None,
+            target_exporters_logs: None,
             deserialization_format: DeserializationFormat::default(),
             group_id: "rotel-consumer".to_string(),
             client_id: "rotel".to_string(),
@@ -295,6 +307,24 @@ impl KafkaReceiverConfig {
     /// Consume logs
     pub fn with_logs(mut self, logs: bool) -> Self {
         self.logs = logs;
+        self
+    }
+
+    /// Override trace exporter targets for this receiver
+    pub fn with_target_exporters_traces(mut self, targets: Option<Vec<String>>) -> Self {
+        self.target_exporters_traces = targets;
+        self
+    }
+
+    /// Override metrics exporter targets for this receiver
+    pub fn with_target_exporters_metrics(mut self, targets: Option<Vec<String>>) -> Self {
+        self.target_exporters_metrics = targets;
+        self
+    }
+
+    /// Override logs exporter targets for this receiver
+    pub fn with_target_exporters_logs(mut self, targets: Option<Vec<String>>) -> Self {
+        self.target_exporters_logs = targets;
         self
     }
 

--- a/src/receivers/kafka/receiver.rs
+++ b/src/receivers/kafka/receiver.rs
@@ -411,7 +411,7 @@ impl KafkaReceiver {
         self.offset_committer.take()
     }
 
-    pub(crate) async fn run(
+    pub async fn run(
         &mut self,
         receivers_cancel: CancellationToken,
     ) -> std::result::Result<(), Box<dyn Error + Send + Sync>> {

--- a/src/topology/export_group.rs
+++ b/src/topology/export_group.rs
@@ -1,0 +1,1017 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::StreamExt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+use tokio::sync::watch;
+use tokio::time::{Instant, Interval, MissedTickBehavior, interval_at};
+use tracing::{info, warn};
+
+use crate::bounded_channel::{BoundedReceiver, BoundedSender, bounded};
+use crate::topology::payload::{
+    Ack, ExporterError, ForwarderAcknowledgement, ForwarderMetadata, Message, MessageMetadata,
+};
+
+struct Slot<T> {
+    /// Retained payload with metadata stripped — metadata is re-applied fresh on each send attempt.
+    payload: Vec<Message<T>>,
+    /// Original upstream metadata, one per message; acked or nacked when the group resolves.
+    originals: Vec<MessageMetadata>,
+    /// Which member is currently in-flight for this batch.
+    member_idx: u32,
+    /// Bumped on each attempt; stale acks/nacks from a previous attempt are ignored.
+    generation: u32,
+}
+
+pub struct ExportGroup<T> {
+    tx: BoundedSender<Vec<Message<T>>>,
+    active_rx: watch::Receiver<u32>,
+    active_atomic: Arc<AtomicU32>,
+    /// Internal forwarder ack channel — exposed for testing only.
+    #[cfg(test)]
+    pub(crate) ack_tx: BoundedSender<ForwarderAcknowledgement>,
+}
+
+impl<T> ExportGroup<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    pub fn sender(&self) -> BoundedSender<Vec<Message<T>>> {
+        self.tx.clone()
+    }
+
+    pub fn active_index(&self) -> u32 {
+        *self.active_rx.borrow()
+    }
+
+    /// Watch channel for breaker state changes. Suitable for tests and telemetry.
+    pub fn subscribe_active(&self) -> watch::Receiver<u32> {
+        self.active_rx.clone()
+    }
+
+    /// Arc<AtomicU32> suitable for registration as an ObservableGauge in telemetry.
+    pub fn active_atomic(&self) -> Arc<AtomicU32> {
+        self.active_atomic.clone()
+    }
+}
+
+pub struct ExportGroupBuilder<T> {
+    members: Vec<BoundedSender<Vec<Message<T>>>>,
+    trip_after: u32,
+    probe_after: Duration,
+    sending_queue_size: usize,
+}
+
+impl<T> ExportGroupBuilder<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    pub fn new(sending_queue_size: usize) -> Self {
+        Self {
+            members: Vec::new(),
+            trip_after: 3,
+            probe_after: Duration::from_secs(30),
+            sending_queue_size,
+        }
+    }
+
+    pub fn add_member(mut self, member: BoundedSender<Vec<Message<T>>>) -> Self {
+        self.members.push(member);
+        self
+    }
+
+    pub fn trip_after(mut self, n: u32) -> Self {
+        self.trip_after = n;
+        self
+    }
+
+    pub fn probe_after(mut self, d: Duration) -> Self {
+        self.probe_after = d;
+        self
+    }
+
+    pub fn build(self) -> ExportGroup<T> {
+        let (tx, rx) = bounded(self.sending_queue_size);
+        let (active_tx, active_rx) = watch::channel(0u32);
+        let active_atomic = Arc::new(AtomicU32::new(0));
+
+        let slab_cap = self.sending_queue_size + 2 * EXPORTER_PIPELINE_SLOP;
+        let (ack_tx, ack_rx) = bounded::<ForwarderAcknowledgement>(slab_cap);
+
+        #[cfg(test)]
+        let ack_tx_for_test = ack_tx.clone();
+
+        let active_atomic_for_task = active_atomic.clone();
+        tokio::spawn(async move {
+            let mut task = ExportGroupTask::new(
+                rx,
+                self.members,
+                active_tx,
+                active_atomic_for_task,
+                self.trip_after,
+                self.probe_after,
+                self.sending_queue_size,
+                ack_tx,
+                ack_rx,
+            );
+            task.run().await;
+        });
+
+        ExportGroup {
+            tx,
+            active_rx,
+            active_atomic,
+            #[cfg(test)]
+            ack_tx: ack_tx_for_test,
+        }
+    }
+}
+
+const EXPORTER_PIPELINE_SLOP: usize = 32;
+
+struct ExportGroupTask<T> {
+    upstream_rx: BoundedReceiver<Vec<Message<T>>>,
+    members: Vec<BoundedSender<Vec<Message<T>>>>,
+    active_tx: watch::Sender<u32>,
+    active_atomic: Arc<AtomicU32>,
+    local_active: usize,
+    consecutive_nacks: u32,
+    trip_after: u32,
+    probe_after: Duration,
+    probe_pending: bool,
+    probe_interval: Option<Interval>,
+    slab: Vec<Option<Slot<T>>>,
+    slab_limit: usize,
+    free: Vec<u32>,
+    ack_tx: BoundedSender<ForwarderAcknowledgement>,
+    ack_rx: BoundedReceiver<ForwarderAcknowledgement>,
+}
+
+impl<T> ExportGroupTask<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        upstream_rx: BoundedReceiver<Vec<Message<T>>>,
+        members: Vec<BoundedSender<Vec<Message<T>>>>,
+        active_tx: watch::Sender<u32>,
+        active_atomic: Arc<AtomicU32>,
+        trip_after: u32,
+        probe_after: Duration,
+        sending_queue_size: usize,
+        ack_tx: BoundedSender<ForwarderAcknowledgement>,
+        ack_rx: BoundedReceiver<ForwarderAcknowledgement>,
+    ) -> Self {
+        let slab_cap = sending_queue_size + 2 * EXPORTER_PIPELINE_SLOP;
+
+        Self {
+            upstream_rx,
+            members,
+            active_tx,
+            active_atomic,
+            local_active: 0,
+            consecutive_nacks: 0,
+            trip_after,
+            probe_after,
+            probe_pending: false,
+            probe_interval: None,
+            slab: Vec::with_capacity(slab_cap),
+            slab_limit: slab_cap,
+            free: Vec::new(),
+            ack_tx,
+            ack_rx,
+        }
+    }
+
+    async fn run(&mut self) {
+        let mut upstream_stream = self.upstream_rx.clone().into_stream();
+        let mut ack_stream = self.ack_rx.clone().into_stream();
+
+        loop {
+            let upstream_ready = !self.free.is_empty() || self.slab.len() < self.slab_limit;
+            let probe_allowed = self.probe_interval.is_some() && !self.probe_pending;
+
+            // biased: drain acks before pulling new upstream batches, so the slab does
+            // not fill up prematurely when the upstream is faster than members.
+            tokio::select! {
+                biased;
+
+                maybe_ack = ack_stream.next() => {
+                    match maybe_ack {
+                        Some(ack) => self.handle_ack(ack).await,
+                        None => break,
+                    }
+                }
+                maybe_batch = upstream_stream.next(), if upstream_ready => {
+                    match maybe_batch {
+                        Some(batch) => self.dispatch(batch).await,
+                        None => break,
+                    }
+                }
+                _ = tick_probe_opt(&mut self.probe_interval), if probe_allowed => {
+                    self.probe_pending = true;
+                }
+            }
+        }
+    }
+
+    async fn dispatch(&mut self, mut batch: Vec<Message<T>>) {
+        // Allocate a slot index.
+        let slot_idx = self.free.pop().unwrap_or_else(|| {
+            let idx = self.slab.len() as u32;
+            self.slab.push(None);
+            idx
+        });
+
+        let target = if self.probe_pending {
+            self.probe_pending = false;
+            0
+        } else {
+            self.local_active
+        };
+
+        // Strip originals and clear metadata from the stored payload. The payload kept
+        // in the slot is always metadata-less; each send_attempt re-applies a fresh
+        // forwarder so ref_count == payload_for_member.len() exactly.
+        let originals: Vec<MessageMetadata> =
+            batch.iter_mut().filter_map(|m| m.metadata.take()).collect();
+
+        self.slab[slot_idx as usize] = Some(Slot {
+            payload: batch,
+            originals,
+            member_idx: target as u32,
+            generation: 0,
+        });
+
+        self.send_attempt(slot_idx).await;
+    }
+
+    /// Clone the metadata-less slot payload, wrap it with a fresh forwarder, then send to
+    /// the current member. On channel failure the send is treated as an immediate nack.
+    async fn send_attempt(&mut self, slot_idx: u32) {
+        let (member_idx, generation) = {
+            let slot = self.slab[slot_idx as usize].as_ref().unwrap();
+            (slot.member_idx, slot.generation)
+        };
+        let payload_for_member = {
+            let slot = self.slab[slot_idx as usize].as_ref().unwrap();
+            apply_forwarder_metadata(&slot.payload, generation, slot_idx, &self.ack_tx)
+        };
+        if self.members[member_idx as usize]
+            .send_async(payload_for_member)
+            .await
+            .is_err()
+        {
+            warn!(
+                "export group: failed to send to member {}, treating as nack",
+                member_idx
+            );
+            self.handle_nack_logic(slot_idx, generation).await;
+        }
+    }
+
+    async fn handle_ack(&mut self, ack: ForwarderAcknowledgement) {
+        match ack {
+            ForwarderAcknowledgement::Ack(details) => {
+                let (generation, slot_idx) = decode_id(&details.request_id);
+                if let Some(slot) = self.slab.get(slot_idx as usize).and_then(|s| s.as_ref()) {
+                    if slot.generation != generation {
+                        return; // stale
+                    }
+                } else {
+                    return; // already freed
+                }
+
+                let slot = self.slab[slot_idx as usize].take().unwrap();
+                self.free.push(slot_idx);
+
+                // Reset consecutive_nacks when the currently-active member succeeds.
+                if slot.member_idx as usize == self.local_active {
+                    self.consecutive_nacks = 0;
+                }
+
+                // Probe succeeded: recover to members[0].
+                if slot.member_idx == 0 && self.local_active != 0 {
+                    info!("export group recovered, active = members[0]");
+                    self.update_active(0);
+                    self.consecutive_nacks = 0;
+                    self.probe_interval = None;
+                }
+
+                for original in slot.originals {
+                    let _ = original.ack().await;
+                }
+            }
+            ForwarderAcknowledgement::Nack(details) => {
+                let (generation, slot_idx) = decode_id(&details.request_id);
+                self.handle_nack_logic(slot_idx, generation).await;
+            }
+        }
+    }
+
+    fn update_active(&mut self, index: usize) {
+        self.local_active = index;
+        self.active_atomic.store(index as u32, Ordering::Release);
+        let _ = self.active_tx.send(index as u32);
+    }
+
+    /// Core nack handler: walk the slot forward to the next member, or exhaust and nack
+    /// originals. Uses an iterative approach to avoid async recursion / Box::pin overhead.
+    async fn handle_nack_logic(&mut self, slot_idx: u32, generation: u32) {
+        // Validate: if the slot is gone or the generation doesn't match, this is stale.
+        {
+            let Some(slot) = self.slab.get(slot_idx as usize).and_then(|s| s.as_ref()) else {
+                return;
+            };
+            if slot.generation != generation {
+                return;
+            }
+        }
+
+        // Iterative walk: keep trying the next member until one accepts the send, or
+        // the member list is exhausted.
+        loop {
+            let (member_idx, cur_gen) = {
+                let slot = self.slab[slot_idx as usize].as_ref().unwrap();
+                (slot.member_idx, slot.generation)
+            };
+
+            // Update breaker state based on the just-failed member.
+            if member_idx as usize == self.local_active {
+                self.consecutive_nacks += 1;
+                if self.consecutive_nacks >= self.trip_after
+                    && (self.local_active + 1) < self.members.len()
+                {
+                    self.update_active(self.local_active + 1);
+                    self.consecutive_nacks = 0;
+                    warn!(
+                        "export group tripped, active = members[{}]",
+                        self.local_active
+                    );
+
+                    if !self.probe_after.is_zero() {
+                        let mut iv =
+                            interval_at(Instant::now() + self.probe_after, self.probe_after);
+                        iv.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                        self.probe_interval = Some(iv);
+                    }
+                }
+            }
+            // Probe nack: stay at current active; probe_interval continues.
+
+            let next_member = member_idx + 1;
+            if (next_member as usize) < self.members.len() {
+                // Advance to the next member and try again.
+                let new_gen = {
+                    let slot = self.slab[slot_idx as usize].as_mut().unwrap();
+                    slot.member_idx = next_member;
+                    slot.generation = cur_gen.wrapping_add(1);
+                    slot.generation
+                };
+                let payload_for_member = {
+                    let slot = self.slab[slot_idx as usize].as_ref().unwrap();
+                    apply_forwarder_metadata(&slot.payload, new_gen, slot_idx, &self.ack_tx)
+                };
+                match self.members[next_member as usize]
+                    .send_async(payload_for_member)
+                    .await
+                {
+                    Ok(()) => break,
+                    Err(_) => {
+                        warn!(
+                            "export group: member {} channel closed, continuing walk",
+                            next_member
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                // Member list exhausted: nack all originals with a synthesized error.
+                let slot = self.slab[slot_idx as usize].take().unwrap();
+                self.free.push(slot_idx);
+
+                let reason = ExporterError::ExportFailed {
+                    error_code: 0,
+                    error_message: "export group: all members nacked".into(),
+                };
+                for original in slot.originals {
+                    let _ = original.nack(reason.clone()).await;
+                }
+                break;
+            }
+        }
+    }
+}
+
+async fn tick_probe_opt(iv_opt: &mut Option<Interval>) {
+    if let Some(iv) = iv_opt {
+        iv.tick().await;
+    } else {
+        std::future::pending::<()>().await;
+    }
+}
+
+fn encode_id(generation: u32, idx: u32) -> String {
+    format!("{generation}:{idx}")
+}
+
+/// Clone `payload` and attach a fresh forwarder to each message using the
+/// take-last-clone idiom so `ref_count == payload.len()` exactly.
+fn apply_forwarder_metadata<T: Clone>(
+    payload: &[Message<T>],
+    generation: u32,
+    slot_idx: u32,
+    ack_tx: &BoundedSender<ForwarderAcknowledgement>,
+) -> Vec<Message<T>> {
+    let mut out = payload.to_vec();
+    let fwd = MessageMetadata::forwarder(ForwarderMetadata::new(
+        encode_id(generation, slot_idx),
+        Some(ack_tx.clone()),
+    ));
+    let last = out.len().saturating_sub(1);
+    let mut fwd_opt = Some(fwd);
+    for (i, msg) in out.iter_mut().enumerate() {
+        msg.metadata = if i == last {
+            fwd_opt.take()
+        } else {
+            Some(fwd_opt.as_ref().unwrap().clone())
+        };
+    }
+    out
+}
+
+fn decode_id(id: &str) -> (u32, u32) {
+    if let Some(pos) = id.find(':') {
+        let generation = id[..pos].parse().unwrap_or(0);
+        let idx = id[pos + 1..].parse().unwrap_or(0);
+        (generation, idx)
+    } else {
+        (0, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bounded_channel::TrySendError;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    // -------------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------------
+
+    /// Thin wrapper around a member receive channel, providing named reactive operations.
+    struct TestMember {
+        rx: BoundedReceiver<Vec<Message<u8>>>,
+    }
+
+    impl TestMember {
+        fn new(rx: BoundedReceiver<Vec<Message<u8>>>) -> Self {
+            Self { rx }
+        }
+
+        async fn expect_batch(&mut self) -> Vec<Message<u8>> {
+            self.rx.next().await.expect("expected a batch from member")
+        }
+    }
+
+    /// Ack every message in a batch using its wrapped forwarder metadata.
+    async fn ack_batch(batch: &[Message<u8>]) {
+        for msg in batch {
+            if let Some(meta) = &msg.metadata {
+                let _ = meta.ack().await;
+            }
+        }
+    }
+
+    /// Nack every message in a batch using its wrapped forwarder metadata.
+    async fn nack_batch(batch: &[Message<u8>], reason: ExporterError) {
+        for msg in batch {
+            if let Some(meta) = &msg.metadata {
+                let _ = meta.nack(reason.clone()).await;
+            }
+        }
+    }
+
+    /// Create an original metadata + a receiver so we can observe ack/nack.
+    fn make_original_with_rx() -> (BoundedReceiver<ForwarderAcknowledgement>, MessageMetadata) {
+        let (tx, rx) = bounded::<ForwarderAcknowledgement>(4);
+        let meta = MessageMetadata::forwarder(ForwarderMetadata::new("orig".into(), Some(tx)));
+        (rx, meta)
+    }
+
+    fn msg(payload: u8, meta: MessageMetadata) -> Message<u8> {
+        Message::new(Some(meta), vec![payload], None)
+    }
+
+    fn msg_no_meta(payload: u8) -> Message<u8> {
+        Message::new(None, vec![payload], None)
+    }
+
+    fn build_group_2(
+        trip_after: u32,
+        probe_after: Duration,
+    ) -> (ExportGroup<u8>, TestMember, TestMember) {
+        let (m0_tx, m0_rx) = bounded(16);
+        let (m1_tx, m1_rx) = bounded(16);
+        let group = ExportGroupBuilder::new(16)
+            .add_member(m0_tx)
+            .add_member(m1_tx)
+            .trip_after(trip_after)
+            .probe_after(probe_after)
+            .build();
+        (group, TestMember::new(m0_rx), TestMember::new(m1_rx))
+    }
+
+    fn build_group_3(trip_after: u32) -> (ExportGroup<u8>, TestMember, TestMember, TestMember) {
+        let (m0_tx, m0_rx) = bounded(16);
+        let (m1_tx, m1_rx) = bounded(16);
+        let (m2_tx, m2_rx) = bounded(16);
+        let group = ExportGroupBuilder::new(16)
+            .add_member(m0_tx)
+            .add_member(m1_tx)
+            .add_member(m2_tx)
+            .trip_after(trip_after)
+            .probe_after(Duration::ZERO)
+            .build();
+        (
+            group,
+            TestMember::new(m0_rx),
+            TestMember::new(m1_rx),
+            TestMember::new(m2_rx),
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // encode/decode
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_encode_decode_id() {
+        assert_eq!(encode_id(0, 0), "0:0");
+        assert_eq!(encode_id(123, 456), "123:456");
+        assert_eq!(decode_id("123:456"), (123, 456));
+        assert_eq!(decode_id("0:0"), (0, 0));
+        assert_eq!(decode_id("bad"), (0, 0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    /// Primary acks → original is acked exactly once; slab slot is freed.
+    #[tokio::test]
+    async fn test_happy_path_closed_member0_acks() {
+        let (group, mut m0, _m1) = build_group_2(3, Duration::ZERO);
+
+        let (mut orig_rx, meta) = make_original_with_rx();
+        group.sender().send(vec![msg(1, meta)]).await.unwrap();
+
+        let batch = m0.expect_batch().await;
+        ack_batch(&batch).await;
+
+        match orig_rx.next().await.unwrap() {
+            ForwarderAcknowledgement::Ack(_) => {}
+            ForwarderAcknowledgement::Nack(_) => panic!("expected Ack"),
+        }
+        assert_eq!(group.active_index(), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Retry on nack
+    // -------------------------------------------------------------------------
+
+    /// m0 nacks → batch retried on m1 → original acked exactly once.
+    #[tokio::test]
+    async fn test_retry_on_nack_m0_then_m1_acks() {
+        let (group, mut m0, mut m1) = build_group_2(3, Duration::ZERO);
+
+        let (mut orig_rx, meta) = make_original_with_rx();
+        group.sender().send(vec![msg(1, meta)]).await.unwrap();
+
+        let batch0 = m0.expect_batch().await;
+        nack_batch(&batch0, ExporterError::Cancelled).await;
+
+        let batch1 = m1.expect_batch().await;
+        ack_batch(&batch1).await;
+
+        match orig_rx.next().await.unwrap() {
+            ForwarderAcknowledgement::Ack(_) => {}
+            ForwarderAcknowledgement::Nack(_) => panic!("expected Ack, not Nack"),
+        }
+
+        // No second message on orig_rx (original was not nacked).
+        let nothing = timeout(Duration::from_secs(5), orig_rx.next()).await;
+        assert!(
+            nothing.is_err() || matches!(nothing.unwrap(), None),
+            "unexpected second ack/nack"
+        );
+    }
+
+    /// m0 nacks, m1 nacks, m2 acks → original acked exactly once.
+    #[tokio::test]
+    async fn test_walk_forward_three_members() {
+        let (group, mut m0, mut m1, mut m2) = build_group_3(99);
+
+        let (mut orig_rx, meta) = make_original_with_rx();
+        group.sender().send(vec![msg(1, meta)]).await.unwrap();
+
+        nack_batch(&m0.expect_batch().await, ExporterError::Cancelled).await;
+        nack_batch(&m1.expect_batch().await, ExporterError::Cancelled).await;
+        ack_batch(&m2.expect_batch().await).await;
+
+        match orig_rx.next().await.unwrap() {
+            ForwarderAcknowledgement::Ack(_) => {}
+            _ => panic!("expected Ack"),
+        }
+    }
+
+    /// All members nack → original is nacked exactly once with the synthesized reason.
+    #[tokio::test]
+    async fn test_all_members_nack_then_original_nacked() {
+        let (group, mut m0, mut m1, mut m2) = build_group_3(99);
+
+        let (mut orig_rx, meta) = make_original_with_rx();
+        group.sender().send(vec![msg(1, meta)]).await.unwrap();
+
+        nack_batch(&m0.expect_batch().await, ExporterError::Cancelled).await;
+        nack_batch(&m1.expect_batch().await, ExporterError::Cancelled).await;
+        nack_batch(&m2.expect_batch().await, ExporterError::Cancelled).await;
+
+        match orig_rx.next().await.unwrap() {
+            ForwarderAcknowledgement::Nack(_) => {}
+            ForwarderAcknowledgement::Ack(_) => panic!("expected Nack"),
+        }
+    }
+
+    /// Batch of 3 messages; nack on one clone; forwarder fires Nack exactly once
+    /// (claim_response semantics); group retries the whole batch on m1.
+    #[tokio::test]
+    async fn test_single_message_nack_in_batch() {
+        let (group, mut m0, mut m1) = build_group_2(99, Duration::ZERO);
+
+        group
+            .sender()
+            .send(vec![msg_no_meta(1), msg_no_meta(2), msg_no_meta(3)])
+            .await
+            .unwrap();
+
+        let batch0 = m0.expect_batch().await;
+        assert_eq!(batch0.len(), 3);
+
+        // Nack only the first message — the shared forwarder fires once.
+        if let Some(meta) = &batch0[0].metadata {
+            let _ = meta.nack(ExporterError::Cancelled).await;
+        }
+        // The other two clones ack (ref_count decrements; response already claimed so no second send).
+        if let Some(meta) = &batch0[1].metadata {
+            let _ = meta.ack().await;
+        }
+        if let Some(meta) = &batch0[2].metadata {
+            let _ = meta.ack().await;
+        }
+
+        // Group should have retried the whole batch on m1.
+        let batch1 = m1.expect_batch().await;
+        assert_eq!(batch1.len(), 3);
+        ack_batch(&batch1).await;
+    }
+
+    // -------------------------------------------------------------------------
+    // Circuit breaker
+    // -------------------------------------------------------------------------
+
+    /// trip_after=2 consecutive m0-nacks → active advances to 1.
+    #[tokio::test]
+    async fn test_trip_after_threshold() {
+        let (group, mut m0, mut m1) = build_group_2(2, Duration::ZERO);
+        let mut active_rx = group.subscribe_active();
+
+        for _ in 0..2 {
+            group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+            // m0 is the starting point (active=0)
+            nack_batch(&m0.expect_batch().await, ExporterError::Cancelled).await;
+            // retry on m1 succeeds
+            ack_batch(&m1.expect_batch().await).await;
+        }
+
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+        assert_eq!(group.active_index(), 1);
+
+        // New batches should start directly at m1.
+        group.sender().send(vec![msg_no_meta(42)]).await.unwrap();
+        let b = m1.expect_batch().await;
+        assert_eq!(b[0].payload, vec![42]);
+        ack_batch(&b).await;
+    }
+
+    /// With active=1, trip_after=2 consecutive m1-nacks (each retried on m2) → active=2.
+    #[tokio::test]
+    async fn test_walk_forward_trip() {
+        let (group, _m0, mut m1, mut m2) = build_group_3(2);
+        let mut active_rx = group.subscribe_active();
+
+        // Pre-trip to active=1: 2 batches starting at m0 (active=0) that nack at m0,
+        // retry on m1 (which acks).
+        {
+            let (m0_tx, m0_rx) = bounded::<Vec<Message<u8>>>(16);
+            drop(m0_rx); // We already have the group's m0 channel; we need to re-build.
+            // Actually the group is already built above with _m0; just ignore m0 here.
+            // Use a separate group for this test to control the trip to active=1 directly.
+            let _ = m0_tx;
+        }
+
+        // Simpler: we pre-trip active=1 by doing 2 nack cycles via the already-built group.
+        // But _m0 is consumed by build_group_3. Drop it so sends to m0 fail immediately
+        // and are treated as nacks (channel-closed path), which also counts toward consecutive_nacks.
+        drop(_m0);
+
+        // With m0 closed, sends to m0 will fail and be treated as nacks → consecutive_nacks increments.
+        for _ in 0..2 {
+            group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+            // m1 gets the retry (m0 closed → immediate nack → walk to m1)
+            ack_batch(&m1.expect_batch().await).await;
+        }
+
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+
+        // Now active=1. Do 2 batches starting at m1 that nack (retried on m2 which acks).
+        // After trip_after=2 consecutive m1-nacks, active should become 2.
+        for _ in 0..2 {
+            group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+            nack_batch(&m1.expect_batch().await, ExporterError::Cancelled).await;
+            ack_batch(&m2.expect_batch().await).await;
+        }
+
+        active_rx.wait_for(|&v| v == 2).await.unwrap();
+        assert_eq!(group.active_index(), 2);
+    }
+
+    /// With active=1, a new batch starts at m1; if m1 nacks, retry is on m2
+    /// (not on m1+1 by coincidence — verified with a 4-member group).
+    #[tokio::test]
+    async fn test_retry_independent_of_breaker() {
+        let (m0_tx, _m0_rx) = bounded::<Vec<Message<u8>>>(16);
+        let (m1_tx, m1_rx) = bounded(16);
+        let (m2_tx, m2_rx) = bounded(16);
+        let (m3_tx, m3_rx) = bounded(16);
+        let group = ExportGroupBuilder::<u8>::new(16)
+            .add_member(m0_tx)
+            .add_member(m1_tx)
+            .add_member(m2_tx)
+            .add_member(m3_tx)
+            .trip_after(1) // trip immediately on first m0 nack
+            .probe_after(Duration::ZERO)
+            .build();
+
+        let mut m1 = TestMember::new(m1_rx);
+        let mut m2 = TestMember::new(m2_rx);
+        let mut m3 = TestMember::new(m3_rx);
+        let mut active_rx = group.subscribe_active();
+
+        // Drop m0_rx so first dispatch immediately nacks → active becomes 1.
+        drop(_m0_rx);
+        group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+        // m1 gets the retry (walk from m0's failed send)
+        ack_batch(&m1.expect_batch().await).await;
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+
+        // Now active=1. New batch starts at m1; m1 nacks → retry on m2 (not m3).
+        let (mut orig_rx, meta) = make_original_with_rx();
+        group.sender().send(vec![msg(5, meta)]).await.unwrap();
+
+        nack_batch(&m1.expect_batch().await, ExporterError::Cancelled).await;
+
+        // Should land on m2, not m3.
+        let b = m2.expect_batch().await;
+        assert_eq!(b[0].payload, vec![5]);
+        ack_batch(&b).await;
+
+        // m3 should receive nothing.
+        let nothing = timeout(Duration::from_secs(5), m3.rx.next()).await;
+        assert!(
+            nothing.is_err() || matches!(nothing, Ok(None)),
+            "m3 should not receive anything"
+        );
+
+        match orig_rx.next().await.unwrap() {
+            ForwarderAcknowledgement::Ack(_) => {}
+            _ => panic!("expected Ack on original"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Stale ack/nack
+    // -------------------------------------------------------------------------
+
+    /// An ack with a mismatched generation is ignored without changing state.
+    #[tokio::test]
+    async fn test_stale_ack_ignored() {
+        let (group, mut m0, _m1) = build_group_2(3, Duration::ZERO);
+
+        // Dispatch one batch; it lands on m0.
+        let (mut orig_rx, meta) = make_original_with_rx();
+        group.sender().send(vec![msg(1, meta)]).await.unwrap();
+        let _batch = m0.expect_batch().await; // m0 holds the batch; we don't ack it yet
+
+        // Inject a stale ack with a wrong generation via the test-only ack_tx.
+        group
+            .ack_tx
+            .send(ForwarderAcknowledgement::Ack(
+                crate::topology::payload::ForwarderPayloadDetails {
+                    // generation=99 does not match the slot's generation=0
+                    request_id: encode_id(99, 0),
+                },
+            ))
+            .await
+            .unwrap();
+
+        // Give the task a moment to process (pump the event loop).
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Now ack the real batch; the original should fire exactly once.
+        ack_batch(&_batch).await;
+        match orig_rx.next().await.unwrap() {
+            ForwarderAcknowledgement::Ack(_) => {}
+            _ => panic!("expected Ack"),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Probe / HALF_OPEN
+    // -------------------------------------------------------------------------
+
+    /// Trip breaker → advance time past probe_after → next batch probes m0 → ack → active=0.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_probe_recovers_member0() {
+        let probe_after = Duration::from_secs(30);
+        let (group, mut m0, mut m1) = build_group_2(2, probe_after);
+        let mut active_rx = group.subscribe_active();
+
+        // Trip the breaker (2 nacks of active member m0, each retried on m1 which acks).
+        for _ in 0..2 {
+            group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+            nack_batch(&m0.expect_batch().await, ExporterError::Cancelled).await;
+            ack_batch(&m1.expect_batch().await).await;
+        }
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+
+        // Advance virtual time past probe_after to fire the probe tick.
+        tokio::time::advance(probe_after + Duration::from_millis(1)).await;
+        // Yield so the task processes the probe tick.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Send a batch — it should be the probe and start at m0.
+        group.sender().send(vec![msg_no_meta(99)]).await.unwrap();
+        let probe_batch = m0.expect_batch().await;
+        assert_eq!(probe_batch[0].payload, vec![99]);
+        ack_batch(&probe_batch).await;
+
+        // active should recover to 0.
+        active_rx.wait_for(|&v| v == 0).await.unwrap();
+        assert_eq!(group.active_index(), 0);
+    }
+
+    /// Probe nack → active stays; probe interval continues.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_probe_nack_keeps_active() {
+        let probe_after = Duration::from_secs(30);
+        let (group, mut m0, mut m1) = build_group_2(2, probe_after);
+        let mut active_rx = group.subscribe_active();
+
+        // Trip the breaker.
+        for _ in 0..2 {
+            group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+            nack_batch(&m0.expect_batch().await, ExporterError::Cancelled).await;
+            ack_batch(&m1.expect_batch().await).await;
+        }
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+
+        // First probe fires.
+        tokio::time::advance(probe_after + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        group.sender().send(vec![msg_no_meta(55)]).await.unwrap();
+        let probe_batch = m0.expect_batch().await;
+        // Nack the probe; it retries on m1 (no other members after m0 in a 2-member group... wait,
+        // actually m0 is member 0 and the probe starts there; nacking it walks to m1).
+        // But we still expect active to stay at 1 (probe nack does not reset active).
+        nack_batch(&probe_batch, ExporterError::Cancelled).await;
+
+        // The retry lands on m1.
+        ack_batch(&m1.expect_batch().await).await;
+
+        // active should still be 1.
+        tokio::task::yield_now().await;
+        assert_eq!(
+            group.active_index(),
+            1,
+            "active should remain 1 after probe nack"
+        );
+
+        // Second probe fires after another probe_after.
+        tokio::time::advance(probe_after + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        group.sender().send(vec![msg_no_meta(66)]).await.unwrap();
+        let probe_batch2 = m0.expect_batch().await;
+        ack_batch(&probe_batch2).await;
+        active_rx.wait_for(|&v| v == 0).await.unwrap();
+    }
+
+    /// During HALF_OPEN, batches dispatched after the probe but before its outcome
+    /// continue to start at members[active], not at members[0].
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn test_probe_does_not_affect_concurrent_batches() {
+        let probe_after = Duration::from_secs(30);
+        let (group, mut m0, mut m1) = build_group_2(2, probe_after);
+        let mut active_rx = group.subscribe_active();
+
+        // Trip breaker.
+        for _ in 0..2 {
+            group.sender().send(vec![msg_no_meta(0)]).await.unwrap();
+            nack_batch(&m0.expect_batch().await, ExporterError::Cancelled).await;
+            ack_batch(&m1.expect_batch().await).await;
+        }
+        active_rx.wait_for(|&v| v == 1).await.unwrap();
+
+        // Fire probe tick.
+        tokio::time::advance(probe_after + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Send two batches. The first should be the probe (starts at m0).
+        // The second should start at m1 (active=1), not m0.
+        group.sender().send(vec![msg_no_meta(1)]).await.unwrap();
+        group.sender().send(vec![msg_no_meta(2)]).await.unwrap();
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // First batch lands on m0 (probe).
+        let probe_batch = m0.expect_batch().await;
+        assert_eq!(probe_batch[0].payload, vec![1]);
+
+        // Second batch lands on m1 (active=1, not probing).
+        let normal_batch = m1.expect_batch().await;
+        assert_eq!(normal_batch[0].payload, vec![2]);
+
+        ack_batch(&probe_batch).await;
+        ack_batch(&normal_batch).await;
+    }
+
+    // -------------------------------------------------------------------------
+    // Slab pressure / backpressure
+    // -------------------------------------------------------------------------
+
+    /// When the slab is full, upstream try_send returns Full (backpressure applied).
+    #[tokio::test]
+    async fn test_slab_pressure_backpressures_upstream() {
+        // Use a tiny slab: sending_queue_size=1 → slab_cap = 1 + 2*32 = 65.
+        // We use sending_queue_size = 1 so the upstream channel capacity is 1.
+        // The slab capacity is 1 + 64 = 65. Use a very small one for this test by
+        // choosing sending_queue_size=0: slab_cap = 0 + 64 = 64.
+        // We need slab_cap to be small for a fast test; use sending_queue_size=0.
+        let slab_cap = 0 + 2 * EXPORTER_PIPELINE_SLOP; // 64
+
+        let (m0_tx, _m0_rx) = bounded::<Vec<Message<u8>>>(slab_cap + 4);
+        let group = ExportGroupBuilder::<u8>::new(0)
+            .add_member(m0_tx)
+            .trip_after(99)
+            .probe_after(Duration::ZERO)
+            .build();
+
+        // Drop the first group; re-build with a controlled small capacity.
+        drop(group);
+
+        let small_cap = 2usize;
+        let actual_slab_cap = small_cap + 2 * EXPORTER_PIPELINE_SLOP;
+        let (m0_tx2, _m0_rx2) = bounded::<Vec<Message<u8>>>(actual_slab_cap + 4);
+        let group2 = ExportGroupBuilder::<u8>::new(small_cap)
+            .add_member(m0_tx2)
+            .trip_after(99)
+            .probe_after(Duration::ZERO)
+            .build();
+
+        let sender2 = group2.sender();
+        // The upstream BoundedSender has capacity small_cap.
+        // The slab has capacity actual_slab_cap.
+        // Fill the upstream channel to capacity (without tasks draining it).
+        for _ in 0..small_cap {
+            sender2.send(vec![msg_no_meta(0)]).await.unwrap();
+        }
+
+        // Now try_send should return Full because upstream channel is at capacity.
+        match sender2.try_send(vec![msg_no_meta(99)]) {
+            Err(TrySendError::Full(_)) => {} // expected
+            Ok(()) => panic!("should have been full"),
+            Err(TrySendError::Disconnected(_)) => panic!("unexpected disconnect"),
+        }
+    }
+}

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -3,6 +3,7 @@
 pub mod batch;
 pub mod batch_resources;
 pub mod debug;
+pub mod export_group;
 pub mod fanout;
 pub mod flush_control;
 pub mod generic_pipeline;

--- a/src/topology/payload.rs
+++ b/src/topology/payload.rs
@@ -602,11 +602,13 @@ pub struct KmsgNack {
     pub reason: ExporterError,
 }
 
+#[derive(Clone)]
 pub enum ForwarderAcknowledgement {
     Ack(ForwarderPayloadDetails),
     Nack(ForwarderPayloadDetails),
 }
 
+#[derive(Clone)]
 pub struct ForwarderPayloadDetails {
     pub request_id: String,
 }

--- a/tests/kafka_integration_tests.rs
+++ b/tests/kafka_integration_tests.rs
@@ -11,19 +11,28 @@
 //! 3. Stop Kafka: ./scripts/kafka-test-env.sh stop
 
 #![cfg(kafka_integration_tests = "true")]
+#![allow(unused_imports)]
 
+use httpmock::Method::POST as HTTP_POST;
+use httpmock::MockServer;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::metrics::v1::{
     Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric, number_data_point,
 };
 use opentelemetry_proto::tonic::resource::v1::Resource;
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::message::Message;
 use rotel::bounded_channel::bounded;
+use rotel::exporters::clickhouse::ClickhouseExporterConfigBuilder;
 use rotel::exporters::kafka::config::{Compression, KafkaExporterConfig, SerializationFormat};
 use rotel::exporters::kafka::{build_logs_exporter, build_metrics_exporter, build_traces_exporter};
+use rotel::receivers::kafka::config::{AutoOffsetReset, KafkaReceiverConfig};
+use rotel::receivers::kafka::receiver::KafkaReceiver;
+use rotel::receivers::otlp_output::OTLPOutput;
+use rotel::topology::export_group::ExportGroupBuilder;
 use rotel::topology::payload::Message as PayloadMessage;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -41,11 +50,12 @@ fn generate_unique_topic(base: &str) -> String {
 }
 
 async fn setup_consumer(topic: &str) -> StreamConsumer {
+    setup_consumer_with_group(topic, format!("test-consumer-{}", uuid::Uuid::new_v4())).await
+}
+
+async fn setup_consumer_with_group(topic: &str, group_id: String) -> StreamConsumer {
     let consumer: StreamConsumer = ClientConfig::new()
-        .set(
-            "group.id",
-            format!("test-consumer-{}", uuid::Uuid::new_v4()),
-        )
+        .set("group.id", group_id)
         .set("bootstrap.servers", KAFKA_BROKER)
         .set("auto.offset.reset", "earliest")
         .set("enable.auto.commit", "false")
@@ -128,8 +138,10 @@ async fn test_kafka_exporter_traces_json() {
     let json: Value = serde_json::from_str(&message_content).expect("Message is not valid JSON");
 
     // Verify it contains trace data
-    assert!(json.is_array(), "Message should be an array");
-    let traces = json.as_array().unwrap();
+    let traces = json
+        .get("resourceSpans")
+        .and_then(|value| value.as_array())
+        .expect("Message should contain resourceSpans array");
     assert!(!traces.is_empty(), "Traces array should not be empty");
 
     // Verify trace structure
@@ -255,8 +267,10 @@ async fn test_kafka_exporter_logs_with_compression() {
     let json: Value = serde_json::from_str(&message_content).expect("Message is not valid JSON");
 
     // Verify it contains log data
-    assert!(json.is_array(), "Message should be an array");
-    let logs = json.as_array().unwrap();
+    let logs = json
+        .get("resourceLogs")
+        .and_then(|value| value.as_array())
+        .expect("Message should contain resourceLogs array");
     assert!(!logs.is_empty(), "Logs array should not be empty");
 
     // Verify log structure
@@ -1064,4 +1078,230 @@ mod uuid {
             format!("test-{}", timestamp)
         }
     }
+}
+
+// ─── Export Group integration test ───────────────────────────────────────────
+//
+// Scenario: Clickhouse (always-5xx) → Kafka (working).
+// Expected:
+//   1. Each of the first `trip_after` batches is nacked by Clickhouse and immediately
+//      retried on the Kafka member, which acks.  No traces are lost.
+//   2. After `trip_after` consecutive Clickhouse nacks the breaker trips; subsequent
+//      batches start directly at the Kafka member (Clickhouse is skipped).
+//   3. All traces appear in the Kafka topic exactly once.
+//
+// Run with:
+//   KAFKA_INTEGRATION_TESTS=true cargo test --test kafka_integration_tests test_export_group_
+
+#[tokio::test]
+async fn test_export_group_clickhouse_then_kafka() {
+    const BATCH_COUNT: usize = 6;
+    const TRIP_AFTER: u32 = 3;
+
+    // ── Spin up a mock Clickhouse that always returns HTTP 503 ──────────────
+    let clickhouse_server = MockServer::start();
+    let clickhouse_mock = clickhouse_server.mock(|when, then| {
+        when.method(HTTP_POST).path("/");
+        then.status(503).body("service unavailable");
+    });
+
+    // ── Build Clickhouse exporter pointed at the mock ───────────────────────
+    let (ch_tx, ch_rx) = bounded::<Vec<PayloadMessage<ResourceSpans>>>(64);
+    let ch_addr = format!("http://127.0.0.1:{}", clickhouse_server.port());
+    let ch_exporter = ClickhouseExporterConfigBuilder::with_defaults(
+        ch_addr,
+        "otel".to_string(),
+        "otel".to_string(),
+    )
+    .with_retry_max_elapsed_time(Duration::from_millis(1))
+    .build()
+    .expect("Clickhouse builder failed")
+    .build_traces_exporter(ch_rx, None)
+    .expect("Clickhouse exporter build failed");
+
+    let ch_cancel = CancellationToken::new();
+    let ch_token = ch_cancel.clone();
+    tokio::spawn(async move {
+        let _ = ch_exporter.start(ch_token).await;
+    });
+
+    // ── Build Kafka exporter ────────────────────────────────────────────────
+    let topic = generate_unique_topic("export_group_traces");
+    let kafka_consumer = setup_consumer(&topic).await;
+    // Give the consumer time to connect and assign partitions.
+    sleep(Duration::from_secs(2)).await;
+
+    let (kafka_tx, kafka_rx) = bounded::<Vec<PayloadMessage<ResourceSpans>>>(64);
+    let kafka_config = KafkaExporterConfig::new(KAFKA_BROKER.to_string())
+        .with_traces_topic(topic.clone())
+        .with_serialization_format(SerializationFormat::Json);
+    let mut kafka_exporter =
+        build_traces_exporter(kafka_config, kafka_rx).expect("Kafka exporter build failed");
+
+    let kafka_cancel = CancellationToken::new();
+    let kafka_token = kafka_cancel.clone();
+    tokio::spawn(async move {
+        kafka_exporter.start(kafka_token).await;
+    });
+
+    // ── Wire an ExportGroup: Clickhouse first, Kafka second ─────────────────
+    let group = ExportGroupBuilder::<ResourceSpans>::new(64)
+        .add_member(ch_tx)
+        .add_member(kafka_tx)
+        .trip_after(TRIP_AFTER)
+        .probe_after(Duration::ZERO) // disable auto-recovery for this test
+        .build();
+
+    let mut active_rx = group.subscribe_active();
+    let group_tx = group.sender();
+
+    // ── Send BATCH_COUNT batches through the group ──────────────────────────
+    let trace_data = FakeOTLP::trace_service_request().resource_spans;
+    for _ in 0..BATCH_COUNT {
+        group_tx
+            .send(vec![PayloadMessage {
+                metadata: None,
+                payload: trace_data.clone(),
+                request_context: None,
+            }])
+            .await
+            .expect("Failed to send to group");
+    }
+
+    // ── Wait for the breaker to trip (after TRIP_AFTER nacks) ──────────────
+    let tripped = timeout(Duration::from_secs(30), active_rx.wait_for(|&v| v == 1)).await;
+    assert!(tripped.is_ok(), "Breaker did not trip within 30s");
+
+    // ── Verify all BATCH_COUNT messages arrived in Kafka ───────────────────
+    let mut received = 0usize;
+    for _ in 0..BATCH_COUNT {
+        let msg = wait_for_message(&kafka_consumer, Duration::from_secs(15)).await;
+        assert!(
+            msg.is_some(),
+            "Missing Kafka message; received {}/{} so far",
+            received,
+            BATCH_COUNT
+        );
+        received += 1;
+    }
+    assert_eq!(
+        received, BATCH_COUNT,
+        "Expected all {} batches in Kafka",
+        BATCH_COUNT
+    );
+
+    // ── Verify Clickhouse only received TRIP_AFTER requests before trip ─────
+    // The first TRIP_AFTER batches hit Clickhouse (and were retried on Kafka).
+    // Post-trip batches bypass Clickhouse entirely.
+    // Retry policy may cause multiple hits per batch on Clickhouse; assert at least TRIP_AFTER.
+    let ch_hits = clickhouse_mock.hits();
+    assert!(
+        ch_hits >= TRIP_AFTER as usize,
+        "Expected Clickhouse to receive at least {} hits, got {}",
+        TRIP_AFTER,
+        ch_hits
+    );
+    // After the trip, subsequent batches should not hit Clickhouse at all.
+    // Give the group a moment to process any in-flight post-trip batches.
+    sleep(Duration::from_millis(200)).await;
+    let ch_hits_after = clickhouse_mock.hits();
+    // Post-trip batches (BATCH_COUNT - TRIP_AFTER) should have all gone straight to Kafka.
+    let expected_max_ch_hits =
+        TRIP_AFTER as usize * (/* retry attempts per batch, typically 1 */2 + 1);
+    assert!(
+        ch_hits_after <= expected_max_ch_hits,
+        "Clickhouse received too many hits after trip ({} > {}); some batches were not short-circuited",
+        ch_hits_after,
+        expected_max_ch_hits
+    );
+
+    ch_cancel.cancel();
+    kafka_cancel.cancel();
+}
+
+#[tokio::test]
+async fn test_kafka_receiver_unacked_dlq_message_is_not_committed() {
+    let topic = generate_unique_topic("dlq_replay_pause");
+    let group_id = format!("dlq-replay-{}", uuid::Uuid::new_v4());
+
+    // Produce a DLQ trace message using the same protobuf format the Kafka receiver consumes.
+    let (producer_tx, producer_rx) = bounded::<Vec<PayloadMessage<ResourceSpans>>>(8);
+    let producer_config = KafkaExporterConfig::new(KAFKA_BROKER.to_string())
+        .with_traces_topic(topic.clone())
+        .with_serialization_format(SerializationFormat::Protobuf);
+    let mut producer =
+        build_traces_exporter(producer_config, producer_rx).expect("Kafka exporter build failed");
+
+    let producer_cancel = CancellationToken::new();
+    let producer_token = producer_cancel.clone();
+    tokio::spawn(async move {
+        producer.start(producer_token).await;
+    });
+
+    producer_tx
+        .send(vec![PayloadMessage {
+            metadata: None,
+            payload: vec![FakeOTLP::trace_service_request().resource_spans[0].clone()],
+            request_context: None,
+        }])
+        .await
+        .expect("Failed to send test trace to Kafka exporter");
+
+    // Wait until Kafka has the message before starting the receiver under test.
+    let probe_consumer = setup_consumer(&topic).await;
+    assert!(
+        wait_for_message(&probe_consumer, TEST_TIMEOUT)
+            .await
+            .is_some(),
+        "Produced DLQ message was not visible in Kafka"
+    );
+    drop(probe_consumer);
+
+    let (receiver_tx, mut receiver_rx) = bounded::<PayloadMessage<ResourceSpans>>(8);
+    let receiver_output = OTLPOutput::new(receiver_tx);
+    let receiver_config = KafkaReceiverConfig::new(KAFKA_BROKER.to_string(), group_id.clone())
+        .with_traces(true)
+        .with_traces_topic(topic.clone())
+        .with_auto_offset_reset(AutoOffsetReset::Earliest);
+    let mut receiver =
+        KafkaReceiver::new(receiver_config, Some(receiver_output), None, None, false)
+            .expect("Kafka receiver build failed");
+    let mut offset_committer = receiver
+        .take_offset_committer()
+        .expect("Offset committer should be enabled when auto-commit is disabled");
+
+    let receiver_cancel = CancellationToken::new();
+    let committer_cancel = CancellationToken::new();
+    let receiver_token = receiver_cancel.clone();
+    let committer_token = committer_cancel.clone();
+    let receiver_handle = tokio::spawn(async move { receiver.run(receiver_token).await });
+    let committer_handle = tokio::spawn(async move { offset_committer.run(committer_token).await });
+
+    let received = timeout(TEST_TIMEOUT, receiver_rx.next())
+        .await
+        .expect("Kafka receiver did not emit the DLQ message")
+        .expect("Kafka receiver output closed unexpectedly");
+    assert!(
+        received.metadata.is_some(),
+        "Kafka receiver output should carry offset-tracking metadata"
+    );
+    // Deliberately do not ack the metadata. This simulates Clickhouse being down while the
+    // replay exporter retries indefinitely, so the DLQ offset must remain uncommitted.
+
+    receiver_cancel.cancel();
+    committer_cancel.cancel();
+    let _ = receiver_handle.await;
+    let _ = committer_handle.await;
+
+    // A new consumer in the same group should still receive the same message because no ack
+    // reached the offset committer.
+    let replay_consumer = setup_consumer_with_group(&topic, group_id).await;
+    assert!(
+        wait_for_message(&replay_consumer, TEST_TIMEOUT)
+            .await
+            .is_some(),
+        "Unacked DLQ message was committed; replay would not pause while Clickhouse is down"
+    );
+
+    producer_cancel.cancel();
 }


### PR DESCRIPTION
## Summary

Background issue: #336 

Adds export groups so Rotel can try exporters in priority order, e.g. Clickhouse first, then Kafka as a local fallback/DLQ. The goal is to keep the happy path fast and cheap by sending directly to Clickhouse, while still preserving data when Clickhouse is unavailable.

This also adds optional receiver target exporters so a Kafka DLQ consumer can replay back to Clickhouse in the same Rotel instance without routing back through the export group and creating a Kafka loop.

## How it works

- Pipelines can target an `export_group` instead of a single exporter.
- The export group retries a failed batch on the next exporter in priority order.
- A circuit breaker skips exporters that are already known to be unhealthy, mainly as a latency optimization.
- Kafka receivers can optionally override their target exporters per telemetry type.
- For DLQ replay, the Kafka receiver can target a Clickhouse exporter directly while OTLP ingest still targets `export_group(clickhouse, kafka)`.

Example flow:

```text
OTLP ingest -> export_group(clickhouse_live, kafka_dlq)
Kafka DLQ consumer -> clickhouse_replay