### PR TITLE
Set up Cursor Cloud dev environment for rotel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Rotel is a single Rust workspace (an OpenTelemetry collector); there is no separate frontend/backend.
+Standard dev commands live in `DEVELOPING.md` and `.github/workflows/ci.yml`; prefer those.
+
+- Toolchain is pinned by `rust-toolchain.toml` (Rust 1.91.x). System deps (`protobuf-compiler`,
+  `libssl-dev`, `libzstd-dev`, `libclang-dev`, `cmake`, gcc) are pre-provisioned in the VM image.
+- Build: `cargo build`. Lint: `cargo fmt --check` (CI only checks formatting; there is no clippy gate).
+- Tests use nextest: `cargo nextest run`. `cargo-nextest` is preinstalled in the image; if missing,
+  `cargo install cargo-nextest --locked`.
+- Kafka/kmsg/rust-processor integration tests are gated behind env flags
+  (`KAFKA_INTEGRATION_TESTS`, `KMSG_INTEGRATION_TESTS`, `RUST_PROCESSOR_INTEGRATION_TESTS`) and are
+  skipped by default; the default `cargo nextest run` does not require Docker. See
+  `KAFKA_INTEGRATION_TESTS.md` for the Kafka harness.
+
+### Running the collector (hello world)
+
+- Start: `cargo run -- start --debug-log traces --exporter blackhole`. It listens on
+  `127.0.0.1:4317` (OTLP gRPC) and `127.0.0.1:4318` (OTLP HTTP). The subcommand is `start`.
+- Send test data with the built-in generator:
+  `cargo run --bin generate-otlp -- traces --http-endpoint localhost:4318`.
+  With `--debug-log traces`, rotel logs `Received traces. ... spans=1` on receipt.
+- CLI flags can also be passed as env vars prefixed with `ROTEL_` (e.g. `ROTEL_OTLP_GRPC_ENDPOINT`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for `rotel` (Rust OpenTelemetry collector) and documents non-obvious run/test details for future agents.

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering build, lint, test (nextest), integration-test env gates, and how to run the collector + send OTLP traces.

## Environment verification

- Build: `cargo build` (default features) ✅
- Lint: `cargo fmt --check` ✅
- Tests: `cargo nextest run` → 533 passed, 10 skipped ✅
- Hello world: started `cargo run -- start --debug-log traces --exporter blackhole`, sent traces via `cargo run --bin generate-otlp -- traces --http-endpoint localhost:4318`; rotel logged `Received traces. ... spans=1` ✅

Update script: `cargo fetch` (system deps and tooling are baked into the VM image; only Rust dep refresh is needed on startup).

[rotel_hello_world.log](https://cursor.com/artifacts/c/art-d69d3679-7f38-48f2-b092-698d92eeae34)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5623f0d-dea8-4b81-8bd4-22ae4b68e9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5623f0d-dea8-4b81-8bd4-22ae4b68e9de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

