### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Rotel is a high-performance OpenTelemetry collector written in Rust. See `DEVELOPING.md` for build/test/run instructions and `README.md` for configuration options.
+
+### Build gotcha: CC/CXX must be gcc/g++
+
+The default `c++` on this VM is clang-18 which cannot find the libstdc++ headers/libs needed by the rdkafka (librdkafka) C++ build. Always build with:
+
+```shell
+CC=gcc CXX=g++ cargo build
+```
+
+These are already exported in `~/.bashrc`. If you open a new shell without sourcing bashrc, set them manually.
+
+The `libstdc++.so` linker symlink at `/usr/lib/x86_64-linux-gnu/libstdc++.so` was created during setup; if missing, recreate it:
+
+```shell
+sudo ln -sf /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so
+```
+
+### Quick reference
+
+- **Build**: `cargo build` (with CC/CXX set)
+- **Lint**: `cargo fmt --check` and `cargo clippy`
+- **Test**: `cargo nextest run` (preferred) or `cargo test`
+- **Run**: `cargo run -- start --debug-log traces --exporter blackhole` (starts with blackhole exporter for local dev)
+- **Send test data**: `cargo run --bin generate-otlp -- traces --http-endpoint localhost:4318`
+
+### Notes
+
+- Rust toolchain version is pinned in `rust-toolchain.toml` (currently 1.91.1).
+- Default features include `rdkafka`, `aws_iam`, `file_receiver`, and `rust_processor`. Kafka integration tests require Docker (see `KAFKA_INTEGRATION_TESTS.md`).
+- The `pyo3` feature (Python processor SDK) requires Python 3.13+ and is not enabled by default.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents, including:

- Build gotcha: `CC=gcc CXX=g++` must be set because the default clang-18 on the VM can't find libstdc++ headers needed by rdkafka's C++ build
- Quick reference for build, lint, test, and run commands
- Notes on toolchain version, default features, and optional features

[rotel_server_output.log](https://cursor.com/artifacts/c/art-21beef11-a8ba-430d-b780-95b6f75020b4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91063e10-8599-46f4-950f-720e505253f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91063e10-8599-46f4-950f-720e505253f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

