### PR TITLE
Bump vulnerable dependencies (rand, aws-lc-sys)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -3368,7 +3368,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.12",
 ]
 
@@ -3731,7 +3731,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bitflags 2.9.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3960,9 +3960,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3971,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4263,7 +4263,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-build 0.14.3",
  "pyo3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rdkafka",
  "read-restrict",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ flate2 = { version = "1.0", features = ["zlib-ng"], default-features = false }
 futures = "0.3.31"
 daemonize = { git = "https://github.com/mheffner/daemonize", branch = "passy-pr54" }
 humantime = "2.1.0"
-rand = "0.8.5"
+rand = "0.8.6"
 bytes = "1.11.1"
 read-restrict = "0.3.0"
 tower = { version = "0.5.2", features = ["retry", "timeout"] }


### PR DESCRIPTION
## Summary

- Bumps `rand` 0.8.5 → 0.8.6 and 0.9.2 → 0.9.3 to fix unsoundness when using `rand::rng()` with a custom logger
- Bumps `aws-lc-rs` 1.16.1 → 1.16.3 (pulling in `aws-lc-sys` 0.38.0 → 0.40.0) to fix two high-severity X.509 vulnerabilities: CRL Distribution Point scope check logic error and Name Constraints bypass via wildcard/Unicode CN

Closes dependabot alerts #20, #21, #34, #38.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes