### PR TITLE
Release: Bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "rotel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "abi_stable",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rotel"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 homepage = "https://github.com/streamfold/rotel"
 readme = "README.md"


### PR DESCRIPTION
This PR bumps the version from 0.2.1 to 0.2.2.

**Bump type:** patch

After merging this PR, a tag `v0.2.2` will be automatically created and pushed, which will trigger the release workflow.

If you want to prevent automatic tagging, add the `no-auto-tag` label to this PR before merging.